### PR TITLE
Fix support tests to use CloudSyncService

### DIFF
--- a/test/helpers/test_fakes.dart
+++ b/test/helpers/test_fakes.dart
@@ -47,3 +47,32 @@ class FakeFirebaseService extends FirebaseService {
   FakeFirebaseService(FakeFirestore firestore)
       : super(firestore: firestore, firebaseAuth: FakeFirebaseAuth());
 }
+
+import 'package:anisphere/modules/noyau/services/cloud_sync_service.dart';
+import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
+import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
+
+class FakeCloudSyncService extends CloudSyncService {
+  FakeCloudSyncService(this.firestore)
+      : super(firebaseService: FakeFirebaseService(firestore));
+
+  final FakeFirestore firestore;
+
+  @override
+  Future<void> pushSupportData(SupportTicketModel feedback) async {
+    try {
+      await firestore
+          .collection('support')
+          .doc(feedback.id)
+          .set(feedback.toJson());
+    } catch (_) {
+      await OfflineSyncQueue.addTask(
+        SyncTask(
+          type: 'support',
+          data: feedback.toJson(),
+          timestamp: DateTime.now(),
+        ),
+      );
+    }
+  }
+}

--- a/test/noyau/unit/support_service_test.dart
+++ b/test/noyau/unit/support_service_test.dart
@@ -1,19 +1,4 @@
-<<<<<<< HEAD
 import 'dart:io';
-=======
-// Copilot Prompt : Test automatique généré pour support_service.dart (unit)
-import 'package:flutter_test/flutter_test.dart';
-import '../../test_config.dart';
-import 'package:mockito/mockito.dart';
-import 'package:hive/hive.dart';
-import 'package:anisphere/modules/noyau/services/support_service.dart';
-import 'package:anisphere/modules/noyau/services/cloud_sync_service.dart';
-import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
-
-class MockBox extends Mock implements Box<SupportTicketModel> {}
-
-class MockCloudSyncService extends Mock implements CloudSyncService {}
->>>>>>> codex/refactor-supportservice-pour-utiliser-cloudsyncservice
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -22,6 +7,7 @@ import 'package:anisphere/modules/noyau/services/support_service.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 
 import '../../helpers/test_fakes.dart';
+
 void main() {
   late Directory tempDir;
 
@@ -33,7 +19,6 @@ void main() {
     await Hive.openBox<SupportTicketModel>('support_data');
     await Hive.openBox<SyncTask>('offline_sync_queue');
   });
-<<<<<<< HEAD
 
   tearDown(() async {
     await Hive.deleteBoxFromDisk('support_data');
@@ -44,7 +29,7 @@ void main() {
   test('saveFeedback stores ticket locally and remotely', () async {
     final firestore = FakeFirestore();
     final service = SupportService(
-      firebaseService: FakeFirebaseService(firestore),
+      cloudSyncService: FakeCloudSyncService(firestore),
       skipHiveInit: true,
       testBox: Hive.box<SupportTicketModel>('support_data'),
     );
@@ -65,7 +50,7 @@ void main() {
   test('saveFeedback queues ticket when Firebase fails', () async {
     final firestore = FakeFirestore(fail: true);
     final service = SupportService(
-      firebaseService: FakeFirebaseService(firestore),
+      cloudSyncService: FakeCloudSyncService(firestore),
       skipHiveInit: true,
       testBox: Hive.box<SupportTicketModel>('support_data'),
     );
@@ -81,29 +66,5 @@ void main() {
     await service.saveFeedback(ticket);
     expect(queueBox.length, 1);
     expect(queueBox.getAt(0)?.data['message'], 'err');
-=======
-  test('saveFeedback calls CloudSyncService and stores locally', () async {
-    final mockBox = MockBox();
-    final mockCloud = MockCloudSyncService();
-    final service = SupportService(
-      cloudSyncService: mockCloud,
-      testBox: mockBox,
-      skipHiveInit: true,
-    );
-
-    final feedback = SupportTicketModel(
-      id: 'f1',
-      userId: 'u1',
-      type: 'bug',
-      message: 'issue',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    );
-
-    await service.saveFeedback(feedback);
-
-    verify(mockBox.put('f1', feedback)).called(1);
-    verify(mockCloud.pushSupportData(feedback)).called(1);
->>>>>>> codex/refactor-supportservice-pour-utiliser-cloudsyncservice
   });
 }

--- a/test/noyau/widget/support_screen_test.dart
+++ b/test/noyau/widget/support_screen_test.dart
@@ -50,7 +50,7 @@ void main() {
 
   testWidgets('submits ticket using provider', (tester) async {
     final service = SupportService(
-      firebaseService: FakeFirebaseService(FakeFirestore()),
+      cloudSyncService: FakeCloudSyncService(FakeFirestore()),
       skipHiveInit: true,
       testBox: Hive.box<SupportTicketModel>('support_data'),
     );


### PR DESCRIPTION
## Summary
- update SupportService tests to use CloudSyncService instead of FirebaseService
- add a `FakeCloudSyncService` helper for tests
- update widget test accordingly

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684717917298832099d59a61a21bcd86