### PR TITLE
Add notification feedback service and unit tests

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -28,17 +28,18 @@
 | test/noyau/unit/app_initializer_test.dart | unit | package:anisphere/modules/noyau/services/app_initializer.dart | À faire |
 | test/noyau/unit/support_service_test.dart | unit | package:anisphere/modules/noyau/services/support_service.dart | À faire |
 | test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | À faire |
-| test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | À faire |
+| test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
+| test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | À faire |
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | À faire |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | À faire |
 | test/noyau/unit/ia_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/ia_sync_service.dart | À faire |
-| test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | À faire |
+| test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | ✅ |
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | À faire |
 | test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | À faire |
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
-| test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | À faire |
+| test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |
 | test/noyau/unit/ia_config_test.dart | unit | package:anisphere/modules/noyau/logic/ia_config.dart | À faire |
 | test/noyau/unit/ia_flag_test.dart | unit | package:anisphere/modules/noyau/logic/ia_flag.dart | À faire |
 | test/noyau/unit/ia_context_test.dart | unit | package:anisphere/modules/noyau/logic/ia_context.dart | À faire |
@@ -74,5 +75,5 @@
 | test/noyau/widget/login_screen_test.dart | widget | package:anisphere/modules/noyau/screens/login_screen.dart | À faire |
 | test/noyau/widget/support_screen_test.dart | widget | package:anisphere/modules/noyau/screens/support_screen.dart | À faire |
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
-| test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | À faire |
+| test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
 | test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |

--- a/lib/modules/noyau/services/notification_feedback_service.dart
+++ b/lib/modules/noyau/services/notification_feedback_service.dart
@@ -1,0 +1,58 @@
+library;
+
+import 'package:hive/hive.dart';
+import 'package:flutter/foundation.dart';
+
+part 'notification_feedback_service.g.dart';
+
+@HiveType(typeId: 102)
+class NotificationFeedback {
+  @HiveField(0)
+  final String id;
+
+  @HiveField(1)
+  final String notificationId;
+
+  @HiveField(2)
+  final bool positive;
+
+  @HiveField(3)
+  final DateTime timestamp;
+
+  NotificationFeedback({
+    required this.id,
+    required this.notificationId,
+    required this.positive,
+    required this.timestamp,
+  });
+}
+
+class NotificationFeedbackService {
+  static const String _boxName = 'notification_feedback';
+
+  /// Stores a feedback entry locally.
+  static Future<void> addFeedback(String notificationId, bool positive) async {
+    final box = await Hive.openBox<NotificationFeedback>(_boxName);
+    final entry = NotificationFeedback(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      notificationId: notificationId,
+      positive: positive,
+      timestamp: DateTime.now(),
+    );
+    await box.add(entry);
+    debugPrint('💬 Feedback enregistré pour $notificationId ($positive)');
+  }
+
+  /// Returns all stored feedback entries.
+  static Future<List<NotificationFeedback>> getAllFeedback() async {
+    final box = await Hive.openBox<NotificationFeedback>(_boxName);
+    return box.values.toList();
+  }
+
+  /// Clears all stored feedback entries.
+  static Future<void> clear() async {
+    final box = await Hive.openBox<NotificationFeedback>(_boxName);
+    await box.clear();
+    debugPrint('🧹 Feedback notifications vidé.');
+  }
+}

--- a/lib/modules/noyau/services/notification_feedback_service.g.dart
+++ b/lib/modules/noyau/services/notification_feedback_service.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_feedback_service.dart';
+
+class NotificationFeedbackAdapter extends TypeAdapter<NotificationFeedback> {
+  @override
+  final int typeId = 102;
+
+  @override
+  NotificationFeedback read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return NotificationFeedback(
+      id: fields[0] as String,
+      notificationId: fields[1] as String,
+      positive: fields[2] as bool,
+      timestamp: fields[3] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, NotificationFeedback obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.notificationId)
+      ..writeByte(2)
+      ..write(obj.positive)
+      ..writeByte(3)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotificationFeedbackAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/noyau/unit/cloud_notification_listener_test.dart
+++ b/test/noyau/unit/cloud_notification_listener_test.dart
@@ -1,13 +1,31 @@
-// Copilot Prompt : Test automatique généré pour cloud_notification_listener.dart (unit)
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
 import '../../test_config.dart';
 
 void main() {
+  const channel = MethodChannel('plugins.flutter.io/firebase_messaging');
+  final List<MethodCall> log = [];
+
   setUpAll(() async {
     await initTestEnv();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      log.add(call);
+      if (call.method.contains('getToken')) {
+        return 'token_123';
+      }
+      return true;
+    });
   });
-  test('cloud_notification_listener fonctionne (test auto)', () {
-    // TODO : compléter le test pour cloud_notification_listener.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() {
+    log.clear();
+  });
+
+  test('getToken returns token from FirebaseMessaging', () async {
+    final token = await CloudNotificationListener.getToken();
+    expect(token, 'token_123');
+    expect(log.any((c) => c.method.contains('getToken')), isTrue);
   });
 }

--- a/test/noyau/unit/ia_metrics_collector_test.dart
+++ b/test/noyau/unit/ia_metrics_collector_test.dart
@@ -1,13 +1,38 @@
-// Copilot Prompt : Test automatique généré pour ia_metrics_collector.dart (unit)
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 import '../../test_config.dart';
 
 void main() {
-  setUpAll(() async {
+  late Directory tempDir;
+
+  setUp(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(IAMetricAdapter());
+    await Hive.openBox<IAMetric>('ia_metrics');
   });
-  test('ia_metrics_collector fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_metrics_collector.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('ia_metrics');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('addMetric stores metric and can be retrieved', () async {
+    await IAMetricsCollector.addMetric('score', 5);
+    final metrics = await IAMetricsCollector.getAllMetrics();
+    expect(metrics.length, 1);
+    expect(metrics.first.name, 'score');
+    expect(metrics.first.value, 5);
+  });
+
+  test('clearMetrics removes stored metrics', () async {
+    await IAMetricsCollector.addMetric('temp', 1);
+    await IAMetricsCollector.clearMetrics();
+    final metrics = await IAMetricsCollector.getAllMetrics();
+    expect(metrics, isEmpty);
   });
 }

