### PR TITLE
Fix imports for generated models

### DIFF
--- a/test/modules/identite/unit/identity_model.g_test.dart
+++ b/test/modules/identite/unit/identity_model.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour identity_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/identite/models/identity_model.g.dart';
+import 'package:anisphere/modules/identite/models/identity_model.dart';
 
 void main() {
   test('identity_model.g fonctionne (test auto)', () {

--- a/test/noyau/unit/animal_model.g_test.dart
+++ b/test/noyau/unit/animal_model.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour animal_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/noyau/models/animal_model.g.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   test('animal_model.g fonctionne (test auto)', () {

--- a/test/noyau/unit/ia_log_service.g_test.dart
+++ b/test/noyau/unit/ia_log_service.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour ia_log_service.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/noyau/services/ia_log_service.g.dart';
+import 'package:anisphere/modules/noyau/services/ia_log_service.dart';
 
 void main() {
   test('ia_log_service.g fonctionne (test auto)', () {

--- a/test/noyau/unit/ia_metrics_collector.g_test.dart
+++ b/test/noyau/unit/ia_metrics_collector.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour ia_metrics_collector.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.g.dart';
+import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 
 void main() {
   test('ia_metrics_collector.g fonctionne (test auto)', () {

--- a/test/noyau/unit/offline_sync_queue.g_test.dart
+++ b/test/noyau/unit/offline_sync_queue.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour offline_sync_queue.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/noyau/services/offline_sync_queue.g.dart';
+import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 
 void main() {
   test('offline_sync_queue.g fonctionne (test auto)', () {

--- a/test/noyau/unit/user_model.g_test.dart
+++ b/test/noyau/unit/user_model.g_test.dart
@@ -1,6 +1,6 @@
 /// Copilot Prompt : Test automatique généré pour user_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
-import 'package:anisphere/modules/noyau/models/user_model.g.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   test('user_model.g fonctionne (test auto)', () {


### PR DESCRIPTION
## Summary
- update tests to import library files instead of generated part files

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684082cc9aa8832085ea37777e4c4dac