### PR TITLE
Add offline photo sync

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -38,7 +38,7 @@
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/noyau/unit/storage_sync_queue_test.dart | unit | package:anisphere/modules/noyau/storage/storage_sync_queue.dart | ✅ |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | À faire |
-| test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | À faire |
+| test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | ✅ |
 | test/noyau/unit/cloud_drive_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_drive_service.dart | ✅ |
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
 | test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |

--- a/lib/modules/noyau/models/photo_model.dart
+++ b/lib/modules/noyau/models/photo_model.dart
@@ -1,0 +1,65 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'photo_model.g.dart';
+
+@HiveType(typeId: 50)
+class PhotoModel {
+  @HiveField(0)
+  final String id;
+
+  @HiveField(1)
+  final String userId;
+
+  @HiveField(2)
+  final String animalId;
+
+  @HiveField(3)
+  final String localPath;
+
+  @HiveField(4)
+  final DateTime createdAt;
+
+  const PhotoModel({
+    required this.id,
+    required this.userId,
+    required this.animalId,
+    required this.localPath,
+    required this.createdAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'userId': userId,
+        'animalId': animalId,
+        'localPath': localPath,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  factory PhotoModel.fromJson(Map<String, dynamic> json) {
+    return PhotoModel(
+      id: json['id'] ?? '',
+      userId: json['userId'] ?? '',
+      animalId: json['animalId'] ?? '',
+      localPath: json['localPath'] ?? '',
+      createdAt: DateTime.tryParse(json['createdAt'] ?? '') ?? DateTime.now(),
+    );
+  }
+
+  PhotoModel copyWith({
+    String? id,
+    String? userId,
+    String? animalId,
+    String? localPath,
+    DateTime? createdAt,
+  }) {
+    return PhotoModel(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      animalId: animalId ?? this.animalId,
+      localPath: localPath ?? this.localPath,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/modules/noyau/models/photo_model.g.dart
+++ b/lib/modules/noyau/models/photo_model.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'photo_model.dart';
+
+class PhotoModelAdapter extends TypeAdapter<PhotoModel> {
+  @override
+  final int typeId = 50;
+
+  @override
+  PhotoModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PhotoModel(
+      id: fields[0] as String,
+      userId: fields[1] as String,
+      animalId: fields[2] as String,
+      localPath: fields[3] as String,
+      createdAt: fields[4] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, PhotoModel obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.userId)
+      ..writeByte(2)
+      ..write(obj.animalId)
+      ..writeByte(3)
+      ..write(obj.localPath)
+      ..writeByte(4)
+      ..write(obj.createdAt);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PhotoModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/modules/noyau/services/cloud_sync_service.dart
+++ b/lib/modules/noyau/services/cloud_sync_service.dart
@@ -8,8 +8,10 @@ import '../models/animal_model.dart';
 import '../models/user_model.dart';
 import '../models/support_ticket_model.dart';
 import '../models/notification_feedback_model.dart';
+import '../models/photo_model.dart';
 import 'firebase_service.dart';
 import '../services/offline_sync_queue.dart';
+import '../services/offline_photo_queue.dart';
 import '../services/storage_optimizer.dart';
 
 class CloudSyncService {
@@ -106,6 +108,17 @@ class CloudSyncService {
     }
   }
 
+  /// 🖼️ Envoie les métadonnées d'une photo
+  Future<void> pushPhotoData(PhotoModel photo) async {
+    try {
+      await _firebaseService.savePhoto(photo);
+      debugPrint('☁️ Photo envoyée au cloud : ${photo.id}');
+    } catch (e) {
+      debugPrint('❌ [CloudSync] Erreur pushPhotoData : $e');
+      await OfflinePhotoQueue.addPhoto(photo);
+    }
+  }
+
   /// 📊 Envoie d’un retour IA local (métriques, logs, feedbacks)
   Future<void> pushIAFeedback(Map<String, dynamic> metrics) async {
     try {
@@ -158,9 +171,20 @@ class CloudSyncService {
             await _firebaseService.sendModuleData(moduleName, task.data);
           } else if (task.type.startsWith("message:")) {
             final convoId = task.type.split(":").last;
-            await _firebaseService.sendModuleData('messaging/$convoId', task.data);
+            await _firebaseService.sendModuleData('messaging/\$convoId', task.data);
           }
       }
     });
+
+    final photos = await OfflinePhotoQueue.getAllPhotos();
+    for (final queued in photos) {
+      try {
+        await _firebaseService.savePhoto(queued.photo);
+      } catch (e) {
+        debugPrint('❌ [CloudSync] Erreur envoi photo offline : \$e');
+        await OfflinePhotoQueue.addPhoto(queued.photo);
+      }
+    }
+    await OfflinePhotoQueue.clearQueue();
   }
 }

--- a/lib/modules/noyau/services/firebase_service.dart
+++ b/lib/modules/noyau/services/firebase_service.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:anisphere/modules/noyau/models/user_model.dart';
 import 'package:anisphere/modules/noyau/models/animal_model.dart';
+import 'package:anisphere/modules/noyau/models/photo_model.dart';
 
 class FirebaseService {
   final FirebaseFirestore db;
@@ -88,6 +89,22 @@ class FirebaseService {
       return true;
     } catch (e) {
       _logError("saveAnimal", e);
+      return false;
+    }
+  }
+
+  /// 🖼️ Sauvegarder ou mettre à jour une photo
+  Future<bool> savePhoto(PhotoModel photo) async {
+    if (photo.id.isEmpty) return false;
+    try {
+      await db.collection('photos').doc(photo.id).set(
+            photo.toJson(),
+            SetOptions(merge: true),
+          );
+      debugPrint('✅ Photo sauvegardée : ${photo.id}');
+      return true;
+    } catch (e) {
+      _logError('savePhoto', e);
       return false;
     }
   }

--- a/lib/modules/noyau/services/offline_photo_queue.dart
+++ b/lib/modules/noyau/services/offline_photo_queue.dart
@@ -1,0 +1,41 @@
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../models/photo_model.dart';
+
+part 'offline_photo_queue.g.dart';
+
+@HiveType(typeId: 131)
+class QueuedPhoto {
+  @HiveField(0)
+  final PhotoModel photo;
+
+  @HiveField(1)
+  final DateTime timestamp;
+
+  QueuedPhoto({required this.photo, DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+}
+
+class OfflinePhotoQueue {
+  static const String _boxName = 'offline_photos';
+
+  static Future<void> addPhoto(PhotoModel photo) async {
+    final box = await Hive.openBox<QueuedPhoto>(_boxName);
+    await box.add(QueuedPhoto(photo: photo));
+    debugPrint('📥 Photo ajoutée à la file offline : ${photo.id}');
+  }
+
+  static Future<List<QueuedPhoto>> getAllPhotos() async {
+    final box = await Hive.openBox<QueuedPhoto>(_boxName);
+    return box.values.toList();
+  }
+
+  static Future<void> clearQueue() async {
+    final box = await Hive.openBox<QueuedPhoto>(_boxName);
+    await box.clear();
+    debugPrint('🧹 File de photos offline vidée.');
+  }
+}

--- a/lib/modules/noyau/services/offline_photo_queue.g.dart
+++ b/lib/modules/noyau/services/offline_photo_queue.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'offline_photo_queue.dart';
+
+class QueuedPhotoAdapter extends TypeAdapter<QueuedPhoto> {
+  @override
+  final int typeId = 131;
+
+  @override
+  QueuedPhoto read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return QueuedPhoto(
+      photo: fields[0] as PhotoModel,
+      timestamp: fields[1] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, QueuedPhoto obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.photo)
+      ..writeByte(1)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is QueuedPhotoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -1,13 +1,70 @@
-// Copilot Prompt : Test automatique généré pour cloud_sync_service.dart (unit)
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/cloud_sync_service.dart';
+import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart';
+import 'package:anisphere/modules/noyau/models/photo_model.dart';
+import 'package:anisphere/modules/noyau/services/firebase_service.dart';
 import '../../test_config.dart';
+import '../../helpers/test_fakes.dart';
+
+class FailingFirebaseService extends FirebaseService {
+  FailingFirebaseService() : super(firestore: FakeFirestore(), firebaseAuth: FakeFirebaseAuth());
+
+  @override
+  Future<bool> savePhoto(PhotoModel photo) async {
+    throw Exception('fail');
+  }
+}
 
 void main() {
-  setUpAll(() async {
+  late Directory tempDir;
+
+  setUp(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(PhotoModelAdapter());
+    Hive.registerAdapter(QueuedPhotoAdapter());
+    await Hive.openBox<QueuedPhoto>('offline_photos');
   });
-  test('cloud_sync_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour cloud_sync_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('offline_photos');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('pushPhotoData uploads photo via FirebaseService', () async {
+    final firestore = FakeFirestore();
+    final service = CloudSyncService(firebaseService: FakeFirebaseService(firestore));
+    final photo = PhotoModel(
+      id: 'p1',
+      userId: 'u1',
+      animalId: 'a1',
+      localPath: 'path.jpg',
+      createdAt: DateTime.now(),
+    );
+
+    await service.pushPhotoData(photo);
+
+    final doc = await firestore.collection('photos').doc('p1').get();
+    expect(doc.data()?['id'], 'p1');
+  });
+
+  test('pushPhotoData queues photo on failure', () async {
+    final service = CloudSyncService(firebaseService: FailingFirebaseService());
+    final photo = PhotoModel(
+      id: 'p2',
+      userId: 'u1',
+      animalId: 'a1',
+      localPath: 'path.jpg',
+      createdAt: DateTime.now(),
+    );
+
+    await service.pushPhotoData(photo);
+
+    final queued = await OfflinePhotoQueue.getAllPhotos();
+    expect(queued.length, 1);
+    expect(queued.first.photo.id, 'p2');
   });
 }


### PR DESCRIPTION
## Summary
- implement `pushPhotoData` in `CloudSyncService`
- queue photo uploads with new `OfflinePhotoQueue`
- save photos with `FirebaseService`
- process photo queue when replaying offline tasks
- add `PhotoModel`
- test photo sync logic
- mark cloud_sync_service_test in tracker

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2852a3448320a3510f58bcd632ea