### PR TITLE
Fix lint warnings in tests and core modules

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
-/// Copilot Prompt : Entrée principale AniSphère.
-/// Initialise Firebase, Hive avec adapters IA, providers, IA, et lance l'app.
+// Copilot Prompt : Entrée principale AniSphère.
+// Initialise Firebase, Hive avec adapters IA, providers, IA, et lance l'app.
 library;
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/lib/modules/identite/services/identity_card_generator.dart
+++ b/lib/modules/identite/services/identity_card_generator.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Générateur PDF pour mini-carte d’identité AniSphère.
-/// Crée un PDF format CB (85x54 mm) avec nom, puce, photo, QR code.
-/// Utilise `pdf` pour génération, preview ou export via un autre service.
+// Copilot Prompt : Générateur PDF pour mini-carte d’identité AniSphère.
+// Crée un PDF format CB (85x54 mm) avec nom, puce, photo, QR code.
+// Utilise `pdf` pour génération, preview ou export via un autre service.
 library;
 import 'dart:io';
 import 'dart:typed_data'; // ✅ Nécessaire pour Uint8List

--- a/lib/modules/identite/services/identity_passport_generator.dart
+++ b/lib/modules/identite/services/identity_passport_generator.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Générateur PDF premium de passeport visuel pour AniSphère.
-/// Produit un document stylisé multilingue (nom, puce, photo, statut, QR, historique)
-/// réservé aux utilisateurs premium. Export PDF prêt à partager.
+// Copilot Prompt : Générateur PDF premium de passeport visuel pour AniSphère.
+// Produit un document stylisé multilingue (nom, puce, photo, statut, QR, historique)
+// réservé aux utilisateurs premium. Export PDF prêt à partager.
 library;
 import 'dart:io';
 import 'dart:typed_data';

--- a/lib/modules/identite/services/identity_reminder_service.dart
+++ b/lib/modules/identite/services/identity_reminder_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service de rappel IA pour mise à jour d’identité.
-/// Vérifie si la dernière MAJ de l’identité animale dépasse 12 mois.
-/// Déclenche une notification IA discrète via IA maîtresse.
+// Copilot Prompt : Service de rappel IA pour mise à jour d’identité.
+// Vérifie si la dernière MAJ de l’identité animale dépasse 12 mois.
+// Déclenche une notification IA discrète via IA maîtresse.
 
 library;
 

--- a/lib/modules/identite/services/identity_service.dart
+++ b/lib/modules/identite/services/identity_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service IdentityService pour AniSphère.
-/// Gère l’enregistrement, la mise à jour, l’historique et la synchronisation locale/cloud
-/// des fiches d’identité animale (QR, statut, photo, badge IA).
+// Copilot Prompt : Service IdentityService pour AniSphère.
+// Gère l’enregistrement, la mise à jour, l’historique et la synchronisation locale/cloud
+// des fiches d’identité animale (QR, statut, photo, badge IA).
 library;
 import 'package:hive/hive.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';

--- a/lib/modules/identite/services/identity_verification_service.dart
+++ b/lib/modules/identite/services/identity_verification_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : IdentityVerificationService pour AniSphère.
-/// Valide automatiquement une fiche identité si la photo est nette, la puce présente,
-/// et les données cohérentes. Active le badge IA “Identité vérifiée”.
+// Copilot Prompt : IdentityVerificationService pour AniSphère.
+// Valide automatiquement une fiche identité si la photo est nette, la puce présente,
+// et les données cohérentes. Active le badge IA “Identité vérifiée”.
 
 library;
 

--- a/lib/modules/identite/services/legal_status_service.dart
+++ b/lib/modules/identite/services/legal_status_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service pour la gestion du statut juridique de l’animal.
-/// Permet de déclarer ou modifier le statut (chien d’assistance, travail, élevage...).
-/// Gère les validations IA, l’enregistrement local et la traçabilité historique.
+// Copilot Prompt : Service pour la gestion du statut juridique de l’animal.
+// Permet de déclarer ou modifier le statut (chien d’assistance, travail, élevage...).
+// Gère les validations IA, l’enregistrement local et la traçabilité historique.
 
 library;
 

--- a/lib/modules/identite/services/ocr_icad_service.dart
+++ b/lib/modules/identite/services/ocr_icad_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : OCRICADService pour AniSphère.
-/// Analyse les documents I-CAD, LOF, carnet papier.
-/// Extrait puce, nom, race, dates, identifiants via OCR (Tesseract + RegEx).
+// Copilot Prompt : OCRICADService pour AniSphère.
+// Analyse les documents I-CAD, LOF, carnet papier.
+// Extrait puce, nom, race, dates, identifiants via OCR (Tesseract + RegEx).
 
 library;
 

--- a/lib/modules/identite/services/photo_verification_service.dart
+++ b/lib/modules/identite/services/photo_verification_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service de vérification photo IA pour AniSphère.
-/// Analyse les photos d’animaux pour détecter netteté, posture, cadrage, duplicata.
-/// Utilise OpenCV/TFLite en local, et score la meilleure photo pour l'identité.
+// Copilot Prompt : Service de vérification photo IA pour AniSphère.
+// Analyse les photos d’animaux pour détecter netteté, posture, cadrage, duplicata.
+// Utilise OpenCV/TFLite en local, et score la meilleure photo pour l'identité.
 library;
 import 'dart:io';
 import 'package:image/image.dart' as img;

--- a/lib/modules/identite/services/qr_generator_service.dart
+++ b/lib/modules/identite/services/qr_generator_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : QRGeneratorService pour AniSphère.
-/// Génère un QR code pointant vers une page publique Firebase d’un animal.
-/// Utilise qr_flutter pour affichage local, Firebase pour publication différée.
+// Copilot Prompt : QRGeneratorService pour AniSphère.
+// Génère un QR code pointant vers une page publique Firebase d’un animal.
+// Utilise qr_flutter pour affichage local, Firebase pour publication différée.
 library;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:qr_flutter/qr_flutter.dart';

