### PR TITLE
Implement queued message class

### DIFF
--- a/lib/modules/messagerie/services/messaging_service.dart
+++ b/lib/modules/messagerie/services/messaging_service.dart
@@ -60,7 +60,8 @@ class MessagingService {
     final pending = await OfflineMessageQueue.getAll();
     if (pending.isEmpty) return;
     final batch = firestore.batch();
-    for (final msg in pending) {
+    for (final queued in pending) {
+      final msg = queued.message;
       final ref = firestore
           .collection('conversations')
           .doc(msg.conversationId)
@@ -70,7 +71,8 @@ class MessagingService {
     }
     try {
       await batch.commit();
-      for (final msg in pending) {
+      for (final queued in pending) {
+        final msg = queued.message;
         await _box?.put(msg.id, msg.copyWith(sent: true));
       }
       await OfflineMessageQueue.clear();

--- a/lib/modules/messagerie/services/offline_message_queue.dart
+++ b/lib/modules/messagerie/services/offline_message_queue.dart
@@ -5,22 +5,36 @@ import 'package:hive/hive.dart';
 
 import '../models/message_model.dart';
 
+part 'offline_message_queue.g.dart';
+
+@HiveType(typeId: 121)
+class QueuedMessage {
+  @HiveField(0)
+  final MessageModel message;
+
+  @HiveField(1)
+  final DateTime timestamp;
+
+  QueuedMessage({required this.message, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+}
+
 class OfflineMessageQueue {
   static const String _boxName = 'offline_messages';
 
-  static Future<void> addMessage(MessageModel message) async {
-    final box = await Hive.openBox<MessageModel>(_boxName);
-    await box.add(message);
+  static Future<void> enqueue(MessageModel message) async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
+    await box.add(QueuedMessage(message: message));
     debugPrint('📥 Message ajouté à la file offline : ${message.id}');
   }
 
-  static Future<List<MessageModel>> getAllMessages() async {
-    final box = await Hive.openBox<MessageModel>(_boxName);
+  static Future<List<QueuedMessage>> getAll() async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
     return box.values.toList();
   }
 
-  static Future<void> clearQueue() async {
-    final box = await Hive.openBox<MessageModel>(_boxName);
+  static Future<void> clear() async {
+    final box = await Hive.openBox<QueuedMessage>(_boxName);
     await box.clear();
     debugPrint('🧹 File de messages offline vidée.');
   }

--- a/lib/modules/messagerie/services/offline_message_queue.g.dart
+++ b/lib/modules/messagerie/services/offline_message_queue.g.dart
@@ -14,15 +14,18 @@ class QueuedMessageAdapter extends TypeAdapter<QueuedMessage> {
     };
     return QueuedMessage(
       message: fields[0] as MessageModel,
+      timestamp: fields[1] as DateTime,
     );
   }
 
   @override
   void write(BinaryWriter writer, QueuedMessage obj) {
     writer
-      ..writeByte(1)
+      ..writeByte(2)
       ..writeByte(0)
-      ..write(obj.message);
+      ..write(obj.message)
+      ..writeByte(1)
+      ..write(obj.timestamp);
   }
 
   @override

--- a/test/messagerie/unit/messaging_service_test.dart
+++ b/test/messagerie/unit/messaging_service_test.dart
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -6,20 +5,15 @@ import 'package:hive/hive.dart';
 import 'package:anisphere/modules/messagerie/models/message_model.dart';
 import 'package:anisphere/modules/messagerie/services/messaging_service.dart';
 import 'package:anisphere/modules/messagerie/services/offline_message_queue.dart';
+
 import '../../test_config.dart';
 import '../../helpers/test_fakes.dart';
-=======
-// Copilot Prompt : Test automatique g\u00e9n\u00e9r\u00e9 pour messaging_service.dart (unit)
-import 'package:flutter_test/flutter_test.dart';
-import '../../test_config.dart';
->>>>>>> codex/ajouter-des-tests-unitaires-et-de-widget
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-<<<<<<< HEAD
   test('sendMessage stores message locally and queues on failure', () async {
     final tempDir = await Directory.systemTemp.createTemp();
     Hive.init(tempDir.path);
@@ -40,12 +34,8 @@ void main() {
     expect(box.get('1')?.content, 'hello');
     final queued = await OfflineMessageQueue.getAll();
     expect(queued.length, 1);
+    expect(queued.first.message.content, 'hello');
 
     await tempDir.delete(recursive: true);
-=======
-  test('messaging_service fonctionne (test auto)', () {
-    // TODO : compl\u00e9ter le test pour messaging_service.dart
-    expect(true, isTrue); // \u00c0 remplacer par un vrai test
->>>>>>> codex/ajouter-des-tests-unitaires-et-de-widget
   });
 }


### PR DESCRIPTION
## Summary
- add `QueuedMessage` model with timestamp
- queue offline messages with `QueuedMessage`
- regenerate Hive adapter and use in messaging service
- update messaging service unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684952eb20808320a286a8c6f114e5ea