### PR TITLE
Use enums for support ticket model

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:anisphere/modules/noyau/services/notification_service.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
+import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
@@ -44,6 +45,9 @@ void main() async {
     // Enregistrement des adapters Hive nécessaires
     Hive.registerAdapter(SyncTaskAdapter());
     Hive.registerAdapter(IAMetricAdapter());
+    Hive.registerAdapter(SupportTicketTypeAdapter());
+    Hive.registerAdapter(SupportTicketStatusAdapter());
+    Hive.registerAdapter(SupportTicketModelAdapter());
     await LocalStorageService.init();
     assert(() {
       debugPrint("📦 Hive initialized successfully!");

--- a/lib/modules/noyau/models/support_ticket_model.dart
+++ b/lib/modules/noyau/models/support_ticket_model.dart
@@ -7,6 +7,26 @@ import 'package:hive/hive.dart';
 
 part 'support_ticket_model.g.dart';
 
+@HiveType(typeId: 22)
+enum SupportTicketType {
+  @HiveField(0)
+  bug,
+  @HiveField(1)
+  idee,
+  @HiveField(2)
+  contact,
+}
+
+@HiveType(typeId: 23)
+enum SupportTicketStatus {
+  @HiveField(0)
+  brouillon,
+  @HiveField(1)
+  enCours,
+  @HiveField(2)
+  resolu,
+}
+
 @HiveType(typeId: 21)
 class SupportTicketModel {
   @HiveField(0)
@@ -16,13 +36,13 @@ class SupportTicketModel {
   final String userId;
 
   @HiveField(2)
-  final String type; // bug, idee, autre
+  final SupportTicketType type;
 
   @HiveField(3)
   final String message;
 
   @HiveField(4)
-  final String status; // brouillon, en_cours, resolu
+  final SupportTicketStatus status;
 
   @HiveField(5)
   final String logs;
@@ -50,7 +70,7 @@ class SupportTicketModel {
     required this.userId,
     required this.type,
     required this.message,
-    this.status = 'brouillon',
+    this.status = SupportTicketStatus.brouillon,
     this.logs = '',
     this.aiResponse = '',
     this.adminNote = '',
@@ -63,9 +83,9 @@ class SupportTicketModel {
   Map<String, dynamic> toJson() => {
         'id': id,
         'userId': userId,
-        'type': type,
+        'type': type.name,
         'message': message,
-        'status': status,
+        'status': status.name,
         'logs': logs,
         'aiResponse': aiResponse,
         'adminNote': adminNote,
@@ -76,12 +96,26 @@ class SupportTicketModel {
       };
 
   factory SupportTicketModel.fromJson(Map<String, dynamic> json) {
+    SupportTicketType parsedType;
+    try {
+      parsedType = SupportTicketType.values
+          .firstWhere((e) => e.name == json['type']);
+    } catch (_) {
+      parsedType = SupportTicketType.bug;
+    }
+    SupportTicketStatus parsedStatus;
+    try {
+      parsedStatus = SupportTicketStatus.values
+          .firstWhere((e) => e.name == json['status']);
+    } catch (_) {
+      parsedStatus = SupportTicketStatus.brouillon;
+    }
     return SupportTicketModel(
       id: json['id'] ?? '',
       userId: json['userId'] ?? '',
-      type: json['type'] ?? 'bug',
+      type: parsedType,
       message: json['message'] ?? '',
-      status: json['status'] ?? 'brouillon',
+      status: parsedStatus,
       logs: json['logs'] ?? '',
       aiResponse: json['aiResponse'] ?? '',
       adminNote: json['adminNote'] ?? '',
@@ -97,9 +131,9 @@ class SupportTicketModel {
   SupportTicketModel copyWith({
     String? id,
     String? userId,
-    String? type,
+    SupportTicketType? type,
     String? message,
-    String? status,
+    SupportTicketStatus? status,
     String? logs,
     String? aiResponse,
     String? adminNote,

--- a/lib/modules/noyau/models/support_ticket_model.g.dart
+++ b/lib/modules/noyau/models/support_ticket_model.g.dart
@@ -19,9 +19,9 @@ class SupportTicketModelAdapter extends TypeAdapter<SupportTicketModel> {
     return SupportTicketModel(
       id: fields[0] as String,
       userId: fields[1] as String,
-      type: fields[2] as String,
+      type: fields[2] as SupportTicketType,
       message: fields[3] as String,
-      status: fields[4] as String,
+      status: fields[4] as SupportTicketStatus,
       logs: fields[5] as String,
       aiResponse: fields[6] as String,
       adminNote: fields[7] as String,
@@ -69,6 +69,94 @@ class SupportTicketModelAdapter extends TypeAdapter<SupportTicketModel> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is SupportTicketModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class SupportTicketTypeAdapter extends TypeAdapter<SupportTicketType> {
+  @override
+  final int typeId = 22;
+
+  @override
+  SupportTicketType read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return SupportTicketType.bug;
+      case 1:
+        return SupportTicketType.idee;
+      case 2:
+        return SupportTicketType.contact;
+      default:
+        return SupportTicketType.bug;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, SupportTicketType obj) {
+    switch (obj) {
+      case SupportTicketType.bug:
+        writer.writeByte(0);
+        break;
+      case SupportTicketType.idee:
+        writer.writeByte(1);
+        break;
+      case SupportTicketType.contact:
+        writer.writeByte(2);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SupportTicketTypeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class SupportTicketStatusAdapter extends TypeAdapter<SupportTicketStatus> {
+  @override
+  final int typeId = 23;
+
+  @override
+  SupportTicketStatus read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return SupportTicketStatus.brouillon;
+      case 1:
+        return SupportTicketStatus.enCours;
+      case 2:
+        return SupportTicketStatus.resolu;
+      default:
+        return SupportTicketStatus.brouillon;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, SupportTicketStatus obj) {
+    switch (obj) {
+      case SupportTicketStatus.brouillon:
+        writer.writeByte(0);
+        break;
+      case SupportTicketStatus.enCours:
+        writer.writeByte(1);
+        break;
+      case SupportTicketStatus.resolu:
+        writer.writeByte(2);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SupportTicketStatusAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/modules/noyau/screens/support_admin_screen.dart
+++ b/lib/modules/noyau/screens/support_admin_screen.dart
@@ -38,7 +38,7 @@ class _SupportAdminScreenState extends State<SupportAdminScreen> {
         itemBuilder: (context, index) {
           final SupportTicketModel f = feedbacks[index];          return ListTile(
             title: Text(f.message),
-            subtitle: Text('${f.type} — ${f.status}'),
+            subtitle: Text('${f.type.name} — ${f.status.name}'),
             trailing: IconButton(
               icon: const Icon(Icons.delete),
               onPressed: () =>

--- a/lib/modules/noyau/screens/support_screen.dart
+++ b/lib/modules/noyau/screens/support_screen.dart
@@ -16,7 +16,7 @@ class SupportScreen extends StatefulWidget {
 
 class _SupportScreenState extends State<SupportScreen> {
   final _messageController = TextEditingController();
-  String _type = 'bug';
+  SupportTicketType _type = SupportTicketType.bug;
   bool _isSending = false;
 
   Future<void> _send() async {
@@ -46,14 +46,18 @@ class _SupportScreenState extends State<SupportScreen> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            DropdownButtonFormField<String>(
+            DropdownButtonFormField<SupportTicketType>(
               value: _type,
               items: const [
-                DropdownMenuItem(value: 'bug', child: Text('Bug')),
-                DropdownMenuItem(value: 'idee', child: Text('Idée')),
-                DropdownMenuItem(value: 'contact', child: Text('Contact')),
+                DropdownMenuItem(
+                    value: SupportTicketType.bug, child: Text('Bug')),
+                DropdownMenuItem(
+                    value: SupportTicketType.idee, child: Text('Idée')),
+                DropdownMenuItem(
+                    value: SupportTicketType.contact, child: Text('Contact')),
               ],
-              onChanged: (v) => setState(() => _type = v ?? 'bug'),
+              onChanged: (v) =>
+                  setState(() => _type = v ?? SupportTicketType.bug),
               decoration: const InputDecoration(labelText: 'Type de message'),
             ),
             TextField(

--- a/lib/modules/noyau/services/support_service.dart
+++ b/lib/modules/noyau/services/support_service.dart
@@ -35,6 +35,15 @@ class SupportService {
   Future<void> _initHive() async {
     if (skipHiveInit || _supportBox != null) return;
     try {
+      if (!Hive.isAdapterRegistered(22)) {
+        Hive.registerAdapter(SupportTicketTypeAdapter());
+      }
+      if (!Hive.isAdapterRegistered(23)) {
+        Hive.registerAdapter(SupportTicketStatusAdapter());
+      }
+      if (!Hive.isAdapterRegistered(21)) {
+        Hive.registerAdapter(SupportTicketModelAdapter());
+      }
       _supportBox = Hive.isBoxOpen(supportBoxName)
           ? Hive.box<SupportTicketModel>(supportBoxName)
           : await Hive.openBox<SupportTicketModel>(supportBoxName);


### PR DESCRIPTION
## Summary
- add `SupportTicketType` and `SupportTicketStatus` enums
- update `SupportTicketModel` to rely on enums
- generate Hive adapters for new enums
- register adapters and adjust screens & services

## Testing
- `bash scripts/test_suivi_automatique.sh` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684709e8f2f88320a292252295fe120b