### PR TITLE
Refactor tests to use FakeFirebaseFirestore

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   hive_test: ^1.0.0
   flutter_lints: ^6.0.0
+  fake_cloud_firestore: ^3.1.0
 
   # 🧪 Code generation
   hive_generator: ^2.0.1

--- a/test/helpers/test_fakes.dart
+++ b/test/helpers/test_fakes.dart
@@ -1,49 +1,21 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mockito/mockito.dart';
+import 'package:anisphere/modules/noyau/services/firebase_service.dart';
 
 class FakeFirebaseAuth extends Fake implements FirebaseAuth {}
 
-class FakeFirestore extends Fake implements FirebaseFirestore {
-  FakeFirestore({this.fail = false});
-  final bool fail;
-  final Map<String, Map<String, Map<String, dynamic>>> data = {};
-
-  @override
-  CollectionReference<Map<String, dynamic>> collection(String path) {
-    data.putIfAbsent(path, () => {});
-    return _FakeCollection(data[path]!, fail);
-  }
-}
-
-class _FakeCollection extends Fake implements CollectionReference<Map<String, dynamic>> {
-  _FakeCollection(this._map, this.fail);
-  final Map<String, Map<String, dynamic>> _map;
-  final bool fail;
-
-  @override
-  DocumentReference<Map<String, dynamic>> doc([String? id]) {
-    return _FakeDoc(_map, id ?? '', fail);
-  }
-}
-
-class _FakeDoc extends Fake implements DocumentReference<Map<String, dynamic>> {
-  _FakeDoc(this._map, this.id, this.fail);
-  final Map<String, Map<String, dynamic>> _map;
-  @override
-  final String id;
-  final bool fail;
-
-  @override
-  Future<void> set(Map<String, dynamic> data, [SetOptions? options]) async {
-    if (fail) throw Exception('fail');
-    _map[id] = data;
-  }
-}
-
-import 'package:anisphere/modules/noyau/services/firebase_service.dart';
-
 class FakeFirebaseService extends FirebaseService {
-  FakeFirebaseService(FakeFirestore firestore)
+  FakeFirebaseService(FakeFirebaseFirestore firestore)
       : super(firestore: firestore, firebaseAuth: FakeFirebaseAuth());
+}
+
+class FailingFirebaseService extends FirebaseService {
+  FailingFirebaseService(FakeFirebaseFirestore firestore)
+      : super(firestore: firestore, firebaseAuth: FakeFirebaseAuth());
+
+  @override
+  Future<void> sendModuleData(String moduleName, Map<String, dynamic> data) async {
+    throw Exception('fail');
+  }
 }

--- a/test/noyau/unit/support_service_test.dart
+++ b/test/noyau/unit/support_service_test.dart
@@ -42,7 +42,7 @@ void main() {
   });
 
   test('saveFeedback stores ticket locally and remotely', () async {
-    final firestore = FakeFirestore();
+    final firestore = FakeFirebaseFirestore();
     final service = SupportService(
       firebaseService: FakeFirebaseService(firestore),
       skipHiveInit: true,
@@ -59,13 +59,14 @@ void main() {
     await service.saveFeedback(ticket);
     final box = Hive.box<SupportTicketModel>('support_data');
     expect(box.get('1')?.message, 'msg');
-    expect(firestore.data['support']?['1']?['message'], 'msg');
+    final doc = await firestore.collection('support').doc('1').get();
+    expect(doc.data()?['message'], 'msg');
   });
 
   test('saveFeedback queues ticket when Firebase fails', () async {
-    final firestore = FakeFirestore(fail: true);
+    final firestore = FakeFirebaseFirestore();
     final service = SupportService(
-      firebaseService: FakeFirebaseService(firestore),
+      firebaseService: FailingFirebaseService(firestore),
       skipHiveInit: true,
       testBox: Hive.box<SupportTicketModel>('support_data'),
     );

--- a/test/noyau/widget/support_screen_test.dart
+++ b/test/noyau/widget/support_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:anisphere/modules/noyau/screens/support_screen.dart';
 import 'package:anisphere/modules/noyau/services/support_service.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 
 import "../../helpers/test_fakes.dart";
 
@@ -50,7 +51,7 @@ void main() {
 
   testWidgets('submits ticket using provider', (tester) async {
     final service = SupportService(
-      firebaseService: FakeFirebaseService(FakeFirestore()),
+      firebaseService: FakeFirebaseService(FakeFirebaseFirestore()),
       skipHiveInit: true,
       testBox: Hive.box<SupportTicketModel>('support_data'),
     );


### PR DESCRIPTION
## Summary
- use `FakeFirebaseFirestore` in test helpers instead of custom fakes
- update tests to use the new fake classes
- add `fake_cloud_firestore` to dev dependencies
- move `firebase_service.dart` import to top of helper file

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847178d0e60832084f020e81957b4a9