### PR TITLE
Add messagerie test scaffolding

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -77,3 +77,9 @@
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
 | test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
 | test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |
+| test/messagerie/unit/messaging_service_test.dart | unit | package:anisphere/modules/messagerie/services/messaging_service.dart | À faire |
+| test/messagerie/unit/offline_message_queue_test.dart | unit | package:anisphere/modules/messagerie/services/offline_message_queue.dart | À faire |
+| test/messagerie/unit/ia_message_analyzer_test.dart | unit | package:anisphere/modules/messagerie/services/ia_message_analyzer.dart | À faire |
+| test/messagerie/widget/chat_screen_widget_test.dart | widget | package:anisphere/modules/messagerie/screens/chat_screen.dart | À faire |
+| test/messagerie/widget/message_list_screen_widget_test.dart | widget | package:anisphere/modules/messagerie/screens/message_list_screen.dart | À faire |
+| test/messagerie/integration/messagerie_integration.dart | integration | package:anisphere/modules/messagerie/screens/chat_screen.dart | À faire |

--- a/lib/modules/messagerie/README.md
+++ b/lib/modules/messagerie/README.md
@@ -1,0 +1,3 @@
+# Module messagerie
+
+Ce dossier contient le code source du module `messagerie`.

--- a/test/messagerie/integration/messagerie_integration.dart
+++ b/test/messagerie/integration/messagerie_integration.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets('MESSAGERIE - Test d\u2019int\u00e9gration', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: Text('MESSAGERIE Integration')),
+    ));
+
+    expect(find.text('MESSAGERIE Integration'), findsOneWidget);
+
+    // TODO: Ajouter d'autres tests d\u2019int\u00e9gration ici
+  });
+}

--- a/test/messagerie/unit/ia_message_analyzer_test.dart
+++ b/test/messagerie/unit/ia_message_analyzer_test.dart
@@ -1,0 +1,14 @@
+// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour ia_message_analyzer.dart (unit)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('ia_message_analyzer fonctionne (test auto)', () {
+    // TODO : compl\u00e9ter le test pour ia_message_analyzer.dart
+    expect(true, isTrue); // \u00c0 remplacer par un vrai test
+  });
+}

--- a/test/messagerie/unit/messaging_service_test.dart
+++ b/test/messagerie/unit/messaging_service_test.dart
@@ -1,0 +1,14 @@
+// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour messaging_service.dart (unit)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('messaging_service fonctionne (test auto)', () {
+    // TODO : compl\u00e9ter le test pour messaging_service.dart
+    expect(true, isTrue); // \u00c0 remplacer par un vrai test
+  });
+}

--- a/test/messagerie/unit/offline_message_queue_test.dart
+++ b/test/messagerie/unit/offline_message_queue_test.dart
@@ -1,0 +1,14 @@
+// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour offline_message_queue.dart (unit)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('offline_message_queue fonctionne (test auto)', () {
+    // TODO : compl\u00e9ter le test pour offline_message_queue.dart
+    expect(true, isTrue); // \u00c0 remplacer par un vrai test
+  });
+}

--- a/test/messagerie/widget/chat_screen_widget_test.dart
+++ b/test/messagerie/widget/chat_screen_widget_test.dart
@@ -1,0 +1,13 @@
+// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour chat_screen.dart (widget)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+  test('chat_screen fonctionne (test auto)', () {
+    // TODO : compl\u00e9ter le test pour chat_screen.dart
+    expect(true, isTrue); // \u00c0 remplacer par un vrai test
+  });
+}

--- a/test/messagerie/widget/message_list_screen_widget_test.dart
+++ b/test/messagerie/widget/message_list_screen_widget_test.dart
@@ -1,0 +1,13 @@
+// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour message_list_screen.dart (widget)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+  test('message_list_screen fonctionne (test auto)', () {
+    // TODO : compl\u00e9ter le test pour message_list_screen.dart
+    expect(true, isTrue); // \u00c0 remplacer par un vrai test
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -76,4 +76,9 @@
 | test/noyau/widget/support_screen_test.dart | widget | package:anisphere/modules/noyau/screens/support_screen.dart | À faire |
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
 | test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
-| test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |
+| test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire || test/messagerie/unit/messaging_service_test.dart | unit | package:anisphere/modules/messagerie/services/messaging_service.dart | À faire |
+| test/messagerie/unit/offline_message_queue_test.dart | unit | package:anisphere/modules/messagerie/services/offline_message_queue.dart | À faire |
+| test/messagerie/unit/ia_message_analyzer_test.dart | unit | package:anisphere/modules/messagerie/services/ia_message_analyzer.dart | À faire |
+| test/messagerie/widget/chat_screen_widget_test.dart | widget | package:anisphere/modules/messagerie/screens/chat_screen.dart | À faire |
+| test/messagerie/widget/message_list_screen_widget_test.dart | widget | package:anisphere/modules/messagerie/screens/message_list_screen.dart | À faire |
+| test/messagerie/integration/messagerie_integration.dart | integration | package:anisphere/modules/messagerie/screens/chat_screen.dart | À faire |


### PR DESCRIPTION
## Summary
- scaffold messagerie test folders and README
- add placeholder unit, widget, and integration tests for messagerie
- track new tests in docs/test_tracker.md and test/test_tracker.md

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b91e3888320aa7512171c766c92