### PR TITLE
Add smartphone sensor and IA services

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -160,6 +160,17 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - Rafraîchir le suivi Markdown et la documentation à chaque étape (script `update_noyau_suivi.dart`)
 - Créer le module indépendant `superadmin` (lib/modules/superadmin/), suivi dédié
 
+### Nouveaux services IA & capteurs
+| Élément | Description | Statut |
+|---------|-------------|--------|
+| device_sensors_service.dart | Accès centralisé à tous les capteurs | ⬜ à faire |
+| ia_context_enricher.dart | Contexte IA enrichi temps réel | ⬜ à faire |
+| behavior_analysis_service.dart | Analyse comportementale IA (TFLite/capteurs) | ⬜ à faire |
+| image_analysis_service.dart | IA analyse images/photo (TFLite) | ⬜ à faire |
+| engagement_score_model.dart | Modèle scoring engagement IA | ⬜ à faire |
+| ia_adaptation_service.dart | Priorisation/ajustement IA selon contexte | ⬜ à faire |
+| behavior_dashboard_screen.dart | UI historique et recommandations | ⬜ à faire |
+
 ---
 
 ## 🗂️ Annexes & liens

--- a/lib/modules/noyau/models/engagement_score_model.dart
+++ b/lib/modules/noyau/models/engagement_score_model.dart
@@ -1,0 +1,13 @@
+// Copilot Prompt : Modèle IA calculant score engagement/progression à partir des données capteurs + historique utilisateur/animal
+// Intègre les critères IA, pondère selon contexte, module, performance attendue
+library;
+
+/// Représente un score d’engagement calculé pour un utilisateur ou un animal.
+class EngagementScore {
+  final String id;
+  final double score;
+  final DateTime date;
+
+  const EngagementScore({required this.id, required this.score, required this.date});
+}
+

--- a/lib/modules/noyau/screens/behavior_dashboard_screen.dart
+++ b/lib/modules/noyau/screens/behavior_dashboard_screen.dart
@@ -1,0 +1,19 @@
+// Copilot Prompt : Écran de visualisation temps réel ou historique des scores IA, contextes, alertes comportementales ou recommandations
+library;
+
+import 'package:flutter/material.dart';
+
+class BehaviorDashboardScreen extends StatelessWidget {
+  const BehaviorDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tableau de comportement')),
+      body: const Center(
+        child: Text('Dashboard comportemental à venir'),
+      ),
+    );
+  }
+}
+

--- a/lib/modules/noyau/services/behavior_analysis_service.dart
+++ b/lib/modules/noyau/services/behavior_analysis_service.dart
@@ -1,0 +1,41 @@
+// Copilot Prompt : Service IA local basé sur TFLite, analyse les données capteurs et images pour mesurer comportement animal/utilisateur (distance, répétition, posture, etc.)
+// Intègre les modèles TFLite pour détection posture, pathologie visible, type activité, etc.
+// Agrège distance parcourue, temps, fréquence, localisation pour chaque session
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:tflite_flutter/tflite_flutter.dart';
+
+import 'device_sensors_service.dart';
+
+/// Analyse comportementale IA locale.
+class BehaviorAnalysisService {
+  final DeviceSensorsService sensors;
+  Interpreter? _interpreter;
+
+  BehaviorAnalysisService({DeviceSensorsService? sensors})
+      : sensors = sensors ?? DeviceSensorsService();
+
+  /// Initialise les modèles TFLite.
+  Future<void> init() async {
+    try {
+      _interpreter ??= await Interpreter.fromAsset('models/behavior.tflite');
+    } catch (e) {
+      _log('Erreur init TFLite : \\$e');
+    }
+  }
+
+  /// Exemple d’analyse basique.
+  Future<double> analyzeSteps() async {
+    await init();
+    // TODO: utiliser les capteurs et le modèle TFLite
+    return 0.0;
+  }
+
+  void _log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    }
+  }
+}
+

--- a/lib/modules/noyau/services/device_sensors_service.dart
+++ b/lib/modules/noyau/services/device_sensors_service.dart
@@ -1,0 +1,55 @@
+// Copilot Prompt : Service Flutter pour accès et gestion des capteurs smartphone (GPS, mouvement, podomètre, batterie, réseau, orientation…)
+// Expose des streams pour chaque type de donnée (distance, temps activité, changement position…)
+// Récupère l’état batterie, la puissance réseau, l’heure système
+library;
+
+import 'package:battery_plus/battery_plus.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pedometer/pedometer.dart';
+import 'package:sensors_plus/sensors_plus.dart';
+
+/// Service Flutter pour l’accès aux capteurs du smartphone.
+class DeviceSensorsService {
+  final Battery _battery = Battery();
+  final Connectivity _connectivity = Connectivity();
+
+  /// Flux d’accéléromètre brut.
+  Stream<AccelerometerEvent> get accelerometerStream => accelerometerEvents;
+
+  /// Flux de gyroscope brut.
+  Stream<GyroscopeEvent> get gyroscopeStream => gyroscopeEvents;
+
+  /// Flux du podomètre.
+  Stream<StepCount> get pedometerStream => Pedometer.stepCountStream;
+
+  /// Renvoie le niveau actuel de batterie en pourcentage.
+  Future<int> getBatteryLevel() async {
+    try {
+      return await _battery.batteryLevel;
+    } catch (e) {
+      _log('Erreur récupération batterie : \\$e');
+      return -1;
+    }
+  }
+
+  /// Renvoie le type de connexion réseau (wifi/4g/offline).
+  Future<ConnectivityResult> getConnectivity() async {
+    try {
+      return await _connectivity.checkConnectivity();
+    } catch (e) {
+      _log('Erreur récupération connectivité : \\$e');
+      return ConnectivityResult.none;
+    }
+  }
+
+  /// Heure système actuelle.
+  DateTime get currentTime => DateTime.now();
+
+  void _log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    }
+  }
+}
+  

