### PR TITLE
Add id field to ConversationModel

### DIFF
--- a/lib/modules/messagerie/models/conversation_model.dart
+++ b/lib/modules/messagerie/models/conversation_model.dart
@@ -7,18 +7,26 @@ part 'conversation_model.g.dart';
 @HiveType(typeId: 71)
 class ConversationModel {
   @HiveField(0)
-  final List<String> participants;
+  final String id;
 
   @HiveField(1)
-  final String lastMessage;
+  final List<String> participants;
 
   @HiveField(2)
-  final DateTime lastTimestamp;
+  final String lastMessage;
 
   @HiveField(3)
+  final DateTime lastTimestamp;
+
+  @HiveField(4)
   final String module;
 
+  String get moduleName => module;
+
+  List<String> get participantIds => participants;
+
   ConversationModel({
+    required this.id,
     this.participants = const [],
     this.lastMessage = '',
     DateTime? lastTimestamp,
@@ -27,6 +35,7 @@ class ConversationModel {
 
   factory ConversationModel.fromJson(Map<String, dynamic> json) {
     return ConversationModel(
+      id: json['id'] ?? '',
       participants: List<String>.from(json['participants'] ?? []),
       lastMessage: json['lastMessage'] ?? '',
       lastTimestamp:
@@ -36,6 +45,7 @@ class ConversationModel {
   }
 
   Map<String, dynamic> toJson() => {
+        'id': id,
         'participants': participants,
         'lastMessage': lastMessage,
         'lastTimestamp': lastTimestamp.toIso8601String(),
@@ -43,12 +53,14 @@ class ConversationModel {
       };
 
   ConversationModel copyWith({
+    String? id,
     List<String>? participants,
     String? lastMessage,
     DateTime? lastTimestamp,
     String? module,
   }) {
     return ConversationModel(
+      id: id ?? this.id,
       participants: participants ?? this.participants,
       lastMessage: lastMessage ?? this.lastMessage,
       lastTimestamp: lastTimestamp ?? this.lastTimestamp,

--- a/lib/modules/messagerie/models/conversation_model.g.dart
+++ b/lib/modules/messagerie/models/conversation_model.g.dart
@@ -17,24 +17,27 @@ class ConversationModelAdapter extends TypeAdapter<ConversationModel> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return ConversationModel(
-      participants: (fields[0] as List).cast<String>(),
-      lastMessage: fields[1] as String,
-      lastTimestamp: fields[2] as DateTime,
-      module: fields[3] as String,
+      id: fields[0] as String,
+      participants: (fields[1] as List).cast<String>(),
+      lastMessage: fields[2] as String,
+      lastTimestamp: fields[3] as DateTime,
+      module: fields[4] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, ConversationModel obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
-      ..write(obj.participants)
+      ..write(obj.id)
       ..writeByte(1)
-      ..write(obj.lastMessage)
+      ..write(obj.participants)
       ..writeByte(2)
-      ..write(obj.lastTimestamp)
+      ..write(obj.lastMessage)
       ..writeByte(3)
+      ..write(obj.lastTimestamp)
+      ..writeByte(4)
       ..write(obj.module);
   }
 


### PR DESCRIPTION
## Summary
- extend `ConversationModel` with an `id` field
- expose `moduleName` and `participantIds` getters
- update constructor, serialization helpers, and copyWith
- regenerate Hive adapter

## Testing
- `dart format lib/modules/messagerie/models/conversation_model.dart lib/modules/messagerie/models/conversation_model.g.dart`
- `flutter test` *(failed: `/workspace/anisphere/flutter/bin/flutter: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684952e9d9ec832088754cc4e83a1d36