### PR TITLE
Add cloud drive service

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -38,6 +38,7 @@
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | À faire |
 | test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | À faire |
+| test/noyau/unit/cloud_drive_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_drive_service.dart | ✅ |
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
 | test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |
 | test/noyau/unit/ia_config_test.dart | unit | package:anisphere/modules/noyau/logic/ia_config.dart | À faire |

--- a/lib/modules/noyau/services/cloud_drive_service.dart
+++ b/lib/modules/noyau/services/cloud_drive_service.dart
@@ -1,0 +1,173 @@
+// Copilot Prompt : Service permettant de stocker des fichiers dans Google Drive, OneDrive ou Dropbox.
+// Gère l'authentification simple via token OAuth et l'upload de fichiers.
+// Fournit aussi des helpers pour vérifier l'espace disponible et connaître le service actif.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+enum DriveProvider { google, onedrive, dropbox }
+
+class CloudDriveService {
+  final http.Client httpClient;
+  String? _googleToken;
+  String? _oneDriveToken;
+  String? _dropboxToken;
+
+  CloudDriveService({http.Client? client}) : httpClient = client ?? http.Client();
+
+  /// 🔑 Enregistre le token OAuth pour Google Drive
+  void authenticateGoogle(String token) {
+    _googleToken = token;
+    _log('Google Drive authenticated');
+  }
+
+  /// 🔑 Enregistre le token OAuth pour OneDrive
+  void authenticateOneDrive(String token) {
+    _oneDriveToken = token;
+    _log('OneDrive authenticated');
+  }
+
+  /// 🔑 Enregistre le token OAuth pour Dropbox
+  void authenticateDropbox(String token) {
+    _dropboxToken = token;
+    _log('Dropbox authenticated');
+  }
+
+  /// 📦 Upload un fichier vers le premier service disponible
+  Future<bool> uploadFile(File file) async {
+    final service = getAvailableService();
+    if (service == null) return false;
+    switch (service) {
+      case DriveProvider.google:
+        return _uploadToGoogle(file);
+      case DriveProvider.onedrive:
+        return _uploadToOneDrive(file);
+      case DriveProvider.dropbox:
+        return _uploadToDropbox(file);
+    }
+  }
+
+  /// 🔍 Vérifie l'espace disponible (en octets) sur le service actif
+  Future<int?> checkQuota() async {
+    final service = getAvailableService();
+    if (service == null) return null;
+    switch (service) {
+      case DriveProvider.google:
+        return _quotaGoogle();
+      case DriveProvider.onedrive:
+        return _quotaOneDrive();
+      case DriveProvider.dropbox:
+        return _quotaDropbox();
+    }
+  }
+
+  /// 🔁 Renvoie le service disponible en priorité : Google > OneDrive > Dropbox
+  DriveProvider? getAvailableService() {
+    if (_googleToken != null) return DriveProvider.google;
+    if (_oneDriveToken != null) return DriveProvider.onedrive;
+    if (_dropboxToken != null) return DriveProvider.dropbox;
+    return null;
+  }
+
+  Future<bool> _uploadToGoogle(File file) async {
+    final uri = Uri.parse('https://www.googleapis.com/upload/drive/v3/files?uploadType=media');
+    final response = await httpClient.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $_googleToken',
+        'Content-Type': 'application/octet-stream',
+      },
+      body: await file.readAsBytes(),
+    );
+    _log('Google upload status ${response.statusCode}');
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
+  Future<bool> _uploadToOneDrive(File file) async {
+    final filename = file.uri.pathSegments.last;
+    final uri = Uri.parse('https://graph.microsoft.com/v1.0/me/drive/root:/$filename:/content');
+    final response = await httpClient.put(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $_oneDriveToken',
+        'Content-Type': 'application/octet-stream',
+      },
+      body: await file.readAsBytes(),
+    );
+    _log('OneDrive upload status ${response.statusCode}');
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
+  Future<bool> _uploadToDropbox(File file) async {
+    final filename = file.uri.pathSegments.last;
+    final uri = Uri.parse('https://content.dropboxapi.com/2/files/upload');
+    final response = await httpClient.post(
+      uri,
+      headers: {
+        'Authorization': 'Bearer $_dropboxToken',
+        'Content-Type': 'application/octet-stream',
+        'Dropbox-API-Arg': jsonEncode({'path': '/$filename', 'mode': 'add', 'autorename': true}),
+      },
+      body: await file.readAsBytes(),
+    );
+    _log('Dropbox upload status ${response.statusCode}');
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
+  Future<int?> _quotaGoogle() async {
+    final uri = Uri.parse('https://www.googleapis.com/drive/v3/about?fields=storageQuota');
+    final res = await httpClient.get(uri, headers: {'Authorization': 'Bearer $_googleToken'});
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final quota = data['storageQuota'] as Map<String, dynamic>?;
+      if (quota != null) {
+        final limit = int.tryParse(quota['limit']?.toString() ?? '0') ?? 0;
+        final usage = int.tryParse(quota['usage']?.toString() ?? '0') ?? 0;
+        return limit - usage;
+      }
+    }
+    return null;
+  }
+
+  Future<int?> _quotaOneDrive() async {
+    final uri = Uri.parse('https://graph.microsoft.com/v1.0/me/drive');
+    final res = await httpClient.get(uri, headers: {'Authorization': 'Bearer $_oneDriveToken'});
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final quota = data['quota'] as Map<String, dynamic>?;
+      if (quota != null) {
+        final remaining = int.tryParse(quota['remaining']?.toString() ?? '0');
+        return remaining;
+      }
+    }
+    return null;
+  }
+
+  Future<int?> _quotaDropbox() async {
+    final uri = Uri.parse('https://api.dropboxapi.com/2/users/get_space_usage');
+    final res = await httpClient.post(uri, headers: {
+      'Authorization': 'Bearer $_dropboxToken',
+      'Content-Type': 'application/json',
+    });
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final allocation = data['allocation'] as Map<String, dynamic>?;
+      final allocated = int.tryParse(allocation?['allocated']?.toString() ?? '0') ?? 0;
+      final used = int.tryParse(data['used']?.toString() ?? '0') ?? 0;
+      return allocated - used;
+    }
+    return null;
+  }
+
+  /// Log typé pour debug uniquement
+  void _log(String message) {
+    assert(() {
+      debugPrint('[CloudDrive] $message');
+      return true;
+    }());
+  }
+}

