### PR TITLE
Update PhotoTask metadata parameters

### DIFF
--- a/lib/modules/noyau/logic/ia_master.dart
+++ b/lib/modules/noyau/logic/ia_master.dart
@@ -132,7 +132,15 @@ class IAMaster {
         channel: IAChannel.execution,
       );
     } catch (e) {
-      await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
+      await OfflinePhotoQueue.addTask(
+        PhotoTask(
+          photo: photo,
+          animalId: photo.animalId,
+          userId: photo.userId,
+          uploaded: photo.uploaded,
+          remoteUrl: photo.remoteUrl,
+        ),
+      );
       debugPrint('⚠️ analyzeAndPushPhoto : file offline');
     }
   }

--- a/lib/modules/noyau/providers/photo_provider.dart
+++ b/lib/modules/noyau/providers/photo_provider.dart
@@ -32,7 +32,15 @@ class PhotoProvider extends ChangeNotifier {
     await box.put(photo.id, photo);
     _photos[photo.id] = photo;
     notifyListeners();
-    await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
+    await OfflinePhotoQueue.addTask(
+      PhotoTask(
+        photo: photo,
+        animalId: photo.animalId,
+        userId: photo.userId,
+        uploaded: photo.uploaded,
+        remoteUrl: photo.remoteUrl,
+      ),
+    );
   }
 
   Future<void> markUploaded(String id, String remoteUrl) async {

--- a/lib/modules/noyau/services/cloud_sync_service.dart
+++ b/lib/modules/noyau/services/cloud_sync_service.dart
@@ -139,7 +139,15 @@ class CloudSyncService {
       debugPrint('☁️ Photo ${photo.id} envoyée au cloud.');
     } catch (e) {
       debugPrint('❌ [CloudSync] Erreur pushPhotoData : $e');
-      await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
+      await OfflinePhotoQueue.addTask(
+        PhotoTask(
+          photo: photo,
+          animalId: photo.animalId,
+          userId: photo.userId,
+          uploaded: photo.uploaded,
+          remoteUrl: photo.remoteUrl,
+        ),
+      );
     }
   }
   /// 📦 Synchro complète pour IAMaster (utilise les logs de l’app)

--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -43,6 +43,8 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
 
     await service.pushPhotoData(photo);
@@ -59,6 +61,8 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
 
     await service.pushPhotoData(photo);

--- a/test/noyau/unit/offline_photo_queue_test.dart
+++ b/test/noyau/unit/offline_photo_queue_test.dart
@@ -23,10 +23,22 @@ void main() {
   test('addTask stores photo in Hive box', () async {
     final photo = PhotoModel(
       id: 'p1',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/1.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
-    await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
+    await OfflinePhotoQueue.addTask(
+      PhotoTask(
+        photo: photo,
+        animalId: photo.animalId,
+        userId: photo.userId,
+        uploaded: photo.uploaded,
+        remoteUrl: photo.remoteUrl,
+      ),
+    );
     final box = await Hive.openBox<PhotoTask>('offline_photo_queue');
     expect(box.length, 1);
     expect(box.getAt(0)?.photo.id, 'p1');
@@ -35,10 +47,22 @@ void main() {
   test('processQueue processes tasks and clears box', () async {
     final photo = PhotoModel(
       id: 'p2',
+      userId: 'u2',
+      animalId: 'a2',
       localPath: '/tmp/2.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: null,
     );
-    await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
+    await OfflinePhotoQueue.addTask(
+      PhotoTask(
+        photo: photo,
+        animalId: photo.animalId,
+        userId: photo.userId,
+        uploaded: photo.uploaded,
+        remoteUrl: photo.remoteUrl,
+      ),
+    );
     final processed = <PhotoTask>[];
     await OfflinePhotoQueue.processQueue((t) async {
       processed.add(t);


### PR DESCRIPTION
## Summary
- update IAMaster to include metadata when queuing PhotoTask
- update PhotoProvider to pass animalId, userId, uploaded, and remoteUrl
- update CloudSyncService to queue PhotoTask with metadata
- revise offline photo queue tests
- revise cloud sync service tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f818d548320ac0da74c8240b9a5