--- a/lib/modules/noyau/logic/ia_config.dart
+++ b/lib/modules/noyau/logic/ia_config.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Configuration IA AniSphère.
-/// Contient les paramètres de configuration IA (seuils, flags, options actives),
-/// modifiables dans le futur via Remote Config.
-/// Utilisé par les modules IA, UX adaptative, alertes intelligentes.
+// Copilot Prompt : Configuration IA AniSphère.
+// Contient les paramètres de configuration IA (seuils, flags, options actives),
+// modifiables dans le futur via Remote Config.
+// Utilisé par les modules IA, UX adaptative, alertes intelligentes.
 library;
 
 class IAConfig {

--- a/lib/modules/noyau/logic/ia_context.dart
+++ b/lib/modules/noyau/logic/ia_context.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Contexte IA local pour AniSphère.
-/// Centralise les infos critiques du contexte utilisateur (hors-ligne, animaux, 1er lancement).
-/// Permet à IAMaster ou IARuleEngine de prendre des décisions locales intelligentes.
-/// Utilisé par IAExecutor, IAScheduler, IAMaster.
-/// IAContext peut être enrichi avec d'autres signaux (modules actifs, version app...)
+// Copilot Prompt : Contexte IA local pour AniSphère.
+// Centralise les infos critiques du contexte utilisateur (hors-ligne, animaux, 1er lancement).
+// Permet à IAMaster ou IARuleEngine de prendre des décisions locales intelligentes.
+// Utilisé par IAExecutor, IAScheduler, IAMaster.
+// IAContext peut être enrichi avec d'autres signaux (modules actifs, version app...)
 
 library;
 

--- a/lib/modules/noyau/logic/ia_executor.dart
+++ b/lib/modules/noyau/logic/ia_executor.dart
@@ -1,8 +1,8 @@
-/// 🧠 IAExecutor — AniSphère
-/// Applique les décisions IA générées par `IAMaster`
-/// Ce moteur exécute : nettoyage, notifications, sync, suggestions UI
-/// Utilisé à l’accueil, au démarrage et lors des triggers IA
-/// Copilot Prompt : "IAExecutor exécute les décisions IA contextuelles et active IAMaster flags ou services associés"
+// 🧠 IAExecutor — AniSphère
+// Applique les décisions IA générées par `IAMaster`
+// Ce moteur exécute : nettoyage, notifications, sync, suggestions UI
+// Utilisé à l’accueil, au démarrage et lors des triggers IA
+// Copilot Prompt : "IAExecutor exécute les décisions IA contextuelles et active IAMaster flags ou services associés"
 
 library;
 

--- a/lib/modules/noyau/logic/ia_flag.dart
+++ b/lib/modules/noyau/logic/ia_flag.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Drapeaux IA globaux AniSphère.
-/// Contient des booléens de configuration rapide pour activer/désactiver
-/// des comportements IA côté client. Utilisé pour debug, test, maintenance.
+// Copilot Prompt : Drapeaux IA globaux AniSphère.
+// Contient des booléens de configuration rapide pour activer/désactiver
+// des comportements IA côté client. Utilisé pour debug, test, maintenance.
 library;
 
 class IAFlag {

--- a/lib/modules/noyau/logic/ia_master.dart
+++ b/lib/modules/noyau/logic/ia_master.dart
@@ -1,8 +1,8 @@
-/// 🤖 IAMaster — IA mâtresse locale AniSphère
-/// Coordonne la logique IA (locale & cloud)
-/// Centralise les décisions, les logs et la stratégie IA
-/// Utilisé au démarrage, dans les exécuteurs IA et la logique UX
-/// Copilot Prompt : "IAMaster manages local IA logic and triggers CloudSyncService when needed"
+// 🤖 IAMaster — IA mâtresse locale AniSphère
+// Coordonne la logique IA (locale & cloud)
+// Centralise les décisions, les logs et la stratégie IA
+// Utilisé au démarrage, dans les exécuteurs IA et la logique UX
+// Copilot Prompt : "IAMaster manages local IA logic and triggers CloudSyncService when needed"
 
 library;
 

--- a/lib/modules/noyau/logic/ia_metrics_collector.dart
+++ b/lib/modules/noyau/logic/ia_metrics_collector.dart
@@ -1,4 +1,4 @@
-/// Copilot Prompt : IAMetricsCollector collects and stores local AI metrics to be sent later to the cloud by CloudSyncService.
+// Copilot Prompt : IAMetricsCollector collects and stores local AI metrics to be sent later to the cloud by CloudSyncService.
 library;
 
 import 'package:flutter/foundation.dart';

--- a/lib/modules/noyau/logic/ia_rule_engine.dart
+++ b/lib/modules/noyau/logic/ia_rule_engine.dart
@@ -1,8 +1,8 @@
-/// 🧠 IARuleEngine — Moteur de règles IA AniSphère
-/// Applique dynamiquement les règles définies dans ia_rules.dart selon le contexte
-/// Appelé automatiquement par IAMaster ou IAExecutor
-/// Retourne des suggestions IA, alertes ou actions à exécuter
-/// Copilot Prompt : "IARuleEngine analyzes AnimalModel list and IAContext to generate smart actions"
+// 🧠 IARuleEngine — Moteur de règles IA AniSphère
+// Applique dynamiquement les règles définies dans ia_rules.dart selon le contexte
+// Appelé automatiquement par IAMaster ou IAExecutor
+// Retourne des suggestions IA, alertes ou actions à exécuter
+// Copilot Prompt : "IARuleEngine analyzes AnimalModel list and IAContext to generate smart actions"
 
 library;
 

--- a/lib/modules/noyau/logic/ia_scheduler.dart
+++ b/lib/modules/noyau/logic/ia_scheduler.dart
@@ -1,8 +1,8 @@
-/// ⏰ IAScheduler — AniSphère
-/// Déclenche l’exécution IA selon des règles temporelles ou événements clés
-/// Utilise IAExecutor pour appliquer les décisions IA
-/// Déclenche automatiquement la synchronisation IA cloud si nécessaire
-/// Copilot Prompt : "IAScheduler triggers IAExecutor and calls IAMaster.syncCloudIA if premium"
+// ⏰ IAScheduler — AniSphère
+// Déclenche l’exécution IA selon des règles temporelles ou événements clés
+// Utilise IAExecutor pour appliquer les décisions IA
+// Déclenche automatiquement la synchronisation IA cloud si nécessaire
+// Copilot Prompt : "IAScheduler triggers IAExecutor and calls IAMaster.syncCloudIA if premium"
 
 library;
 

--- a/lib/modules/noyau/models/animal_model.dart
+++ b/lib/modules/noyau/models/animal_model.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Modèle d’animal pour AniSphère.
-/// Stockage Hive + export Firebase (toJson/fromJson), copie, updateAt.
-/// Champs : identité, espèce, race, image, date de naissance, propriétaire, timestamps.
-/// Utilisé dans le noyau pour la gestion des animaux.
+// Copilot Prompt : Modèle d’animal pour AniSphère.
+// Stockage Hive + export Firebase (toJson/fromJson), copie, updateAt.
+// Champs : identité, espèce, race, image, date de naissance, propriétaire, timestamps.
+// Utilisé dans le noyau pour la gestion des animaux.
 
 library;
 

--- a/lib/modules/noyau/models/support_ticket_model.dart
+++ b/lib/modules/noyau/models/support_ticket_model.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Modèle de support et feedback pour AniSphère.
-/// Permet à l'utilisateur de signaler un bug, proposer une idée ou contacter l'équipe.
-/// Compatible Hive et Firebase.
+// Copilot Prompt : Modèle de support et feedback pour AniSphère.
+// Permet à l'utilisateur de signaler un bug, proposer une idée ou contacter l'équipe.
+// Compatible Hive et Firebase.
 library;
 
 import 'package:hive/hive.dart';

--- a/lib/modules/noyau/models/user_model.dart
+++ b/lib/modules/noyau/models/user_model.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Modèle utilisateur AniSphère complet pour IA hybride (Hive + Firebase).
-/// Sérialisable Hive et Firebase. Contient rôles, préférences, animaux, timestamps.
-/// Prévu pour une app IA, offline-first, multi-rôle et multi-module.
+// Copilot Prompt : Modèle utilisateur AniSphère complet pour IA hybride (Hive + Firebase).
+// Sérialisable Hive et Firebase. Contient rôles, préférences, animaux, timestamps.
+// Prévu pour une app IA, offline-first, multi-rôle et multi-module.
 
 library;
 

--- a/lib/modules/noyau/providers/animal_provider.dart
+++ b/lib/modules/noyau/providers/animal_provider.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Provider AnimalProvider pour AniSphère.
-/// Gère la liste locale des animaux via AnimalService.
-/// Permet d’ajouter, supprimer, synchroniser et notifier l’UI.
-/// IA-compatible, optimisé offline-first et modulaire.
+// Copilot Prompt : Provider AnimalProvider pour AniSphère.
+// Gère la liste locale des animaux via AnimalService.
+// Permet d’ajouter, supprimer, synchroniser et notifier l’UI.
+// IA-compatible, optimisé offline-first et modulaire.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/providers/user_provider.dart
+++ b/lib/modules/noyau/providers/user_provider.dart
@@ -1,7 +1,7 @@
-/// Provider utilisateur pour AniSphère.
-/// Gère l’état utilisateur, les connexions (email, Google, Apple),
-/// la synchronisation Firebase/Hive et les notifications UI.
-/// Copilot Prompt : "UserProvider gère l’utilisateur, la connexion, et déclenche la synchro IA cloud si premium"
+// Provider utilisateur pour AniSphère.
+// Gère l’état utilisateur, les connexions (email, Google, Apple),
+// la synchronisation Firebase/Hive et les notifications UI.
+// Copilot Prompt : "UserProvider gère l’utilisateur, la connexion, et déclenche la synchro IA cloud si premium"
 
 library;
 

--- a/lib/modules/noyau/screens/animal_form_screen.dart
+++ b/lib/modules/noyau/screens/animal_form_screen.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Écran de création/modification d’un animal dans AniSphère.
-/// Permet à l’utilisateur de saisir manuellement les infos d’un animal.
-/// Prévu pour accueillir plus tard l’upload de documents avec OCR IA.
-/// Champs : nom, espèce, race, date de naissance, photo.
-/// L’animal est ensuite enregistré via AnimalService (Hive + Firebase).
+// Copilot Prompt : Écran de création/modification d’un animal dans AniSphère.
+// Permet à l’utilisateur de saisir manuellement les infos d’un animal.
+// Prévu pour accueillir plus tard l’upload de documents avec OCR IA.
+// Champs : nom, espèce, race, date de naissance, photo.
+// L’animal est ensuite enregistré via AnimalService (Hive + Firebase).
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/animal_profile_screen.dart
+++ b/lib/modules/noyau/screens/animal_profile_screen.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Écran de profil détaillé d’un animal pour AniSphère.
-/// Affiche les infos de l’animal, photo, espèce, race, date.
-/// Intègre des sections IA (actions personnalisées, stats), modules actifs,
-/// et une future timeline (santé, éducation, dressage, etc.).
-/// Prêt pour évolutions IA cloud + formations IA premium.
+// Copilot Prompt : Écran de profil détaillé d’un animal pour AniSphère.
+// Affiche les infos de l’animal, photo, espèce, race, date.
+// Intègre des sections IA (actions personnalisées, stats), modules actifs,
+// et une future timeline (santé, éducation, dressage, etc.).
+// Prêt pour évolutions IA cloud + formations IA premium.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/animal_screen.dart
+++ b/lib/modules/noyau/screens/animal_screen.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Écran de visualisation d’un animal dans AniSphère.
-/// Affiche les données complètes d’un animal enregistré (nom, espèce, race, date, image).
-/// Intègre un bouton “Identité” vers `IdentityScreen` avec `IdentityService`.
-/// Préparé pour afficher les modules IA, l’historique, et la fiche publique.
-/// Suivi du branding AniSphère et UX à la Samsung Health.
+// Copilot Prompt : Écran de visualisation d’un animal dans AniSphère.
+// Affiche les données complètes d’un animal enregistré (nom, espèce, race, date, image).
+// Intègre un bouton “Identité” vers `IdentityScreen` avec `IdentityService`.
+// Préparé pour afficher les modules IA, l’historique, et la fiche publique.
+// Suivi du branding AniSphère et UX à la Samsung Health.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/animals_screen.dart
+++ b/lib/modules/noyau/screens/animals_screen.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Écran de liste des animaux pour AniSphère.
-/// Affiche les animaux depuis AnimalService (Hive), sous forme de cartes.
-/// Montre une suggestion IA si aucun animal n’est enregistré.
-/// Utilise le widget AnimalCard. Prévu pour accueil type Samsung Health.
-/// Préparé pour intégration IA contextuelle future par animal.
+// Copilot Prompt : Écran de liste des animaux pour AniSphère.
+// Affiche les animaux depuis AnimalService (Hive), sous forme de cartes.
+// Montre une suggestion IA si aucun animal n’est enregistré.
+// Utilise le widget AnimalCard. Prévu pour accueil type Samsung Health.
+// Préparé pour intégration IA contextuelle future par animal.
 
 library;
 

--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : HomeScreen AniSphère enrichi avec IA.
-/// Intègre les widgets IA dynamiques : IABanner, IAChip, IASuggestionCard, IALogViewer.
-/// Affiche les résumés IA des modules actifs via ModulesSummaryService.
+// Copilot Prompt : HomeScreen AniSphère enrichi avec IA.
+// Intègre les widgets IA dynamiques : IABanner, IAChip, IASuggestionCard, IALogViewer.
+// Affiche les résumés IA des modules actifs via ModulesSummaryService.
 
 library;
 

--- a/lib/modules/noyau/screens/login_screen.dart
+++ b/lib/modules/noyau/screens/login_screen.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Écran de connexion pour AniSphère.
-/// Permet de se connecter avec email, Google ou Apple.
-/// Utilise UserProvider, redirige vers MainScreen.
-/// Affiche erreurs et loading intelligemment.
-/// Inclut bouton vers création de compte.
+// Copilot Prompt : Écran de connexion pour AniSphère.
+// Permet de se connecter avec email, Google ou Apple.
+// Utilise UserProvider, redirige vers MainScreen.
+// Affiche erreurs et loading intelligemment.
+// Inclut bouton vers création de compte.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -1,5 +1,5 @@
-/// Copilot Prompt : MainScreen avec navigation sécurisée, IAScheduler et accès superadmin masqué.
-/// Comporte 4 onglets dynamiques + accès à IADebugScreen par long press (si rôle = super_admin).
+// Copilot Prompt : MainScreen avec navigation sécurisée, IAScheduler et accès superadmin masqué.
+// Comporte 4 onglets dynamiques + accès à IADebugScreen par long press (si rôle = super_admin).
 library;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran des modules dans AniSphère.
-/// Affiche les modules disponibles avec cartes claires (nom, description, statut).
-/// Préparé pour activer, acheter ou découvrir chaque module.
-/// Inspiré de l’ergonomie Samsung Health.
+// Copilot Prompt : Écran des modules dans AniSphère.
+// Affiche les modules disponibles avec cartes claires (nom, description, statut).
+// Préparé pour activer, acheter ou découvrir chaque module.
+// Inspiré de l’ergonomie Samsung Health.
 library;
 import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';

--- a/lib/modules/noyau/screens/notification_admin_screen.dart
+++ b/lib/modules/noyau/screens/notification_admin_screen.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : NotificationAdminScreen permet au superadmin d'envoyer des notifications cloud manuelles.
-/// Il peut choisir le titre, le message, la cible (tous, rôle, ID utilisateur), le module, et le type.
-/// Intégré au noyau AniSphère, utilisé pour les communications importantes, marketing ou système.
+// Copilot Prompt : NotificationAdminScreen permet au superadmin d'envoyer des notifications cloud manuelles.
+// Il peut choisir le titre, le message, la cible (tous, rôle, ID utilisateur), le module, et le type.
+// Intégré au noyau AniSphère, utilisé pour les communications importantes, marketing ou système.
 
 library;
 

--- a/lib/modules/noyau/screens/notification_admin_tools_screen.dart
+++ b/lib/modules/noyau/screens/notification_admin_tools_screen.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Outils avancés pour les notifications AniSphère (admin).
-/// Affiche l’historique des notifications envoyées, permet de gérer des brouillons,
-/// tester localement et envoyer à des groupes personnalisés.
+// Copilot Prompt : Outils avancés pour les notifications AniSphère (admin).
+// Affiche l’historique des notifications envoyées, permet de gérer des brouillons,
+// tester localement et envoyer à des groupes personnalisés.
 
 library;
 

--- a/lib/modules/noyau/screens/notifications_screen.dart
+++ b/lib/modules/noyau/screens/notifications_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran des notifications AniSphère.
-/// Liste toutes les notifications IA et système.
-/// Trie les messages par modules et par date.
-/// Prévu pour une extension IA intelligente (filtrage, urgences…).
+// Copilot Prompt : Écran des notifications AniSphère.
+// Liste toutes les notifications IA et système.
+// Trie les messages par modules et par date.
+// Prévu pour une extension IA intelligente (filtrage, urgences…).
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/qr_screen.dart
+++ b/lib/modules/noyau/screens/qr_screen.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Écran QR pour AniSphère.
-/// Permet de scanner un QR code ou de générer un QR lié à l’utilisateur ou à un animal.
-/// Utilise mobile_scanner + QRService. Préparé pour la synchronisation IA via QR.
+// Copilot Prompt : Écran QR pour AniSphère.
+// Permet de scanner un QR code ou de générer un QR lié à l’utilisateur ou à un animal.
+// Utilise mobile_scanner + QRService. Préparé pour la synchronisation IA via QR.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/register_screen.dart
+++ b/lib/modules/noyau/screens/register_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran d’inscription pour AniSphère.
-/// Permet à l’utilisateur de créer un compte avec nom, email, téléphone, profession.
-/// Utilise UserProvider.signUp(), redirige vers MainScreen.
-/// Affiche erreurs et loading.
+// Copilot Prompt : Écran d’inscription pour AniSphère.
+// Permet à l’utilisateur de créer un compte avec nom, email, téléphone, profession.
+// Utilise UserProvider.signUp(), redirige vers MainScreen.
+// Affiche erreurs et loading.
 library;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran de partage AniSphère.
-/// Permet à l’utilisateur de partager ses données ou ses animaux (QR, export).
-/// Doit être visuellement clair, responsive et conforme au brandbook.
-/// Préparé pour afficher un QR code, un bouton d’export, et d’autres options IA.
+// Copilot Prompt : Écran de partage AniSphère.
+// Permet à l’utilisateur de partager ses données ou ses animaux (QR, export).
+// Doit être visuellement clair, responsive et conforme au brandbook.
+// Préparé pour afficher un QR code, un bouton d’export, et d’autres options IA.
 library;
 import 'package:flutter/material.dart';
 

--- a/lib/modules/noyau/screens/splash_screen.dart
+++ b/lib/modules/noyau/screens/splash_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran de splash pour AniSphère.
-/// Vérifie si un utilisateur est déjà connecté via UserProvider.
-/// Redirige automatiquement vers MainScreen ou LoginScreen.
-/// Affiche une animation de chargement pendant l’analyse.
+// Copilot Prompt : Écran de splash pour AniSphère.
+// Vérifie si un utilisateur est déjà connecté via UserProvider.
+// Redirige automatiquement vers MainScreen ou LoginScreen.
+// Affiche une animation de chargement pendant l’analyse.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/screens/super_admin_screen.dart
+++ b/lib/modules/noyau/screens/super_admin_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : SuperAdminScreen sécurisé pour AniSphère.
-/// Réservé au rôle "superadmin". Affiche logs IA, flags, statut sync, et permet de forcer une synchronisation.
-/// Écran masqué, accessible uniquement en mode développeur ou via menu caché.
-/// Optimisé UI et sécurité. UX fluide, statut clair.
+// Copilot Prompt : SuperAdminScreen sécurisé pour AniSphère.
+// Réservé au rôle "superadmin". Affiche logs IA, flags, statut sync, et permet de forcer une synchronisation.
+// Écran masqué, accessible uniquement en mode développeur ou via menu caché.
+// Optimisé UI et sécurité. UX fluide, statut clair.
 library;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/modules/noyau/screens/user_profile_screen.dart
+++ b/lib/modules/noyau/screens/user_profile_screen.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écran complet du profil utilisateur AniSphère.
-/// Affiche identité, modules actifs, statut IA, QR ID, actions pratiques.
-/// UX fluide inspirée Samsung Health, sections bien définies.
-/// IA-ready, QR, export, stats, confidentialité préparés.
+// Copilot Prompt : Écran complet du profil utilisateur AniSphère.
+// Affiche identité, modules actifs, statut IA, QR ID, actions pratiques.
+// UX fluide inspirée Samsung Health, sections bien définies.
+// IA-ready, QR, export, stats, confidentialité préparés.
 
 library;
 

--- a/lib/modules/noyau/services/animal_service.dart
+++ b/lib/modules/noyau/services/animal_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service AnimalService pour AniSphère.
-/// Gère le stockage local (Hive), la synchro Firebase, les ajouts/suppressions.
-/// IA-compatible, testable, optimisé offline-first.
+// Copilot Prompt : Service AnimalService pour AniSphère.
+// Gère le stockage local (Hive), la synchro Firebase, les ajouts/suppressions.
+// IA-compatible, testable, optimisé offline-first.
 
 library;
 

--- a/lib/modules/noyau/services/backup_service.dart
+++ b/lib/modules/noyau/services/backup_service.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : BackupService complet pour AniSphère.
-/// Sauvegarde automatiquement les données Hive vers Firebase.
-/// Gère également la restauration des données sauvegardées.
-/// Compatible avec IAContext, AnimalService, UserService.
-/// Optimisé offline-first, sécurisé, gestion erreurs propre.
+// Copilot Prompt : BackupService complet pour AniSphère.
+// Sauvegarde automatiquement les données Hive vers Firebase.
+// Gère également la restauration des données sauvegardées.
+// Compatible avec IAContext, AnimalService, UserService.
+// Optimisé offline-first, sécurisé, gestion erreurs propre.
 
 library;
 

--- a/lib/modules/noyau/services/cloud_admin_notifier.dart
+++ b/lib/modules/noyau/services/cloud_admin_notifier.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : AniSphère cloud notification manager for superadmin.
-/// Permet d’envoyer des notifications cloud ciblées ou globales via Firestore.
-/// Prévu pour une Firebase Function ou une lecture client-side en background.
-/// Utilisé par le superadmin uniquement.
+// Copilot Prompt : AniSphère cloud notification manager for superadmin.
+// Permet d’envoyer des notifications cloud ciblées ou globales via Firestore.
+// Prévu pour une Firebase Function ou une lecture client-side en background.
+// Utilisé par le superadmin uniquement.
 
 library;
 

--- a/lib/modules/noyau/services/cloud_notification_listener.dart
+++ b/lib/modules/noyau/services/cloud_notification_listener.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Écouteur de notifications cloud AniSphère.
-/// Se connecte à Firebase Messaging pour recevoir les notifications push.
-/// Affiche les notifications via NotificationService.
-/// À intégrer dans l'initialisation de l'application.
+// Copilot Prompt : Écouteur de notifications cloud AniSphère.
+// Se connecte à Firebase Messaging pour recevoir les notifications push.
+// Affiche les notifications via NotificationService.
+// À intégrer dans l'initialisation de l'application.
 
 library;
 

--- a/lib/modules/noyau/services/cloud_notification_service.dart
+++ b/lib/modules/noyau/services/cloud_notification_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service de notifications cloud AniSphère.
-/// Permet au superadmin d’envoyer des notifications push via Firebase (Firestore).
-/// Utilisé par NotificationAdminScreen et IA maîtresse (alertes IA globales).
+// Copilot Prompt : Service de notifications cloud AniSphère.
+// Permet au superadmin d’envoyer des notifications push via Firebase (Firestore).
+// Utilisé par NotificationAdminScreen et IA maîtresse (alertes IA globales).
 
 library;
 

--- a/lib/modules/noyau/services/firebase_service.dart
+++ b/lib/modules/noyau/services/firebase_service.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Service Firebase pour AniSphère.
-/// Gère la déconnexion, la lecture/écriture Firestore des utilisateurs et animaux.
-/// Utilise FirebaseAuth + Firestore.
-/// Inclut gestion des erreurs, logs conditionnels, fusion automatique des données.
-/// IA-ready et modulaire.
+// Copilot Prompt : Service Firebase pour AniSphère.
+// Gère la déconnexion, la lecture/écriture Firestore des utilisateurs et animaux.
+// Utilise FirebaseAuth + Firestore.
+// Inclut gestion des erreurs, logs conditionnels, fusion automatique des données.
+// IA-ready et modulaire.
 
 library;
 

--- a/lib/modules/noyau/services/ia_sync_service.dart
+++ b/lib/modules/noyau/services/ia_sync_service.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : IASyncService AniSphère.
-/// Détecte automatiquement les événements importants (ajout animal, update, module actif),
-/// Vérifie si l’utilisateur est premium et déclenche la synchronisation IA cloud.
-/// Optimisé sans coût : batch, différé, sans doublon, sans surcharge.
-/// Utilise CloudSyncService en arrière-plan. Journalise localement via IALogger.
+// Copilot Prompt : IASyncService AniSphère.
+// Détecte automatiquement les événements importants (ajout animal, update, module actif),
+// Vérifie si l’utilisateur est premium et déclenche la synchronisation IA cloud.
+// Optimisé sans coût : batch, différé, sans doublon, sans surcharge.
+// Utilise CloudSyncService en arrière-plan. Journalise localement via IALogger.
 
 library;
 

--- a/lib/modules/noyau/services/local_storage_service.dart
+++ b/lib/modules/noyau/services/local_storage_service.dart
@@ -1,8 +1,8 @@
-/// Copilot Prompt : Service de stockage Hive local pour AniSphère.
-/// Gère deux boîtes : utilisateurs et animaux.
-/// Fournit des fonctions de lecture/écriture bas niveau.
-/// Utilisé en complément de UserService et AnimalService.
-/// Peut être utilisé aussi pour debug offline.
+// Copilot Prompt : Service de stockage Hive local pour AniSphère.
+// Gère deux boîtes : utilisateurs et animaux.
+// Fournit des fonctions de lecture/écriture bas niveau.
+// Utilisé en complément de UserService et AnimalService.
+// Peut être utilisé aussi pour debug offline.
 library;
 
 import 'package:hive_flutter/hive_flutter.dart';

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Service de gestion des modules AniSphère.
-/// Gère l’état des modules (activé, premium, disponible).
-/// Persiste les statuts avec LocalStorageService.
-/// Utilisé par ModulesScreen et IA pour déterminer les accès.
+// Copilot Prompt : Service de gestion des modules AniSphère.
+// Gère l’état des modules (activé, premium, disponible).
+// Persiste les statuts avec LocalStorageService.
+// Utilisé par ModulesScreen et IA pour déterminer les accès.
 
 library;
 

--- a/lib/modules/noyau/services/notification_service.dart
+++ b/lib/modules/noyau/services/notification_service.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Service de notifications pour le noyau AniSphère.
-/// Permet d'envoyer des notifications locales intelligentes selon le contexte IA.
-/// Gère également la préparation des canaux pour l'envoi de notifications.
-/// Utilisable avec Firebase Messaging à terme pour le cloud.
+// Copilot Prompt : Service de notifications pour le noyau AniSphère.
+// Permet d'envoyer des notifications locales intelligentes selon le contexte IA.
+// Gère également la préparation des canaux pour l'envoi de notifications.
+// Utilisable avec Firebase Messaging à terme pour le cloud.
 
 library;
 

--- a/lib/modules/noyau/services/offline_sync_queue.dart
+++ b/lib/modules/noyau/services/offline_sync_queue.dart
@@ -1,4 +1,4 @@
-/// Copilot Prompt : OfflineSyncQueue handles buffered sync for AniSphère when offline. Uses Hive to store temporary data and flushes on reconnect.
+// Copilot Prompt : OfflineSyncQueue handles buffered sync for AniSphère when offline. Uses Hive to store temporary data and flushes on reconnect.
 library;
 
 import 'package:hive/hive.dart';

--- a/lib/modules/noyau/services/qr_service.dart
+++ b/lib/modules/noyau/services/qr_service.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Service de QR code pour AniSphère.
-/// Génère des QR codes (texte, URL, ID), et intègre un scanner mobile.
-/// Utilise qr_flutter pour l'affichage, mobile_scanner pour la lecture.
-/// Prévu pour la synchronisation d’animaux, d'utilisateurs et de partages IA.
+// Copilot Prompt : Service de QR code pour AniSphère.
+// Génère des QR codes (texte, URL, ID), et intègre un scanner mobile.
+// Utilise qr_flutter pour l'affichage, mobile_scanner pour la lecture.
+// Prévu pour la synchronisation d’animaux, d'utilisateurs et de partages IA.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/services/support_service.dart
+++ b/lib/modules/noyau/services/support_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : SupportService AniSphère
-/// Gère les retours utilisateurs (bug, idée, contact) avec Hive et Firebase.
-/// Sauvegarde locale offline-first, puis envoi cloud via Firebase.
+// Copilot Prompt : SupportService AniSphère
+// Gère les retours utilisateurs (bug, idée, contact) avec Hive et Firebase.
+// Sauvegarde locale offline-first, puis envoi cloud via Firebase.
 library;
 
 import 'package:flutter/foundation.dart';

--- a/lib/modules/noyau/services/user_service.dart
+++ b/lib/modules/noyau/services/user_service.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Service utilisateur AniSphère (Firebase + Hive).
-/// Gère synchronisation cloud, sauvegarde locale, suppression, et MAJ IA.
-/// Optimisé pour IA maîtresse, offline-first, multi-profil.
+// Copilot Prompt : Service utilisateur AniSphère (Firebase + Hive).
+// Gère synchronisation cloud, sauvegarde locale, suppression, et MAJ IA.
+// Optimisé pour IA maîtresse, offline-first, multi-profil.
 
 library;
 

--- a/lib/modules/noyau/storage/ia_storage_modules.dart
+++ b/lib/modules/noyau/storage/ia_storage_modules.dart
@@ -1,5 +1,5 @@
-/// Copilot Prompt : Module IA pour collecte de métriques et gestion offline-first.
-/// Contient IAMetricsCollector (score IA) et OfflineSyncQueue (buffer de synchronisation).
+// Copilot Prompt : Module IA pour collecte de métriques et gestion offline-first.
+// Contient IAMetricsCollector (score IA) et OfflineSyncQueue (buffer de synchronisation).
 
 library;
 

--- a/lib/modules/noyau/widgets/animal_card.dart
+++ b/lib/modules/noyau/widgets/animal_card.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Widget AnimalCard pour AniSphère.
-/// Affiche un animal sous forme de carte élégante avec image, nom, espèce.
-/// Utilisé dans la liste des animaux, l'accueil et les modules IA.
+// Copilot Prompt : Widget AnimalCard pour AniSphère.
+// Affiche un animal sous forme de carte élégante avec image, nom, espèce.
+// Utilisé dans la liste des animaux, l'accueil et les modules IA.
 
 library;
 

--- a/lib/modules/noyau/widgets/ia_banner.dart
+++ b/lib/modules/noyau/widgets/ia_banner.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Widget IABanner pour AniSphère.
-/// Affiche une bannière contextuelle IA en haut d’un écran.
-/// Peut signaler un état IA actif (mode onboarding, offline, alerte santé).
-/// Discret, mais visible et réutilisable dans tous les modules.
+// Copilot Prompt : Widget IABanner pour AniSphère.
+// Affiche une bannière contextuelle IA en haut d’un écran.
+// Peut signaler un état IA actif (mode onboarding, offline, alerte santé).
+// Discret, mais visible et réutilisable dans tous les modules.
 library;
 import 'package:flutter/material.dart';
 

--- a/lib/modules/noyau/widgets/ia_chip.dart
+++ b/lib/modules/noyau/widgets/ia_chip.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Widget IAChip pour AniSphère.
-/// Affiche un petit badge (Chip) représentant un état IA ou un tag intelligent.
-/// Utilisé dans les dashboards, listes d’animaux ou en haut des écrans IA.
+// Copilot Prompt : Widget IAChip pour AniSphère.
+// Affiche un petit badge (Chip) représentant un état IA ou un tag intelligent.
+// Utilisé dans les dashboards, listes d’animaux ou en haut des écrans IA.
 library;
 import 'package:flutter/material.dart';
 

--- a/lib/modules/noyau/widgets/ia_log_viewer.dart
+++ b/lib/modules/noyau/widgets/ia_log_viewer.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Widget IALogViewer pour AniSphère.
-/// Affiche la liste des logs IA locaux enregistrés dans Hive.
-/// Sert au debug, à la maintenance, ou au retour utilisateur avancé.
-/// Peut être affiché dans une page "À propos", "Debug", ou panneau IA.
+// Copilot Prompt : Widget IALogViewer pour AniSphère.
+// Affiche la liste des logs IA locaux enregistrés dans Hive.
+// Sert au debug, à la maintenance, ou au retour utilisateur avancé.
+// Peut être affiché dans une page "À propos", "Debug", ou panneau IA.
 library;
 import 'package:flutter/material.dart';
 import '../logic/ia_logger.dart';

--- a/lib/modules/noyau/widgets/ia_suggestion_card.dart
+++ b/lib/modules/noyau/widgets/ia_suggestion_card.dart
@@ -1,7 +1,7 @@
-/// Copilot Prompt : Widget IASuggestionCard pour AniSphère.
-/// Affiche une carte de suggestion IA avec un titre, un message, une icône et un bouton.
-/// Utilisé sur l’écran d’accueil, le dashboard IA, ou dans les modules.
-/// Doit être élégant, discret, mais réactif.
+// Copilot Prompt : Widget IASuggestionCard pour AniSphère.
+// Affiche une carte de suggestion IA avec un titre, un message, une icône et un bouton.
+// Utilisé sur l’écran d’accueil, le dashboard IA, ou dans les modules.
+// Doit être élégant, discret, mais réactif.
 library;
 import 'package:flutter/material.dart';
 

--- a/lib/modules/noyau/widgets/more_menu.dart
+++ b/lib/modules/noyau/widgets/more_menu.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Menu contextuel AniSphère (3 points vertical).
-/// Permet d'accéder rapidement au profil, paramètres, notifications, etc.
-/// Intégration prévue dans tous les écrans via AppBar > actions.
+// Copilot Prompt : Menu contextuel AniSphère (3 points vertical).
+// Permet d'accéder rapidement au profil, paramètres, notifications, etc.
+// Intégration prévue dans tous les écrans via AppBar > actions.
 library;
 
 import 'package:flutter/material.dart';

--- a/lib/modules/noyau/widgets/notification_icon.dart
+++ b/lib/modules/noyau/widgets/notification_icon.dart
@@ -1,6 +1,6 @@
-/// Copilot Prompt : Widget NotificationIcon pour AniSphère.
-/// Affiche une cloche avec un badge rouge si des notifications non lues sont présentes.
-/// S'intègre dans l'AppBar de `MainScreen`.
+// Copilot Prompt : Widget NotificationIcon pour AniSphère.
+// Affiche une cloche avec un badge rouge si des notifications non lues sont présentes.
+// S'intègre dans l'AppBar de `MainScreen`.
 
 library;
 

--- a/test/identite/unit/identity_model.g_test.dart
+++ b/test/identite/unit/identity_model.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour identity_model.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour identity_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/identite/models/identity_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/animal_model.g_test.dart
+++ b/test/noyau/unit/animal_model.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_model.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour animal_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/animal_model_test.dart
+++ b/test/noyau/unit/animal_model_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_model.dart (unit)
+// Copilot Prompt : Test automatique généré pour animal_model.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/animal_provider_test.dart
+++ b/test/noyau/unit/animal_provider_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_provider.dart (unit)
+// Copilot Prompt : Test automatique généré pour animal_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/providers/animal_provider.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/animal_service_test.dart
+++ b/test/noyau/unit/animal_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour animal_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/animal_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/app_initializer_test.dart
+++ b/test/noyau/unit/app_initializer_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour app_initializer.dart (unit)
+// Copilot Prompt : Test automatique généré pour app_initializer.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/app_initializer.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/auth_service_test.dart
+++ b/test/noyau/unit/auth_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour auth_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour auth_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/auth_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/backup_service_test.dart
+++ b/test/noyau/unit/backup_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour backup_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour backup_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/backup_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/cloud_admin_notifier_test.dart
+++ b/test/noyau/unit/cloud_admin_notifier_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour cloud_admin_notifier.dart (unit)
+// Copilot Prompt : Test automatique généré pour cloud_admin_notifier.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/cloud_admin_notifier.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/cloud_notification_listener_test.dart
+++ b/test/noyau/unit/cloud_notification_listener_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour cloud_notification_listener.dart (unit)
+// Copilot Prompt : Test automatique généré pour cloud_notification_listener.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/cloud_notification_service_test.dart
+++ b/test/noyau/unit/cloud_notification_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour cloud_notification_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour cloud_notification_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/cloud_notification_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour cloud_sync_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour cloud_sync_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/cloud_sync_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/firebase_service_test.dart
+++ b/test/noyau/unit/firebase_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour firebase_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour firebase_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/firebase_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_channel_test.dart
+++ b/test/noyau/unit/ia_channel_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_channel.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_channel.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_channel.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_config_test.dart
+++ b/test/noyau/unit/ia_config_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_config.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_config.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_config.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_context_provider_test.dart
+++ b/test/noyau/unit/ia_context_provider_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_context_provider.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_context_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/providers/ia_context_provider.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_context_test.dart
+++ b/test/noyau/unit/ia_context_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_context.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_context.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_context.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_executor_test.dart
+++ b/test/noyau/unit/ia_executor_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_executor.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_executor.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_executor.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_flag_test.dart
+++ b/test/noyau/unit/ia_flag_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_flag.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_flag.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_flag.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_log_service.g_test.dart
+++ b/test/noyau/unit/ia_log_service.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_log_service.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_log_service.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/ia_log_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_log_service_test.dart
+++ b/test/noyau/unit/ia_log_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_log_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_log_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/ia_log_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_logger_test.dart
+++ b/test/noyau/unit/ia_logger_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_logger.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_logger.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_logger.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_master_test.dart
+++ b/test/noyau/unit/ia_master_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_master.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_master.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_master.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_metrics_collector.g_test.dart
+++ b/test/noyau/unit/ia_metrics_collector.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_metrics_collector.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_metrics_collector.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_metrics_collector_test.dart
+++ b/test/noyau/unit/ia_metrics_collector_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_metrics_collector.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_metrics_collector.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_rule_engine_test.dart
+++ b/test/noyau/unit/ia_rule_engine_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_rule_engine.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_rule_engine.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_rule_engine.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_rules_test.dart
+++ b/test/noyau/unit/ia_rules_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_rules.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_rules.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_rules.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_scheduler_test.dart
+++ b/test/noyau/unit/ia_scheduler_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_scheduler.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_scheduler.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_scheduler.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_sync_service_test.dart
+++ b/test/noyau/unit/ia_sync_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_sync_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour ia_sync_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/ia_sync_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/local_storage_service_test.dart
+++ b/test/noyau/unit/local_storage_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour local_storage_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour local_storage_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/maintenance_service_test.dart
+++ b/test/noyau/unit/maintenance_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour maintenance_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour maintenance_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/maintenance_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour modules_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour modules_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/modules_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/modules_summary_service_test.dart
+++ b/test/noyau/unit/modules_summary_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour modules_summary_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour modules_summary_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/modules_summary_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/notification_service_test.dart
+++ b/test/noyau/unit/notification_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour notification_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour notification_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/notification_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/offline_sync_queue.g_test.dart
+++ b/test/noyau/unit/offline_sync_queue.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour offline_sync_queue.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour offline_sync_queue.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/offline_sync_queue_test.dart
+++ b/test/noyau/unit/offline_sync_queue_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour offline_sync_queue.dart (unit)
+// Copilot Prompt : Test automatique généré pour offline_sync_queue.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/qr_service_test.dart
+++ b/test/noyau/unit/qr_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour qr_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour qr_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/qr_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/support_model_test.dart
+++ b/test/noyau/unit/support_model_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour support_model.dart (unit)
+// Copilot Prompt : Test automatique généré pour support_model.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/support_provider_test.dart
+++ b/test/noyau/unit/support_provider_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour support_provider.dart (unit)
+// Copilot Prompt : Test automatique généré pour support_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/providers/support_provider.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/support_service_test.dart
+++ b/test/noyau/unit/support_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour support_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour support_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/support_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/user_model.g_test.dart
+++ b/test/noyau/unit/user_model.g_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour user_model.g.dart (unit)
+// Copilot Prompt : Test automatique généré pour user_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/user_model_test.dart
+++ b/test/noyau/unit/user_model_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour user_model.dart (unit)
+// Copilot Prompt : Test automatique généré pour user_model.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour user_provider.dart (unit)
+// Copilot Prompt : Test automatique généré pour user_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/user_service_test.dart
+++ b/test/noyau/unit/user_service_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour user_service.dart (unit)
+// Copilot Prompt : Test automatique généré pour user_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/user_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/animal_card_test.dart
+++ b/test/noyau/widget/animal_card_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_card.dart (widget)
+// Copilot Prompt : Test automatique généré pour animal_card.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/animal_card.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/animal_form_screen_test.dart
+++ b/test/noyau/widget/animal_form_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_form_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour animal_form_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/animal_form_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/animal_profile_screen_test.dart
+++ b/test/noyau/widget/animal_profile_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_profile_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour animal_profile_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/animal_profile_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/animal_screen_test.dart
+++ b/test/noyau/widget/animal_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animal_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour animal_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/animal_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/animals_screen_test.dart
+++ b/test/noyau/widget/animals_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour animals_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour animals_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/animals_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/home_screen_test.dart
+++ b/test/noyau/widget/home_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour home_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour home_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/home_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/ia_banner_test.dart
+++ b/test/noyau/widget/ia_banner_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_banner.dart (widget)
+// Copilot Prompt : Test automatique généré pour ia_banner.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/ia_banner.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/ia_chip_test.dart
+++ b/test/noyau/widget/ia_chip_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_chip.dart (widget)
+// Copilot Prompt : Test automatique généré pour ia_chip.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/ia_chip.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/ia_debug_screen_test.dart
+++ b/test/noyau/widget/ia_debug_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_debug_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour ia_debug_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/ia_debug_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/ia_log_viewer_test.dart
+++ b/test/noyau/widget/ia_log_viewer_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_log_viewer.dart (widget)
+// Copilot Prompt : Test automatique généré pour ia_log_viewer.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/ia_log_viewer.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/ia_suggestion_card_test.dart
+++ b/test/noyau/widget/ia_suggestion_card_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour ia_suggestion_card.dart (widget)
+// Copilot Prompt : Test automatique généré pour ia_suggestion_card.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/ia_suggestion_card.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/login_screen_test.dart
+++ b/test/noyau/widget/login_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour login_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour login_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/login_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour main_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour main_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/main_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/modules_screen_test.dart
+++ b/test/noyau/widget/modules_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour modules_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour modules_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/modules_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/more_menu_test.dart
+++ b/test/noyau/widget/more_menu_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour more_menu.dart (widget)
+// Copilot Prompt : Test automatique généré pour more_menu.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/more_menu.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/notification_admin_screen_test.dart
+++ b/test/noyau/widget/notification_admin_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour notification_admin_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour notification_admin_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/notification_admin_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/notification_admin_tools_screen_test.dart
+++ b/test/noyau/widget/notification_admin_tools_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour notification_admin_tools_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour notification_admin_tools_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/notification_admin_tools_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/notification_icon_test.dart
+++ b/test/noyau/widget/notification_icon_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour notification_icon.dart (widget)
+// Copilot Prompt : Test automatique généré pour notification_icon.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/widgets/notification_icon.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/notifications_screen_test.dart
+++ b/test/noyau/widget/notifications_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour notifications_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour notifications_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/notifications_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/qr_screen_test.dart
+++ b/test/noyau/widget/qr_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour qr_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour qr_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/qr_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/register_screen_test.dart
+++ b/test/noyau/widget/register_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour register_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour register_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/register_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/settings_screen_test.dart
+++ b/test/noyau/widget/settings_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour settings_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour settings_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/settings_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/share_screen_test.dart
+++ b/test/noyau/widget/share_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour share_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour share_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/share_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/splash_screen_test.dart
+++ b/test/noyau/widget/splash_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour splash_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour splash_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/super_admin_screen_test.dart
+++ b/test/noyau/widget/super_admin_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour super_admin_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour super_admin_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/super_admin_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/support_admin_screen_test.dart
+++ b/test/noyau/widget/support_admin_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour support_admin_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour support_admin_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/support_admin_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/support_screen_test.dart
+++ b/test/noyau/widget/support_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour support_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour support_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/support_screen.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/widget/user_profile_screen_test.dart
+++ b/test/noyau/widget/user_profile_screen_test.dart
@@ -1,7 +1,6 @@
-/// Copilot Prompt : Test automatique généré pour user_profile_screen.dart (widget)
+// Copilot Prompt : Test automatique généré pour user_profile_screen.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/user_profile_screen.dart';
 
 void main() {
   setUpAll(() async {


### PR DESCRIPTION
## Summary
- normalize comment style by replacing leading `///` with `//`
- clean placeholder tests by removing unused imports

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840997966dc8320a089c7fad359b8f6