### PR TITLE
Fix pushPhotoData duplication

### DIFF
--- a/lib/modules/noyau/services/cloud_sync_service.dart
+++ b/lib/modules/noyau/services/cloud_sync_service.dart
@@ -132,16 +132,6 @@ class CloudSyncService {
     }
   }
 
-  /// 🖼️ Envoie une photo pour apprentissage IA ou la met en attente.
-  Future<void> pushPhotoData(PhotoModel photo) async {
-    try {
-      await _firebaseService.sendModuleData('photos', photo.toJson());
-      debugPrint('☁️ Photo ${photo.id} envoyée au cloud.');
-    } catch (e) {
-      debugPrint('❌ [CloudSync] Erreur pushPhotoData : $e');
-      await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
-    }
-  }
   /// 📦 Synchro complète pour IAMaster (utilise les logs de l’app)
   Future<void> syncFullIA(String userId, List<String> logs) async {
     try {


### PR DESCRIPTION
## Summary
- remove duplicate `pushPhotoData` in CloudSyncService
- keep single version storing via `FirebaseService.savePhoto` and queueing on error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f802c748320b2d8e031aca37007