### PR TITLE
Implement messaging provider methods

### DIFF
--- a/lib/modules/messagerie/models/conversation_model.dart
+++ b/lib/modules/messagerie/models/conversation_model.dart
@@ -7,52 +7,60 @@ part 'conversation_model.g.dart';
 @HiveType(typeId: 71)
 class ConversationModel {
   @HiveField(0)
-  final List<String> participants;
+  final String id;
 
   @HiveField(1)
-  final String lastMessage;
+  final List<String> participantIds;
 
   @HiveField(2)
-  final DateTime lastTimestamp;
+  final String lastMessage;
 
   @HiveField(3)
-  final String module;
+  final DateTime lastTimestamp;
+
+  @HiveField(4)
+  final String moduleName;
 
   ConversationModel({
-    this.participants = const [],
+    required this.id,
+    this.participantIds = const [],
     this.lastMessage = '',
     DateTime? lastTimestamp,
-    this.module = '',
+    this.moduleName = '',
   }) : lastTimestamp = lastTimestamp ?? DateTime.now();
 
   factory ConversationModel.fromJson(Map<String, dynamic> json) {
     return ConversationModel(
-      participants: List<String>.from(json['participants'] ?? []),
+      id: json['id'] ?? '',
+      participantIds: List<String>.from(json['participantIds'] ?? []),
       lastMessage: json['lastMessage'] ?? '',
       lastTimestamp:
           DateTime.tryParse(json['lastTimestamp'] ?? '') ?? DateTime.now(),
-      module: json['module'] ?? '',
+      moduleName: json['moduleName'] ?? '',
     );
   }
 
   Map<String, dynamic> toJson() => {
-        'participants': participants,
+        'id': id,
+        'participantIds': participantIds,
         'lastMessage': lastMessage,
         'lastTimestamp': lastTimestamp.toIso8601String(),
-        'module': module,
+        'moduleName': moduleName,
       };
 
   ConversationModel copyWith({
-    List<String>? participants,
+    String? id,
+    List<String>? participantIds,
     String? lastMessage,
     DateTime? lastTimestamp,
-    String? module,
+    String? moduleName,
   }) {
     return ConversationModel(
-      participants: participants ?? this.participants,
+      id: id ?? this.id,
+      participantIds: participantIds ?? this.participantIds,
       lastMessage: lastMessage ?? this.lastMessage,
       lastTimestamp: lastTimestamp ?? this.lastTimestamp,
-      module: module ?? this.module,
+      moduleName: moduleName ?? this.moduleName,
     );
   }
 }

--- a/lib/modules/messagerie/models/conversation_model.g.dart
+++ b/lib/modules/messagerie/models/conversation_model.g.dart
@@ -17,25 +17,28 @@ class ConversationModelAdapter extends TypeAdapter<ConversationModel> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return ConversationModel(
-      participants: (fields[0] as List).cast<String>(),
-      lastMessage: fields[1] as String,
-      lastTimestamp: fields[2] as DateTime,
-      module: fields[3] as String,
+      id: fields[0] as String,
+      participantIds: (fields[1] as List).cast<String>(),
+      lastMessage: fields[2] as String,
+      lastTimestamp: fields[3] as DateTime,
+      moduleName: fields[4] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, ConversationModel obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
-      ..write(obj.participants)
+      ..write(obj.id)
       ..writeByte(1)
-      ..write(obj.lastMessage)
+      ..write(obj.participantIds)
       ..writeByte(2)
-      ..write(obj.lastTimestamp)
+      ..write(obj.lastMessage)
       ..writeByte(3)
-      ..write(obj.module);
+      ..write(obj.lastTimestamp)
+      ..writeByte(4)
+      ..write(obj.moduleName);
   }
 
   @override

