### PR TITLE
Add messaging models and offline queue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,8 @@ import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
 import 'package:anisphere/modules/noyau/logic/ia_master.dart';
+import 'package:anisphere/modules/messagerie/models/message_model.dart';
+import 'package:anisphere/modules/messagerie/models/conversation_model.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -46,6 +48,8 @@ void main() async {
     Hive.registerAdapter(SupportTicketTypeAdapter());
     Hive.registerAdapter(SupportTicketStatusAdapter());
     Hive.registerAdapter(SupportTicketModelAdapter());
+    Hive.registerAdapter(MessageModelAdapter());
+    Hive.registerAdapter(ConversationModelAdapter());
     await LocalStorageService.init();
     assert(() {
       debugPrint("📦 Hive initialized successfully!");

--- a/lib/modules/messagerie/models/conversation_model.dart
+++ b/lib/modules/messagerie/models/conversation_model.dart
@@ -1,0 +1,58 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'conversation_model.g.dart';
+
+@HiveType(typeId: 71)
+class ConversationModel {
+  @HiveField(0)
+  final List<String> participants;
+
+  @HiveField(1)
+  final String lastMessage;
+
+  @HiveField(2)
+  final DateTime lastTimestamp;
+
+  @HiveField(3)
+  final String module;
+
+  ConversationModel({
+    this.participants = const [],
+    this.lastMessage = '',
+    DateTime? lastTimestamp,
+    this.module = '',
+  }) : lastTimestamp = lastTimestamp ?? DateTime.now();
+
+  factory ConversationModel.fromJson(Map<String, dynamic> json) {
+    return ConversationModel(
+      participants: List<String>.from(json['participants'] ?? []),
+      lastMessage: json['lastMessage'] ?? '',
+      lastTimestamp:
+          DateTime.tryParse(json['lastTimestamp'] ?? '') ?? DateTime.now(),
+      module: json['module'] ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'participants': participants,
+        'lastMessage': lastMessage,
+        'lastTimestamp': lastTimestamp.toIso8601String(),
+        'module': module,
+      };
+
+  ConversationModel copyWith({
+    List<String>? participants,
+    String? lastMessage,
+    DateTime? lastTimestamp,
+    String? module,
+  }) {
+    return ConversationModel(
+      participants: participants ?? this.participants,
+      lastMessage: lastMessage ?? this.lastMessage,
+      lastTimestamp: lastTimestamp ?? this.lastTimestamp,
+      module: module ?? this.module,
+    );
+  }
+}

--- a/lib/modules/messagerie/models/conversation_model.g.dart
+++ b/lib/modules/messagerie/models/conversation_model.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'conversation_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ConversationModelAdapter extends TypeAdapter<ConversationModel> {
+  @override
+  final int typeId = 71;
+
+  @override
+  ConversationModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ConversationModel(
+      participants: (fields[0] as List).cast<String>(),
+      lastMessage: fields[1] as String,
+      lastTimestamp: fields[2] as DateTime,
+      module: fields[3] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ConversationModel obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.participants)
+      ..writeByte(1)
+      ..write(obj.lastMessage)
+      ..writeByte(2)
+      ..write(obj.lastTimestamp)
+      ..writeByte(3)
+      ..write(obj.module);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConversationModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/modules/messagerie/models/message_model.dart
+++ b/lib/modules/messagerie/models/message_model.dart
@@ -1,0 +1,89 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'message_model.g.dart';
+
+@HiveType(typeId: 70)
+class MessageModel {
+  @HiveField(0)
+  final String id;
+
+  @HiveField(1)
+  final String senderId;
+
+  @HiveField(2)
+  final String receiverId;
+
+  @HiveField(3)
+  final String content;
+
+  @HiveField(4)
+  final DateTime timestamp;
+
+  @HiveField(5)
+  final String moduleContext;
+
+  @HiveField(6)
+  final int priority;
+
+  @HiveField(7)
+  final String status;
+
+  const MessageModel({
+    required this.id,
+    required this.senderId,
+    required this.receiverId,
+    required this.content,
+    required this.timestamp,
+    this.moduleContext = '',
+    this.priority = 0,
+    this.status = '',
+  });
+
+  factory MessageModel.fromJson(Map<String, dynamic> json) {
+    return MessageModel(
+      id: json['id'] ?? '',
+      senderId: json['senderId'] ?? '',
+      receiverId: json['receiverId'] ?? '',
+      content: json['content'] ?? '',
+      timestamp: DateTime.tryParse(json['timestamp'] ?? '') ?? DateTime.now(),
+      moduleContext: json['moduleContext'] ?? '',
+      priority: json['priority'] ?? 0,
+      status: json['status'] ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'senderId': senderId,
+        'receiverId': receiverId,
+        'content': content,
+        'timestamp': timestamp.toIso8601String(),
+        'moduleContext': moduleContext,
+        'priority': priority,
+        'status': status,
+      };
+
+  MessageModel copyWith({
+    String? id,
+    String? senderId,
+    String? receiverId,
+    String? content,
+    DateTime? timestamp,
+    String? moduleContext,
+    int? priority,
+    String? status,
+  }) {
+    return MessageModel(
+      id: id ?? this.id,
+      senderId: senderId ?? this.senderId,
+      receiverId: receiverId ?? this.receiverId,
+      content: content ?? this.content,
+      timestamp: timestamp ?? this.timestamp,
+      moduleContext: moduleContext ?? this.moduleContext,
+      priority: priority ?? this.priority,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/lib/modules/messagerie/models/message_model.g.dart
+++ b/lib/modules/messagerie/models/message_model.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'message_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class MessageModelAdapter extends TypeAdapter<MessageModel> {
+  @override
+  final int typeId = 70;
+
+  @override
+  MessageModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return MessageModel(
+      id: fields[0] as String,
+      senderId: fields[1] as String,
+      receiverId: fields[2] as String,
+      content: fields[3] as String,
+      timestamp: fields[4] as DateTime,
+      moduleContext: fields[5] as String,
+      priority: fields[6] as int,
+      status: fields[7] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, MessageModel obj) {
+    writer
+      ..writeByte(8)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.senderId)
+      ..writeByte(2)
+      ..write(obj.receiverId)
+      ..writeByte(3)
+      ..write(obj.content)
+      ..writeByte(4)
+      ..write(obj.timestamp)
+      ..writeByte(5)
+      ..write(obj.moduleContext)
+      ..writeByte(6)
+      ..write(obj.priority)
+      ..writeByte(7)
+      ..write(obj.status);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MessageModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/modules/messagerie/services/offline_message_queue.dart
+++ b/lib/modules/messagerie/services/offline_message_queue.dart
@@ -1,0 +1,27 @@
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../models/message_model.dart';
+
+class OfflineMessageQueue {
+  static const String _boxName = 'offline_messages';
+
+  static Future<void> addMessage(MessageModel message) async {
+    final box = await Hive.openBox<MessageModel>(_boxName);
+    await box.add(message);
+    debugPrint('📥 Message ajouté à la file offline : ${message.id}');
+  }
+
+  static Future<List<MessageModel>> getAllMessages() async {
+    final box = await Hive.openBox<MessageModel>(_boxName);
+    return box.values.toList();
+  }
+
+  static Future<void> clearQueue() async {
+    final box = await Hive.openBox<MessageModel>(_boxName);
+    await box.clear();
+    debugPrint('🧹 File de messages offline vidée.');
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `MessageModel` and `ConversationModel` with Hive/JSON serialization
- provide `OfflineMessageQueue` service for storing unsent messages locally
- register the new Hive adapters in `main.dart`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b8c5d5c83209344e5d3938fa951