### PR TITLE
Add PhotoTask Hive queue

### DIFF
--- a/lib/modules/noyau/services/offline_photo_queue.g.dart
+++ b/lib/modules/noyau/services/offline_photo_queue.g.dart
@@ -38,3 +38,40 @@ class QueuedPhotoAdapter extends TypeAdapter<QueuedPhoto> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+class PhotoTaskAdapter extends TypeAdapter<PhotoTask> {
+  @override
+  final int typeId = 132;
+
+  @override
+  PhotoTask read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PhotoTask(
+      photo: fields[0] as PhotoModel,
+      timestamp: fields[1] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, PhotoTask obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.photo)
+      ..writeByte(1)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PhotoTaskAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}


### PR DESCRIPTION
## Summary
- extend offline photo queue to support PhotoTask objects
- add new Hive adapter for PhotoTask

## Testing
- `flutter test test/noyau/unit/offline_photo_queue_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f7ccde48320bc0fc83c90dcd5dc