### PR TITLE
Fix ModulesSummaryService and add unit tests

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -27,7 +27,7 @@
 | test/noyau/unit/user_service_test.dart | unit | package:anisphere/modules/noyau/services/user_service.dart | À faire |
 | test/noyau/unit/app_initializer_test.dart | unit | package:anisphere/modules/noyau/services/app_initializer.dart | À faire |
 | test/noyau/unit/support_service_test.dart | unit | package:anisphere/modules/noyau/services/support_service.dart | À faire |
-| test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | À faire |
+| test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | ✅ |
 | test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
 | test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | À faire |

--- a/lib/modules/noyau/services/modules_summary_service.dart
+++ b/lib/modules/noyau/services/modules_summary_service.dart
@@ -99,5 +99,15 @@ class ModulesSummaryService {
 
     return summaries;
   }
+
+  /// 📝 Génère un résumé textuel pour l'UI.
+  Future<String> generateSummaryText() async {
+    final summaries = await generateSummaries();
+    if (summaries.isEmpty) {
+      return 'Aucun module actif';
+    }
+    return summaries
+        .map((s) => '${s.moduleName}: ${s.summary}')
+        .join(' | ');
   }
-  /// 📝 Génère un résumé textuel pour l'UI
+}

--- a/test/noyau/unit/modules_summary_service_test.dart
+++ b/test/noyau/unit/modules_summary_service_test.dart
@@ -1,13 +1,65 @@
-// Copilot Prompt : Test automatique généré pour modules_summary_service.dart (unit)
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:anisphere/modules/noyau/services/modules_summary_service.dart';
+import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
+
 import '../../test_config.dart';
 
+class FakeAnimalService extends AnimalService {
+  FakeAnimalService() : super(skipHiveInit: true);
+
+  @override
+  Future<List<AnimalModel>> getAllAnimals() async {
+    return [
+      AnimalModel(
+        id: 'a1',
+        name: 'Rex',
+        species: 'chien',
+        breed: 'berger',
+        imageUrl: '',
+        ownerId: 'u1',
+        createdAt: DateTime(2023, 1, 1),
+        updatedAt: DateTime(2023, 1, 1),
+      )
+    ];
+  }
+}
+
 void main() {
+  late Directory tempDir;
+
   setUpAll(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await LocalStorageService.init();
+    await LocalStorageService.set('module_status_Santé', 'actif');
+    await LocalStorageService.set('module_status_Éducation', 'actif');
+    await LocalStorageService.set('module_status_Dressage', 'actif');
   });
-  test('modules_summary_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour modules_summary_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk('users');
+    await Hive.deleteBoxFromDisk('animals');
+    await Hive.deleteBoxFromDisk('settings');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('generateSummaries returns summaries for active modules', () async {
+    final service = ModulesSummaryService(
+      animalService: FakeAnimalService(),
+      context: IAContext.empty(),
+    );
+
+    final summaries = await service.generateSummaries();
+
+    expect(summaries.length, 3);
+    expect(summaries.map((s) => s.moduleName), containsAll(['Santé', 'Éducation', 'Dressage']));
   });
 }

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -27,7 +27,7 @@
 | test/noyau/unit/user_service_test.dart | unit | package:anisphere/modules/noyau/services/user_service.dart | À faire |
 | test/noyau/unit/app_initializer_test.dart | unit | package:anisphere/modules/noyau/services/app_initializer.dart | À faire |
 | test/noyau/unit/support_service_test.dart | unit | package:anisphere/modules/noyau/services/support_service.dart | À faire |
-| test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | À faire |
+| test/noyau/unit/modules_summary_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_summary_service.dart | ✅ |
 | test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
 | test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | À faire |


### PR DESCRIPTION
## Summary
- implement `generateSummaryText` in `ModulesSummaryService`
- add test for `generateSummaries`
- mark `modules_summary_service_test` as complete in trackers

## Testing
- `flutter test test/noyau/unit/modules_summary_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dcb34fc8320899816180204176f