--- a/test/noyau/unit/cloud_drive_service_test.dart
+++ b/test/noyau/unit/cloud_drive_service_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+import 'package:anisphere/modules/noyau/services/cloud_drive_service.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('uploadFile uses Google Drive API when authenticated', () async {
+    late http.Request captured;
+    final client = MockClient((request) async {
+      captured = request;
+      return http.Response('{}', 200);
+    });
+
+    final service = CloudDriveService(client: client);
+    service.authenticateGoogle('token123');
+
+    final file = File('${Directory.systemTemp.path}/g.txt');
+    await file.writeAsString('hello');
+
+    final result = await service.uploadFile(file);
+
+    expect(result, isTrue);
+    expect(captured.url.toString(), contains('googleapis.com'));
+    expect(captured.headers['Authorization'], 'Bearer token123');
+  });
+
+  test('uploadFile uses OneDrive when Google unavailable', () async {
+    late http.Request captured;
+    final client = MockClient((request) async {
+      captured = request;
+      return http.Response('{}', 201);
+    });
+
+    final service = CloudDriveService(client: client);
+    service.authenticateOneDrive('one');
+
+    final file = File('${Directory.systemTemp.path}/o.txt');
+    await file.writeAsString('hi');
+
+    final result = await service.uploadFile(file);
+
+    expect(result, isTrue);
+    expect(captured.url.toString(), contains('graph.microsoft.com'));
+    expect(captured.method, 'PUT');
+  });
+
+  test('checkQuota calls Dropbox API', () async {
+    final client = MockClient((request) async {
+      expect(request.url.toString(), contains('dropboxapi.com'));
+      return http.Response('{"used":100,"allocation":{"allocated":1000}}', 200);
+    });
+
+    final service = CloudDriveService(client: client);
+    service.authenticateDropbox('d');
+
+    final remaining = await service.checkQuota();
+
+    expect(remaining, 900);
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -38,6 +38,7 @@
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | À faire |
 | test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | À faire |
+| test/noyau/unit/cloud_drive_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_drive_service.dart | ✅ |
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
 | test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |
 | test/noyau/unit/ia_config_test.dart | unit | package:anisphere/modules/noyau/logic/ia_config.dart | À faire |


### PR DESCRIPTION
## Summary
- add `CloudDriveService` supporting Google Drive, OneDrive and Dropbox
- expose `uploadFile`, `checkQuota` and `getAvailableService`
- test cloud drive logic with mocked HTTP clients
- track the new tests in `test_tracker.md`

## Testing
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*
- `flutter test test/noyau/unit/cloud_drive_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a745dca08832083981bb3dcab80f3