--- a/test/noyau/unit/notification_feedback_service_test.dart
+++ b/test/noyau/unit/notification_feedback_service_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/notification_feedback_service.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(NotificationFeedbackAdapter());
+    await Hive.openBox<NotificationFeedback>('notification_feedback');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('notification_feedback');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('addFeedback stores feedback in Hive box', () async {
+    await NotificationFeedbackService.addFeedback('notif1', true);
+    final box = await Hive.openBox<NotificationFeedback>('notification_feedback');
+    expect(box.length, 1);
+    expect(box.getAt(0)?.notificationId, 'notif1');
+    expect(box.getAt(0)?.positive, true);
+  });
+
+  test('getAllFeedback returns stored entries', () async {
+    await NotificationFeedbackService.addFeedback('notif2', false);
+    final all = await NotificationFeedbackService.getAllFeedback();
+    expect(all.length, 1);
+    expect(all.first.notificationId, 'notif2');
+    expect(all.first.positive, false);
+  });
+
+  test('clear removes all feedback', () async {
+    await NotificationFeedbackService.addFeedback('notif3', true);
+    await NotificationFeedbackService.clear();
+    final all = await NotificationFeedbackService.getAllFeedback();
+    expect(all, isEmpty);
+  });
+}

--- a/test/noyau/unit/notification_service_test.dart
+++ b/test/noyau/unit/notification_service_test.dart
@@ -1,13 +1,42 @@
-// Copilot Prompt : Test automatique généré pour notification_service.dart (unit)
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/noyau/services/notification_service.dart';
 import '../../test_config.dart';
 
 void main() {
+  const channel = MethodChannel('dexterous.com/flutter/local_notifications');
+  final List<MethodCall> log = [];
+
   setUpAll(() async {
     await initTestEnv();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      log.add(call);
+      return true;
+    });
   });
-  test('notification_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour notification_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() {
+    log.clear();
+  });
+
+  test('initialize triggers plugin initialization', () async {
+    await NotificationService.initialize();
+    expect(log.any((c) => c.method == 'initialize'), isTrue);
+  });
+
+  test('showNotification sends show call', () async {
+    await NotificationService.showNotification(title: 't', body: 'b', id: 1);
+    expect(log.any((c) => c.method == 'show'), isTrue);
+  });
+
+  test('cancel cancels specific notification', () async {
+    await NotificationService.cancel(1);
+    expect(log.any((c) => c.method == 'cancel'), isTrue);
+  });
+
+  test('cancelAll cancels all notifications', () async {
+    await NotificationService.cancelAll();
+    expect(log.any((c) => c.method == 'cancelAll'), isTrue);
   });
 }

--- a/test/noyau/widget/notifications_screen_test.dart
+++ b/test/noyau/widget/notifications_screen_test.dart
@@ -1,13 +1,20 @@
-// Copilot Prompt : Test automatique généré pour notifications_screen.dart (widget)
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/noyau/screens/notifications_screen.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('notifications_screen fonctionne (test auto)', () {
-    // TODO : compléter le test pour notifications_screen.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  testWidgets('NotificationsScreen displays sample data', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: NotificationsScreen()));
+
+    expect(find.text('Notifications'), findsOneWidget);
+    // One sample module title should appear
+    expect(find.text('Santé'), findsOneWidget);
+    // One of the sample notification titles
+    expect(find.text('Vaccin à jour'), findsOneWidget);
   });
 }

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -28,17 +28,18 @@
 | test/noyau/unit/app_initializer_test.dart | unit | package:anisphere/modules/noyau/services/app_initializer.dart | À faire |
 | test/noyau/unit/support_service_test.dart | unit | package:anisphere/modules/noyau/services/support_service.dart | À faire |
 | test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | À faire |
-| test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | À faire |
+| test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
+| test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | À faire |
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | À faire |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | À faire |
 | test/noyau/unit/ia_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/ia_sync_service.dart | À faire |
-| test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | À faire |
+| test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | ✅ |
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | À faire |
 | test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | À faire |
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
-| test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | À faire |
+| test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |
 | test/noyau/unit/ia_config_test.dart | unit | package:anisphere/modules/noyau/logic/ia_config.dart | À faire |
 | test/noyau/unit/ia_flag_test.dart | unit | package:anisphere/modules/noyau/logic/ia_flag.dart | À faire |
 | test/noyau/unit/ia_context_test.dart | unit | package:anisphere/modules/noyau/logic/ia_context.dart | À faire |
@@ -74,5 +75,5 @@
 | test/noyau/widget/login_screen_test.dart | widget | package:anisphere/modules/noyau/screens/login_screen.dart | À faire |
 | test/noyau/widget/support_screen_test.dart | widget | package:anisphere/modules/noyau/screens/support_screen.dart | À faire |
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
-| test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | À faire |
+| test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
 | test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |


### PR DESCRIPTION
## Summary
- implement `NotificationFeedbackService` with Hive storage
- generate adapter for `NotificationFeedback`
- write unit tests for new service
- replace placeholder tests with real ones for notifications and metrics
- update test tracker entries

## Testing
- `dart scripts/update_test_tracker.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68484ddf84b0832083f2a546175832d1