### PR TITLE
Add upload metadata to PhotoModel

### DIFF
--- a/lib/modules/noyau/logic/ia_master.dart
+++ b/lib/modules/noyau/logic/ia_master.dart
@@ -121,9 +121,12 @@ class IAMaster {
     final analysis = await IAPhotoAnalyzer().analyze(file);
     final photo = PhotoModel(
       id: analysis['hash'],
+      userId: analysis['userId'] ?? '',
+      animalId: analysis['animalId'] ?? '',
       localPath: file.path,
       createdAt: DateTime.now(),
       uploaded: false,
+      remoteUrl: null,
     );
     try {
       await _cloudSyncService.pushPhotoData(photo);

--- a/lib/modules/noyau/models/photo_model.dart
+++ b/lib/modules/noyau/models/photo_model.dart
@@ -21,12 +21,20 @@ class PhotoModel {
   @HiveField(4)
   final DateTime createdAt;
 
+  @HiveField(5)
+  final bool uploaded;
+
+  @HiveField(6)
+  final String? remoteUrl;
+
   const PhotoModel({
     required this.id,
     required this.userId,
     required this.animalId,
     required this.localPath,
     required this.createdAt,
+    required this.uploaded,
+    this.remoteUrl,
   });
 
   Map<String, dynamic> toJson() => {
@@ -35,6 +43,8 @@ class PhotoModel {
         'animalId': animalId,
         'localPath': localPath,
         'createdAt': createdAt.toIso8601String(),
+        'uploaded': uploaded,
+        'remoteUrl': remoteUrl,
       };
 
   factory PhotoModel.fromJson(Map<String, dynamic> json) {
@@ -44,6 +54,8 @@ class PhotoModel {
       animalId: json['animalId'] ?? '',
       localPath: json['localPath'] ?? '',
       createdAt: DateTime.tryParse(json['createdAt'] ?? '') ?? DateTime.now(),
+      uploaded: json['uploaded'] ?? false,
+      remoteUrl: json['remoteUrl'],
     );
   }
 
@@ -53,6 +65,8 @@ class PhotoModel {
     String? animalId,
     String? localPath,
     DateTime? createdAt,
+    bool? uploaded,
+    String? remoteUrl,
   }) {
     return PhotoModel(
       id: id ?? this.id,
@@ -60,6 +74,8 @@ class PhotoModel {
       animalId: animalId ?? this.animalId,
       localPath: localPath ?? this.localPath,
       createdAt: createdAt ?? this.createdAt,
+      uploaded: uploaded ?? this.uploaded,
+      remoteUrl: remoteUrl ?? this.remoteUrl,
     );
   }
 }

--- a/lib/modules/noyau/models/photo_model.g.dart
+++ b/lib/modules/noyau/models/photo_model.g.dart
@@ -18,13 +18,15 @@ class PhotoModelAdapter extends TypeAdapter<PhotoModel> {
       animalId: fields[2] as String,
       localPath: fields[3] as String,
       createdAt: fields[4] as DateTime,
+      uploaded: fields[5] as bool,
+      remoteUrl: fields[6] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, PhotoModel obj) {
     writer
-      ..writeByte(5)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -34,7 +36,11 @@ class PhotoModelAdapter extends TypeAdapter<PhotoModel> {
       ..writeByte(3)
       ..write(obj.localPath)
       ..writeByte(4)
-      ..write(obj.createdAt);
+      ..write(obj.createdAt)
+      ..writeByte(5)
+      ..write(obj.uploaded)
+      ..writeByte(6)
+      ..write(obj.remoteUrl);
   }
 
   @override

--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -43,6 +43,8 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
 
     await service.pushPhotoData(photo);
@@ -59,6 +61,8 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
 
     await service.pushPhotoData(photo);

--- a/test/noyau/unit/offline_photo_queue_test.dart
+++ b/test/noyau/unit/offline_photo_queue_test.dart
@@ -23,8 +23,12 @@ void main() {
   test('addTask stores photo in Hive box', () async {
     final photo = PhotoModel(
       id: 'p1',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/1.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
     await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
     final box = await Hive.openBox<PhotoTask>('offline_photo_queue');
@@ -35,8 +39,12 @@ void main() {
   test('processQueue processes tasks and clears box', () async {
     final photo = PhotoModel(
       id: 'p2',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/2.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
     await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
     final processed = <PhotoTask>[];

--- a/test/noyau/unit/photo_model_test.dart
+++ b/test/noyau/unit/photo_model_test.dart
@@ -5,9 +5,12 @@ void main() {
   test('PhotoModel toJson/fromJson round trip', () {
     final model = PhotoModel(
       id: '1',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/img.png',
       createdAt: DateTime.parse('2024-01-01'),
       uploaded: false,
+      remoteUrl: null,
     );
     final json = model.toJson();
     final copy = PhotoModel.fromJson(json);


### PR DESCRIPTION
## Summary
- track photo upload status and URL via new fields
- update Hive adapter and model helpers
- adjust IAMaster and provider tests to match new fields

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f802b148320b9811ad276426030