### PR TITLE
Add conversationId and sent status to MessageModel

### DIFF
--- a/lib/modules/messagerie/models/message_model.dart
+++ b/lib/modules/messagerie/models/message_model.dart
@@ -1,4 +1,5 @@
 library;
+// TODO: ajouter test
 
 import 'package:hive/hive.dart';
 
@@ -10,40 +11,49 @@ class MessageModel {
   final String id;
 
   @HiveField(1)
-  final String senderId;
+  final String conversationId;
 
   @HiveField(2)
-  final String receiverId;
+  final String senderId;
 
   @HiveField(3)
-  final String content;
+  final String receiverId;
 
   @HiveField(4)
-  final DateTime timestamp;
+  final String content;
 
   @HiveField(5)
-  final String moduleContext;
+  final DateTime timestamp;
 
   @HiveField(6)
-  final int priority;
+  final String moduleContext;
 
   @HiveField(7)
+  final int priority;
+
+  @HiveField(8)
   final String status;
+
+  @HiveField(9)
+  final bool sent;
 
   const MessageModel({
     required this.id,
+    required this.conversationId,
     required this.senderId,
-    required this.receiverId,
+    this.receiverId = '',
     required this.content,
-    required this.timestamp,
+    DateTime? timestamp,
     this.moduleContext = '',
     this.priority = 0,
     this.status = '',
-  });
+    this.sent = false,
+  }) : timestamp = timestamp ?? DateTime.now();
 
   factory MessageModel.fromJson(Map<String, dynamic> json) {
     return MessageModel(
       id: json['id'] ?? '',
+      conversationId: json['conversationId'] ?? '',
       senderId: json['senderId'] ?? '',
       receiverId: json['receiverId'] ?? '',
       content: json['content'] ?? '',
@@ -51,11 +61,13 @@ class MessageModel {
       moduleContext: json['moduleContext'] ?? '',
       priority: json['priority'] ?? 0,
       status: json['status'] ?? '',
+      sent: json['sent'] ?? false,
     );
   }
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'conversationId': conversationId,
         'senderId': senderId,
         'receiverId': receiverId,
         'content': content,
@@ -63,10 +75,12 @@ class MessageModel {
         'moduleContext': moduleContext,
         'priority': priority,
         'status': status,
+        'sent': sent,
       };
 
   MessageModel copyWith({
     String? id,
+    String? conversationId,
     String? senderId,
     String? receiverId,
     String? content,
@@ -74,9 +88,11 @@ class MessageModel {
     String? moduleContext,
     int? priority,
     String? status,
+    bool? sent,
   }) {
     return MessageModel(
       id: id ?? this.id,
+      conversationId: conversationId ?? this.conversationId,
       senderId: senderId ?? this.senderId,
       receiverId: receiverId ?? this.receiverId,
       content: content ?? this.content,
@@ -84,6 +100,7 @@ class MessageModel {
       moduleContext: moduleContext ?? this.moduleContext,
       priority: priority ?? this.priority,
       status: status ?? this.status,
+      sent: sent ?? this.sent,
     );
   }
 }

--- a/lib/modules/messagerie/models/message_model.g.dart
+++ b/lib/modules/messagerie/models/message_model.g.dart
@@ -18,36 +18,42 @@ class MessageModelAdapter extends TypeAdapter<MessageModel> {
     };
     return MessageModel(
       id: fields[0] as String,
-      senderId: fields[1] as String,
-      receiverId: fields[2] as String,
-      content: fields[3] as String,
-      timestamp: fields[4] as DateTime,
-      moduleContext: fields[5] as String,
-      priority: fields[6] as int,
-      status: fields[7] as String,
+      conversationId: fields[1] as String,
+      senderId: fields[2] as String,
+      receiverId: fields[3] as String,
+      content: fields[4] as String,
+      timestamp: fields[5] as DateTime,
+      moduleContext: fields[6] as String,
+      priority: fields[7] as int,
+      status: fields[8] as String,
+      sent: fields[9] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, MessageModel obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(10)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
-      ..write(obj.senderId)
+      ..write(obj.conversationId)
       ..writeByte(2)
-      ..write(obj.receiverId)
+      ..write(obj.senderId)
       ..writeByte(3)
-      ..write(obj.content)
+      ..write(obj.receiverId)
       ..writeByte(4)
-      ..write(obj.timestamp)
+      ..write(obj.content)
       ..writeByte(5)
-      ..write(obj.moduleContext)
+      ..write(obj.timestamp)
       ..writeByte(6)
-      ..write(obj.priority)
+      ..write(obj.moduleContext)
       ..writeByte(7)
-      ..write(obj.status);
+      ..write(obj.priority)
+      ..writeByte(8)
+      ..write(obj.status)
+      ..writeByte(9)
+      ..write(obj.sent);
   }
 
   @override


### PR DESCRIPTION
## Summary
- extend `MessageModel` with `conversationId` and `sent` fields
- regenerate Hive adapter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684952e96cfc8320babf59f5e78af5f4