### PR TITLE
Add stockage follow-up doc

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -322,7 +322,7 @@ Suivre la roadmap et proposer les prochaines priorités intelligemment
 📈 Suivi et amélioration continue
 
 Fichier noyau_suivi.md mis à jour automatiquement après chaque push
-
+Consultez [docs/stockage_suivi.md](docs/stockage_suivi.md) pour le suivi du stockage (Hive, Firebase, drives).
 Rapport IA hebdomadaire dans l’interface Super Admin avec :
 
 modules à supprimer, à optimiser ou à promouvoir

--- a/docs/stockage_suivi.md
+++ b/docs/stockage_suivi.md
@@ -1,0 +1,9 @@
+# 📦 stockage_suivi.md — Suivi du stockage et de la synchronisation
+
+Ce fichier suit l'avancement du stockage local via Hive ainsi que des solutions cloud et externes.
+
+| Principe | Implémentation actuelle | Statut |
+|----------|------------------------|-------|
+| Stockage local (Hive) | Base fonctionnelle prête (modèles principaux) | ✅ Fait |
+| Stockage cloud (Firebase) | Structure Firestore/Storage à finaliser | 🔄 À démarrer |
+| Sauvegarde sur drives externes | Spécifications en cours (Google Drive, iCloud…) | 🔄 À démarrer |


### PR DESCRIPTION
## Summary
- document storage implementation status in `docs/stockage_suivi.md`
- reference the new file from `README_DEV.md`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a745a65bc8320a70e5df7d558f302