### PR TITLE
Add messaging module with offline queue

### DIFF
--- a/lib/modules/messagerie/models/message_model.dart
+++ b/lib/modules/messagerie/models/message_model.dart
@@ -1,0 +1,69 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'message_model.g.dart';
+
+/// Model representing a chat message.
+@HiveType(typeId: 120)
+class MessageModel {
+  @HiveField(0)
+  final String id;
+
+  @HiveField(1)
+  final String conversationId;
+
+  @HiveField(2)
+  final String senderId;
+
+  @HiveField(3)
+  final String content;
+
+  @HiveField(4)
+  final DateTime timestamp;
+
+  @HiveField(5)
+  final bool sent;
+
+  MessageModel({
+    required this.id,
+    required this.conversationId,
+    required this.senderId,
+    required this.content,
+    DateTime? timestamp,
+    this.sent = false,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  factory MessageModel.fromMap(Map<String, dynamic> map) {
+    return MessageModel(
+      id: map['id'] ?? '',
+      conversationId: map['conversationId'] ?? '',
+      senderId: map['senderId'] ?? '',
+      content: map['content'] ?? '',
+      timestamp: DateTime.tryParse(map['timestamp'] ?? '') ?? DateTime.now(),
+      sent: map['sent'] ?? false,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'conversationId': conversationId,
+      'senderId': senderId,
+      'content': content,
+      'timestamp': timestamp.toIso8601String(),
+      'sent': sent,
+    };
+  }
+
+  MessageModel copyWith({bool? sent}) {
+    return MessageModel(
+      id: id,
+      conversationId: conversationId,
+      senderId: senderId,
+      content: content,
+      timestamp: timestamp,
+      sent: sent ?? this.sent,
+    );
+  }
+}

--- a/lib/modules/messagerie/models/message_model.g.dart
+++ b/lib/modules/messagerie/models/message_model.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'message_model.dart';
+
+class MessageModelAdapter extends TypeAdapter<MessageModel> {
+  @override
+  final int typeId = 120;
+
+  @override
+  MessageModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return MessageModel(
+      id: fields[0] as String,
+      conversationId: fields[1] as String,
+      senderId: fields[2] as String,
+      content: fields[3] as String,
+      timestamp: fields[4] as DateTime,
+      sent: fields[5] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, MessageModel obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.conversationId)
+      ..writeByte(2)
+      ..write(obj.senderId)
+      ..writeByte(3)
+      ..write(obj.content)
+      ..writeByte(4)
+      ..write(obj.timestamp)
+      ..writeByte(5)
+      ..write(obj.sent);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MessageModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/modules/messagerie/providers/messaging_provider.dart
+++ b/lib/modules/messagerie/providers/messaging_provider.dart
@@ -1,0 +1,41 @@
+library;
+
+import 'package:flutter/material.dart';
+
+import '../models/message_model.dart';
+import '../services/messaging_service.dart';
+
+/// Provider managing active conversations and new message notifications.
+class MessagingProvider extends ChangeNotifier {
+  final MessagingService _service;
+  final Map<String, List<MessageModel>> _conversations = {};
+
+  MessagingProvider({MessagingService? service})
+      : _service = service ?? MessagingService();
+
+  List<MessageModel> getMessages(String conversationId) =>
+      _conversations[conversationId] ?? [];
+
+  Future<void> loadConversation(String conversationId) async {
+    final msgs = await _service.getMessages(conversationId);
+    _conversations[conversationId] = msgs;
+    notifyListeners();
+  }
+
+  Future<void> send(MessageModel message) async {
+    await _service.sendMessage(message);
+    _conversations.putIfAbsent(message.conversationId, () => []);
+    _conversations[message.conversationId]!.add(message);
+    notifyListeners();
+  }
+
+  Future<void> refresh(List<String> conversationIds) async {
+    for (final id in conversationIds) {
+      await loadConversation(id);
+    }
+  }
+
+  Future<void> syncOffline() async {
+    await _service.syncOfflineMessages();
+  }
+}

--- a/lib/modules/messagerie/services/messaging_service.dart
+++ b/lib/modules/messagerie/services/messaging_service.dart
@@ -1,0 +1,81 @@
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../models/message_model.dart';
+import 'offline_message_queue.dart';
+
+/// Service handling messages storage and synchronization.
+class MessagingService {
+  static const String boxName = 'messages_box';
+
+  final FirebaseFirestore firestore;
+  Box<MessageModel>? _box;
+
+  MessagingService({FirebaseFirestore? firestoreInstance})
+      : firestore = firestoreInstance ?? FirebaseFirestore.instance;
+
+  Future<void> _initHive() async {
+    if (_box != null) return;
+    if (!Hive.isAdapterRegistered(120)) {
+      Hive.registerAdapter(MessageModelAdapter());
+    }
+    if (!Hive.isAdapterRegistered(121)) {
+      Hive.registerAdapter(QueuedMessageAdapter());
+    }
+    _box = Hive.isBoxOpen(boxName)
+        ? Hive.box<MessageModel>(boxName)
+        : await Hive.openBox<MessageModel>(boxName);
+  }
+
+  Future<void> sendMessage(MessageModel message) async {
+    await _initHive();
+    await _box?.put(message.id, message);
+    try {
+      await firestore
+          .collection('conversations')
+          .doc(message.conversationId)
+          .collection('messages')
+          .doc(message.id)
+          .set(message.toMap());
+      await _box?.put(message.id, message.copyWith(sent: true));
+    } catch (e) {
+      debugPrint('❌ Envoi Firestore échoué, mise en queue.');
+      await OfflineMessageQueue.enqueue(message);
+    }
+  }
+
+  Future<List<MessageModel>> getMessages(String conversationId) async {
+    await _initHive();
+    return _box?.values
+            .where((m) => m.conversationId == conversationId)
+            .toList() ??
+        [];
+  }
+
+  Future<void> syncOfflineMessages() async {
+    await _initHive();
+    final pending = await OfflineMessageQueue.getAll();
+    if (pending.isEmpty) return;
+    final batch = firestore.batch();
+    for (final msg in pending) {
+      final ref = firestore
+          .collection('conversations')
+          .doc(msg.conversationId)
+          .collection('messages')
+          .doc(msg.id);
+      batch.set(ref, msg.toMap(), SetOptions(merge: true));
+    }
+    try {
+      await batch.commit();
+      for (final msg in pending) {
+        await _box?.put(msg.id, msg.copyWith(sent: true));
+      }
+      await OfflineMessageQueue.clear();
+    } catch (e) {
+      debugPrint('❌ Batch sync failed: $e');
+    }
+  }
+}

--- a/lib/modules/messagerie/services/offline_message_queue.dart
+++ b/lib/modules/messagerie/services/offline_message_queue.dart
@@ -1,0 +1,52 @@
+library;
+
+import 'package:hive/hive.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/message_model.dart';
+
+part 'offline_message_queue.g.dart';
+
+/// Stores messages that could not be sent immediately.
+@HiveType(typeId: 121)
+class QueuedMessage {
+  @HiveField(0)
+  final MessageModel message;
+
+  QueuedMessage({required this.message});
+}
+
+class OfflineMessageQueue {
+  static const String _boxName = 'offline_message_queue';
+
+  static Future<void> enqueue(MessageModel message) async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
+    await box.add(QueuedMessage(message: message));
+    debugPrint('📥 Message mis en attente: ${message.id}');
+  }
+
+  static Future<List<MessageModel>> getAll() async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
+    return box.values.map((e) => e.message).toList();
+  }
+
+  static Future<void> clear() async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
+    await box.clear();
+  }
+
+  static Future<void> process(
+    Future<void> Function(MessageModel msg) send,
+  ) async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
+    final messages = box.values.toList();
+    for (final queued in messages) {
+      try {
+        await send(queued.message);
+      } catch (e) {
+        debugPrint('❌ Erreur envoi message offline: $e');
+      }
+    }
+    await clear();
+  }
+}