--- a/lib/modules/noyau/services/ia_adaptation_service.dart
+++ b/lib/modules/noyau/services/ia_adaptation_service.dart
@@ -1,0 +1,33 @@
+// Copilot Prompt : Service qui ajuste les priorités IA (analyses, notifications, sync) selon l’état réseau/batterie, l’heure et les habitudes
+// Peut désactiver ou retarder analyses si batterie faible/réseau mauvais
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'device_sensors_service.dart';
+
+/// Service d’adaptation IA selon le contexte réel.
+class IAAdaptationService {
+  final DeviceSensorsService sensors;
+
+  IAAdaptationService({DeviceSensorsService? sensors})
+      : sensors = sensors ?? DeviceSensorsService();
+
+  /// Exemple de décision simplifiée.
+  Future<bool> shouldRunHeavyAnalysis() async {
+    final battery = await sensors.getBatteryLevel();
+    final connectivity = await sensors.getConnectivity();
+    final isLowBattery = battery >= 0 && battery < 20;
+    final isOffline = connectivity == ConnectivityResult.none;
+
+    return !isLowBattery && !isOffline;
+  }
+
+  void log(String msg) {
+    if (kDebugMode) {
+      debugPrint(msg);
+    }
+  }
+}
+

--- a/lib/modules/noyau/services/ia_context_enricher.dart
+++ b/lib/modules/noyau/services/ia_context_enricher.dart
@@ -1,0 +1,43 @@
+// Copilot Prompt : Service qui enrichit en temps réel le contexte IA avec les données des capteurs (heure, batterie, réseau, habitudes…)
+// Fournit un objet contextuel complet pour chaque décision IA
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import '../logic/ia_context.dart';
+import 'device_sensors_service.dart';
+
+/// Enrichit l'IAContext avec les informations issues des capteurs.
+class IAContextEnricher {
+  final DeviceSensorsService sensors;
+
+  IAContextEnricher({DeviceSensorsService? sensors})
+      : sensors = sensors ?? DeviceSensorsService();
+
+  /// Construit un IAContext enrichi à partir de la base existante.
+  Future<IAContext> enrich(IAContext base) async {
+    try {
+      final connectivity = await sensors.getConnectivity();
+      await sensors.getBatteryLevel(); // charge la valeur en cache si besoin
+
+      return IAContext(
+        isOffline: connectivity == ConnectivityResult.none,
+        isFirstLaunch: base.isFirstLaunch,
+        hasAnimals: base.hasAnimals,
+        animalCount: base.animalCount,
+        lastSyncDate: base.lastSyncDate,
+      );
+    } catch (e) {
+      _log('Erreur enrichissement IAContext : \\$e');
+      return base;
+    }
+  }
+
+  void _log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    }
+  }
+}
+

--- a/lib/modules/noyau/services/image_analysis_service.dart
+++ b/lib/modules/noyau/services/image_analysis_service.dart
@@ -1,0 +1,33 @@
+// Copilot Prompt : Service IA local TFLite dédié à l’analyse d’image/photo prise par l’utilisateur : posture, anomalie, maladie visible, type d’activité
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:tflite_flutter/tflite_flutter.dart';
+
+/// Analyse d’image locale via TFLite.
+class ImageAnalysisService {
+  Interpreter? _interpreter;
+
+  /// Initialise le modèle.
+  Future<void> init() async {
+    try {
+      _interpreter ??= await Interpreter.fromAsset('models/image.tflite');
+    } catch (e) {
+      _log('Erreur init modèle image : \\$e');
+    }
+  }
+
+  /// Analyse une image et renvoie un label.
+  Future<String> analyze(List<double> input) async {
+    await init();
+    // TODO: appel réel au modèle
+    return 'unknown';
+  }
+
+  void _log(String msg) {
+    if (kDebugMode) {
+      debugPrint(msg);
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,12 @@ dependencies:
   image_picker: ^1.0.7
   mobile_scanner: ^7.0.0
 
+  # 📱 Capteurs smartphone & IA locale
+  sensors_plus: ^6.1.1
+  battery_plus: ^6.2.1
+  pedometer: ^4.1.1
+  tflite_flutter: ^0.11.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- create device sensors service to gather battery, connectivity and motion data
- add IA context enricher, behavior analysis, image analysis and adaptation services
- add engagement score model
- add simple dashboard screen placeholder
- document new IA sensor tasks in `noyau_suivi.md`
- update dependencies for sensors and TFLite

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b0c0523f483208b33d3ea8044d877