### PR TITLE
Add basic unit tests

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -14,7 +14,7 @@
 | test/identite/unit/photo_verification_service_test.dart | unit | package:anisphere/modules/identite/services/photo_verification_service.dart | À faire |
 | test/identite/widget/identity_screen_test.dart | widget | package:anisphere/modules/identite/screens/identity_screen.dart | À faire |
 | test/identite/integration/identity_flow_test.dart | integration | package:anisphere/modules/identite/screens/identity_screen.dart | À faire |
-| test/noyau/unit/animal_model_test.dart | unit | package:anisphere/modules/noyau/models/animal_model.dart | À faire |
+| test/noyau/unit/animal_model_test.dart | unit | package:anisphere/modules/noyau/models/animal_model.dart | ✅ |
 | test/noyau/unit/support_model_test.dart | unit | package:anisphere/modules/noyau/models/support_model.dart | À faire |
 | test/noyau/unit/user_model_test.dart | unit | package:anisphere/modules/noyau/models/user_model.dart | À faire |
 | test/noyau/unit/animal_model.g_test.dart | unit | package:anisphere/modules/noyau/models/animal_model.g.dart | À faire |
@@ -23,7 +23,7 @@
 | test/noyau/unit/auth_service_test.dart | unit | package:anisphere/modules/noyau/services/auth_service.dart | À faire |
 | test/noyau/unit/offline_sync_queue.g_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.g.dart | À faire |
 | test/noyau/unit/maintenance_service_test.dart | unit | package:anisphere/modules/noyau/services/maintenance_service.dart | À faire |
-| test/noyau/unit/qr_service_test.dart | unit | package:anisphere/modules/noyau/services/qr_service.dart | À faire |
+| test/noyau/unit/qr_service_test.dart | unit | package:anisphere/modules/noyau/services/qr_service.dart | ✅ |
 | test/noyau/unit/user_service_test.dart | unit | package:anisphere/modules/noyau/services/user_service.dart | À faire |
 | test/noyau/unit/app_initializer_test.dart | unit | package:anisphere/modules/noyau/services/app_initializer.dart | À faire |
 | test/noyau/unit/support_service_test.dart | unit | package:anisphere/modules/noyau/services/support_service.dart | À faire |
@@ -43,7 +43,7 @@
 | test/noyau/unit/ia_executor_test.dart | unit | package:anisphere/modules/noyau/logic/ia_executor.dart | À faire |
 | test/noyau/unit/ia_metrics_collector_test.dart | unit | package:anisphere/modules/noyau/logic/ia_metrics_collector.dart | ✅ |
 | test/noyau/unit/ia_config_test.dart | unit | package:anisphere/modules/noyau/logic/ia_config.dart | À faire |
-| test/noyau/unit/ia_flag_test.dart | unit | package:anisphere/modules/noyau/logic/ia_flag.dart | À faire |
+| test/noyau/unit/ia_flag_test.dart | unit | package:anisphere/modules/noyau/logic/ia_flag.dart | ✅ |
 | test/noyau/unit/ia_context_test.dart | unit | package:anisphere/modules/noyau/logic/ia_context.dart | À faire |
 | test/noyau/unit/ia_scheduler_test.dart | unit | package:anisphere/modules/noyau/logic/ia_scheduler.dart | À faire |
 | test/noyau/unit/ia_rules_test.dart | unit | package:anisphere/modules/noyau/logic/ia_rules.dart | À faire |

--- a/test/noyau/unit/animal_model_test.dart
+++ b/test/noyau/unit/animal_model_test.dart
@@ -6,8 +6,23 @@ void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('animal_model fonctionne (test auto)', () {
-    // TODO : compléter le test pour animal_model.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('toJson and fromJson preserve fields', () {
+    final now = DateTime.now();
+    final animal = AnimalModel(
+      id: 'a1',
+      name: 'Rex',
+      species: 'dog',
+      breed: 'Labrador',
+      imageUrl: 'url',
+      ownerId: 'u1',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final json = animal.toJson();
+    final copy = AnimalModel.fromJson(json);
+
+    expect(copy.id, animal.id);
+    expect(copy.name, animal.name);
   });
 }

--- a/test/noyau/unit/ia_flag_test.dart
+++ b/test/noyau/unit/ia_flag_test.dart
@@ -1,13 +1,19 @@
 // Copilot Prompt : Test automatique généré pour ia_flag.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/noyau/logic/ia_flag.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_flag fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_flag.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('reset restores default values', () {
+    IAFlag.enableSync = false;
+    IAFlag.offlineOnly = true;
+
+    IAFlag.reset();
+
+    expect(IAFlag.enableSync, isTrue);
+    expect(IAFlag.offlineOnly, isFalse);
   });
 }

--- a/test/noyau/unit/qr_service_test.dart
+++ b/test/noyau/unit/qr_service_test.dart
@@ -1,13 +1,19 @@
 // Copilot Prompt : Test automatique généré pour qr_service.dart (unit)
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:anisphere/modules/noyau/services/qr_service.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('qr_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour qr_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  testWidgets('generateQRCode returns a widget', (tester) async {
+    final widget = QRService.generateQRCode('data');
+
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+
+    expect(find.byType(QrImageView), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add minimal tests for AnimalModel, IAFlag and QRService
- update test tracker for these tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2856912c8320b8d59647f48ec66a