### PR TITLE
Fix PhotoTask adapter serialization

### DIFF
--- a/lib/modules/noyau/services/offline_photo_queue.dart
+++ b/lib/modules/noyau/services/offline_photo_queue.dart
@@ -25,10 +25,28 @@ class PhotoTask {
   final PhotoModel photo;
 
   @HiveField(1)
+  final String animalId;
+
+  @HiveField(2)
+  final String userId;
+
+  @HiveField(3)
+  final bool uploaded;
+
+  @HiveField(4)
+  final String remoteUrl;
+
+  @HiveField(5)
   final DateTime timestamp;
 
-  PhotoTask({required this.photo, DateTime? timestamp})
-      : timestamp = timestamp ?? DateTime.now();
+  PhotoTask({
+    required this.photo,
+    required this.animalId,
+    required this.userId,
+    this.uploaded = false,
+    this.remoteUrl = '',
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
 }
 
 class OfflinePhotoQueue {

--- a/lib/modules/noyau/services/offline_photo_queue.g.dart
+++ b/lib/modules/noyau/services/offline_photo_queue.g.dart
@@ -51,17 +51,29 @@ class PhotoTaskAdapter extends TypeAdapter<PhotoTask> {
     };
     return PhotoTask(
       photo: fields[0] as PhotoModel,
-      timestamp: fields[1] as DateTime,
+      animalId: fields[1] as String,
+      userId: fields[2] as String,
+      uploaded: fields[3] as bool,
+      remoteUrl: fields[4] as String,
+      timestamp: fields[5] as DateTime,
     );
   }
 
   @override
   void write(BinaryWriter writer, PhotoTask obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(6)
       ..writeByte(0)
       ..write(obj.photo)
       ..writeByte(1)
+      ..write(obj.animalId)
+      ..writeByte(2)
+      ..write(obj.userId)
+      ..writeByte(3)
+      ..write(obj.uploaded)
+      ..writeByte(4)
+      ..write(obj.remoteUrl)
+      ..writeByte(5)
       ..write(obj.timestamp);
   }
 


### PR DESCRIPTION
## Summary
- extend `PhotoTask` model used for offline photo queue
- update generated adapter to read/write all fields

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c77956f708320950daf95270fad07