--- a/lib/modules/messagerie/services/offline_message_queue.g.dart
+++ b/lib/modules/messagerie/services/offline_message_queue.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'offline_message_queue.dart';
+
+class QueuedMessageAdapter extends TypeAdapter<QueuedMessage> {
+  @override
+  final int typeId = 121;
+
+  @override
+  QueuedMessage read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return QueuedMessage(
+      message: fields[0] as MessageModel,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, QueuedMessage obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.message);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QueuedMessageAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/messagerie/unit/messaging_provider_test.dart
+++ b/test/messagerie/unit/messaging_provider_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/messagerie/providers/messaging_provider.dart';
+import 'package:anisphere/modules/messagerie/models/message_model.dart';
+import 'package:anisphere/modules/messagerie/services/messaging_service.dart';
+
+class _FakeService extends MessagingService {
+  List<MessageModel> sent = [];
+  _FakeService();
+  @override
+  Future<void> sendMessage(MessageModel message) async {
+    sent.add(message);
+  }
+
+  @override
+  Future<List<MessageModel>> getMessages(String conversationId) async {
+    return sent.where((m) => m.conversationId == conversationId).toList();
+  }
+}
+
+void main() {
+  test('send adds message to conversation and delegates to service', () async {
+    final service = _FakeService();
+    final provider = MessagingProvider(service: service);
+    final msg = MessageModel(
+      id: '1',
+      conversationId: 'c1',
+      senderId: 'u1',
+      content: 'hi',
+    );
+
+    await provider.send(msg);
+    expect(provider.getMessages('c1').length, 1);
+    expect(service.sent.length, 1);
+  });
+}

--- a/test/messagerie/unit/messaging_service_test.dart
+++ b/test/messagerie/unit/messaging_service_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/messagerie/models/message_model.dart';
+import 'package:anisphere/modules/messagerie/services/messaging_service.dart';
+import 'package:anisphere/modules/messagerie/services/offline_message_queue.dart';
+import '../../test_config.dart';
+import '../../helpers/test_fakes.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('sendMessage stores message locally and queues on failure', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(MessageModelAdapter());
+    Hive.registerAdapter(QueuedMessageAdapter());
+
+    final service = MessagingService(firestoreInstance: FakeFirestore(fail: true));
+    final message = MessageModel(
+      id: '1',
+      conversationId: 'c1',
+      senderId: 'u1',
+      content: 'hello',
+    );
+
+    await service.sendMessage(message);
+
+    final box = await Hive.openBox<MessageModel>('messages_box');
+    expect(box.get('1')?.content, 'hello');
+    final queued = await OfflineMessageQueue.getAll();
+    expect(queued.length, 1);
+
+    await tempDir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- add offline message queue using Hive
- create messaging service for local storage and Firestore sync
- implement messaging provider
- add unit tests for service and provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b8dce888320bcfae1d90ddec308