--- a/lib/modules/messagerie/models/message_model.dart
+++ b/lib/modules/messagerie/models/message_model.dart
@@ -10,32 +10,40 @@ class MessageModel {
   final String id;
 
   @HiveField(1)
-  final String senderId;
+  final String conversationId;
 
   @HiveField(2)
-  final String receiverId;
+  final String senderId;
 
   @HiveField(3)
-  final String content;
+  final String receiverId;
 
   @HiveField(4)
-  final DateTime timestamp;
+  final String content;
 
   @HiveField(5)
-  final String moduleContext;
+  final DateTime timestamp;
 
   @HiveField(6)
-  final int priority;
+  final bool sent;
 
   @HiveField(7)
+  final String moduleContext;
+
+  @HiveField(8)
+  final int priority;
+
+  @HiveField(9)
   final String status;
 
   const MessageModel({
     required this.id,
+    required this.conversationId,
     required this.senderId,
     required this.receiverId,
     required this.content,
     required this.timestamp,
+    this.sent = false,
     this.moduleContext = '',
     this.priority = 0,
     this.status = '',
@@ -44,10 +52,12 @@ class MessageModel {
   factory MessageModel.fromJson(Map<String, dynamic> json) {
     return MessageModel(
       id: json['id'] ?? '',
+      conversationId: json['conversationId'] ?? '',
       senderId: json['senderId'] ?? '',
       receiverId: json['receiverId'] ?? '',
       content: json['content'] ?? '',
       timestamp: DateTime.tryParse(json['timestamp'] ?? '') ?? DateTime.now(),
+      sent: json['sent'] ?? false,
       moduleContext: json['moduleContext'] ?? '',
       priority: json['priority'] ?? 0,
       status: json['status'] ?? '',
@@ -56,31 +66,39 @@ class MessageModel {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'conversationId': conversationId,
         'senderId': senderId,
         'receiverId': receiverId,
         'content': content,
         'timestamp': timestamp.toIso8601String(),
+        'sent': sent,
         'moduleContext': moduleContext,
         'priority': priority,
         'status': status,
       };
 
+  Map<String, dynamic> toMap() => toJson();
+
   MessageModel copyWith({
     String? id,
+    String? conversationId,
     String? senderId,
     String? receiverId,
     String? content,
     DateTime? timestamp,
+    bool? sent,
     String? moduleContext,
     int? priority,
     String? status,
   }) {
     return MessageModel(
       id: id ?? this.id,
+      conversationId: conversationId ?? this.conversationId,
       senderId: senderId ?? this.senderId,
       receiverId: receiverId ?? this.receiverId,
       content: content ?? this.content,
       timestamp: timestamp ?? this.timestamp,
+      sent: sent ?? this.sent,
       moduleContext: moduleContext ?? this.moduleContext,
       priority: priority ?? this.priority,
       status: status ?? this.status,

--- a/lib/modules/messagerie/models/message_model.g.dart
+++ b/lib/modules/messagerie/models/message_model.g.dart
@@ -18,35 +18,41 @@ class MessageModelAdapter extends TypeAdapter<MessageModel> {
     };
     return MessageModel(
       id: fields[0] as String,
-      senderId: fields[1] as String,
-      receiverId: fields[2] as String,
-      content: fields[3] as String,
-      timestamp: fields[4] as DateTime,
-      moduleContext: fields[5] as String,
-      priority: fields[6] as int,
-      status: fields[7] as String,
+      conversationId: fields[1] as String,
+      senderId: fields[2] as String,
+      receiverId: fields[3] as String,
+      content: fields[4] as String,
+      timestamp: fields[5] as DateTime,
+      sent: fields[6] as bool,
+      moduleContext: fields[7] as String,
+      priority: fields[8] as int,
+      status: fields[9] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, MessageModel obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(10)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
-      ..write(obj.senderId)
+      ..write(obj.conversationId)
       ..writeByte(2)
-      ..write(obj.receiverId)
+      ..write(obj.senderId)
       ..writeByte(3)
-      ..write(obj.content)
+      ..write(obj.receiverId)
       ..writeByte(4)
-      ..write(obj.timestamp)
+      ..write(obj.content)
       ..writeByte(5)
-      ..write(obj.moduleContext)
+      ..write(obj.timestamp)
       ..writeByte(6)
-      ..write(obj.priority)
+      ..write(obj.sent)
       ..writeByte(7)
+      ..write(obj.moduleContext)
+      ..writeByte(8)
+      ..write(obj.priority)
+      ..writeByte(9)
       ..write(obj.status);
   }
 

--- a/lib/modules/messagerie/providers/messaging_provider.dart
+++ b/lib/modules/messagerie/providers/messaging_provider.dart
@@ -3,35 +3,61 @@ library;
 import 'package:flutter/material.dart';
 
 import '../models/message_model.dart';
+import '../models/conversation_model.dart';
 import '../services/messaging_service.dart';
 
 /// Provider managing active conversations and new message notifications.
 class MessagingProvider extends ChangeNotifier {
   final MessagingService _service;
-  final Map<String, List<MessageModel>> _conversations = {};
+  final List<ConversationModel> _conversations = [];
+  final Map<String, List<MessageModel>> _messages = {};
 
   MessagingProvider({MessagingService? service})
       : _service = service ?? MessagingService();
 
-  List<MessageModel> getMessages(String conversationId) =>
-      _conversations[conversationId] ?? [];
+  List<ConversationModel> get conversations => List.unmodifiable(_conversations);
 
-  Future<void> loadConversation(String conversationId) async {
+  Future<void> init() async {
+    for (final conv in _conversations) {
+      await loadMessages(conv.id);
+    }
+  }
+
+  List<MessageModel> messagesFor(String id) => _messages[id] ?? [];
+
+  Future<void> loadMessages(String conversationId) async {
     final msgs = await _service.getMessages(conversationId);
-    _conversations[conversationId] = msgs;
+    _messages[conversationId] = msgs;
     notifyListeners();
   }
 
-  Future<void> send(MessageModel message) async {
+  Future<MessageModel> sendMessage(
+      String conversationId, String senderId, String text) async {
+    final message = MessageModel(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      conversationId: conversationId,
+      senderId: senderId,
+      receiverId: '',
+      content: text,
+      timestamp: DateTime.now(),
+    );
     await _service.sendMessage(message);
-    _conversations.putIfAbsent(message.conversationId, () => []);
-    _conversations[message.conversationId]!.add(message);
+    _messages.putIfAbsent(conversationId, () => []).add(message);
+
+    final idx = _conversations.indexWhere((c) => c.id == conversationId);
+    if (idx != -1) {
+      _conversations[idx] = _conversations[idx].copyWith(
+        lastMessage: text,
+        lastTimestamp: DateTime.now(),
+      );
+    }
     notifyListeners();
+    return message;
   }
 
   Future<void> refresh(List<String> conversationIds) async {
     for (final id in conversationIds) {
-      await loadConversation(id);
+      await loadMessages(id);
     }
   }
 

--- a/lib/modules/messagerie/services/messaging_service.dart
+++ b/lib/modules/messagerie/services/messaging_service.dart
@@ -43,7 +43,7 @@ class MessagingService {
       await _box?.put(message.id, message.copyWith(sent: true));
     } catch (e) {
       debugPrint('❌ Envoi Firestore échoué, mise en queue.');
-      await OfflineMessageQueue.enqueue(message);
+      await OfflineMessageQueue.addMessage(message);
     }
   }
 
@@ -57,7 +57,7 @@ class MessagingService {
 
   Future<void> syncOfflineMessages() async {
     await _initHive();
-    final pending = await OfflineMessageQueue.getAll();
+    final pending = await OfflineMessageQueue.getAllMessages();
     if (pending.isEmpty) return;
     final batch = firestore.batch();
     for (final msg in pending) {
@@ -73,7 +73,7 @@ class MessagingService {
       for (final msg in pending) {
         await _box?.put(msg.id, msg.copyWith(sent: true));
       }
-      await OfflineMessageQueue.clear();
+      await OfflineMessageQueue.clearQueue();
     } catch (e) {
       debugPrint('❌ Batch sync failed: $e');
     }

--- a/test/messagerie/unit/messaging_provider_test.dart
+++ b/test/messagerie/unit/messaging_provider_test.dart
@@ -21,15 +21,8 @@ void main() {
   test('send adds message to conversation and delegates to service', () async {
     final service = _FakeService();
     final provider = MessagingProvider(service: service);
-    final msg = MessageModel(
-      id: '1',
-      conversationId: 'c1',
-      senderId: 'u1',
-      content: 'hi',
-    );
-
-    await provider.send(msg);
-    expect(provider.getMessages('c1').length, 1);
+    await provider.sendMessage('c1', 'u1', 'hi');
+    expect(provider.messagesFor('c1').length, 1);
     expect(service.sent.length, 1);
   });
 }

--- a/test/messagerie/unit/messaging_service_test.dart
+++ b/test/messagerie/unit/messaging_service_test.dart
@@ -39,7 +39,9 @@ void main() {
       id: '1',
       conversationId: 'c1',
       senderId: 'u1',
+      receiverId: 'u2',
       content: 'hello',
+      timestamp: DateTime.now(),
     );
 
     await service.sendMessage(message);
@@ -59,7 +61,9 @@ void main() {
       id: '2',
       conversationId: 'c2',
       senderId: 'u2',
+      receiverId: 'u1',
       content: 'offline',
+      timestamp: DateTime.now(),
     );
 
     await service.sendMessage(message);


### PR DESCRIPTION
## Summary
- extend `MessageModel` with conversation info and status tracking
- extend `ConversationModel` with identifiers for screens
- add messaging provider helpers to send/load/init conversations
- fix messaging service to use updated queue helpers
- adjust unit tests for provider and service

## Testing
- `flutter test test/messagerie/unit/messaging_provider_test.dart -r compact` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849560192008320997277baffdcab17