### PR TITLE
Update photo queue tests

### DIFF
--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -2,7 +2,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:anisphere/modules/noyau/services/cloud_sync_service.dart';
-import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart';
+import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
+    show PhotoTask, OfflinePhotoQueue;
 import 'package:anisphere/modules/noyau/models/photo_model.dart';
 import 'package:anisphere/modules/noyau/services/firebase_service.dart';
 import '../../test_config.dart';
@@ -25,12 +26,12 @@ void main() {
     tempDir = await Directory.systemTemp.createTemp();
     Hive.init(tempDir.path);
     Hive.registerAdapter(PhotoModelAdapter());
-    Hive.registerAdapter(QueuedPhotoAdapter());
-    await Hive.openBox<QueuedPhoto>('offline_photos');
+    Hive.registerAdapter(PhotoTaskAdapter());
+    await Hive.openBox<PhotoTask>('offline_photo_queue');
   });
 
   tearDown(() async {
-    await Hive.deleteBoxFromDisk('offline_photos');
+    await Hive.deleteBoxFromDisk('offline_photo_queue');
     await tempDir.delete(recursive: true);
   });
 
@@ -43,6 +44,8 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: '',
     );
 
     await service.pushPhotoData(photo);
@@ -59,12 +62,17 @@ void main() {
       animalId: 'a1',
       localPath: 'path.jpg',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: '',
     );
 
     await service.pushPhotoData(photo);
 
-    final queued = await OfflinePhotoQueue.getAllPhotos();
-    expect(queued.length, 1);
-    expect(queued.first.photo.id, 'p2');
+    final processed = <PhotoTask>[];
+    await OfflinePhotoQueue.processQueue((pt) async {
+      processed.add(pt);
+    });
+    expect(processed.length, 1);
+    expect(processed.first.photo.id, 'p2');
   });
 }

--- a/test/noyau/unit/offline_photo_queue_test.dart
+++ b/test/noyau/unit/offline_photo_queue_test.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
-import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart';
+import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
+    show PhotoTask, OfflinePhotoQueue;
 import 'package:anisphere/modules/noyau/models/photo_model.dart';
 
 void main() {
@@ -23,8 +24,12 @@ void main() {
   test('addTask stores photo in Hive box', () async {
     final photo = PhotoModel(
       id: 'p1',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/1.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: '',
     );
     await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
     final box = await Hive.openBox<PhotoTask>('offline_photo_queue');
@@ -35,8 +40,12 @@ void main() {
   test('processQueue processes tasks and clears box', () async {
     final photo = PhotoModel(
       id: 'p2',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/2.png',
       createdAt: DateTime.now(),
+      uploaded: false,
+      remoteUrl: '',
     );
     await OfflinePhotoQueue.addTask(PhotoTask(photo: photo));
     final processed = <PhotoTask>[];

--- a/test/noyau/unit/photo_model_test.dart
+++ b/test/noyau/unit/photo_model_test.dart
@@ -5,14 +5,20 @@ void main() {
   test('PhotoModel toJson/fromJson round trip', () {
     final model = PhotoModel(
       id: '1',
+      userId: 'u1',
+      animalId: 'a1',
       localPath: '/tmp/img.png',
       createdAt: DateTime.parse('2024-01-01'),
       uploaded: false,
+      remoteUrl: '',
     );
     final json = model.toJson();
     final copy = PhotoModel.fromJson(json);
     expect(copy.id, model.id);
     expect(copy.localPath, model.localPath);
     expect(copy.uploaded, model.uploaded);
+    expect(copy.remoteUrl, model.remoteUrl);
+    expect(copy.userId, model.userId);
+    expect(copy.animalId, model.animalId);
   });
 }


### PR DESCRIPTION
## Summary
- cover new `PhotoModel` fields in unit tests
- import `PhotoTask` for offline queue tests
- exercise new queue methods

## Testing
- `flutter test --coverage` *(fails: `flutter` not found)*
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f8437ec8320a8dd4eeff600696e