### PR TITLE
Add GpsProvider and docs update

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -113,6 +113,8 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - [06/2025] Création du modèle `photo_model.dart` (métadonnées, stockage Hive).
 - [06/2025] Mise en place de `photo_upload_queue.dart` pour la synchronisation différée hors ligne.
 - [06/2025] Tests unitaires : `camera_service_test.dart`, `photo_model_test.dart`, `photo_upload_queue_test.dart`.
+- [06/2025] Ajout du `gps_provider.dart` pour suivre la position et l'état de connexion.
+- [06/2025] Test unitaire associé : `gps_provider_test.dart`.
 ---
 
 ## 🚩 Statut actuel du noyau (05/06/2025)
@@ -143,6 +145,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - `main_screen.dart`, `home_screen.dart`, `modules_screen.dart`, `settings_screen.dart`, `share_screen.dart`, `animal_form_screen.dart`, `animal_profile_screen.dart`
 - `notification_service.dart`, `notification_icon.dart`
 - `camera_service.dart`, `photo_model.dart`, `photo_upload_queue.dart`
+- `gps_provider.dart`
 - `ia_master.dart`, `ia_rule_engine.dart`, `ia_executor.dart`, `ia_scheduler.dart`, `ia_logger.dart`
 - **Tests** dans `test/noyau/`
 - **Scripts d’automatisation** : `generate_test_module.dart`, `update_noyau_suivi.dart`
@@ -173,6 +176,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 | Élément | Description | Statut |
 |---------|-------------|--------|
 | device_sensors_service.dart | Accès centralisé à tous les capteurs | ⬜ à faire |
+| gps_provider.dart | Flux position + connexion | ✅ fait |
 | ia_context_enricher.dart | Contexte IA enrichi temps réel | ⬜ à faire |
 | behavior_analysis_service.dart | Analyse comportementale IA (TFLite/capteurs) | ⬜ à faire |
 | image_analysis_service.dart | IA analyse images/photo (TFLite) | ⬜ à faire |

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -59,6 +59,7 @@
 | test/noyau/unit/ia_context_provider_test.dart | unit | package:anisphere/modules/noyau/providers/ia_context_provider.dart | À faire |
 | test/noyau/unit/user_provider_test.dart | unit | package:anisphere/modules/noyau/providers/user_provider.dart | À faire |
 | test/noyau/unit/animal_provider_test.dart | unit | package:anisphere/modules/noyau/providers/animal_provider.dart | À faire |
+| test/noyau/unit/gps_provider_test.dart | unit | package:anisphere/modules/noyau/providers/gps_provider.dart | À faire |
 | test/noyau/widget/ia_banner_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_banner.dart | À faire |
 | test/noyau/widget/more_menu_test.dart | widget | package:anisphere/modules/noyau/widgets/more_menu.dart | À faire |
 | test/noyau/widget/ia_chip_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_chip.dart | À faire |

--- a/lib/modules/noyau/providers/gps_provider.dart
+++ b/lib/modules/noyau/providers/gps_provider.dart
@@ -1,0 +1,40 @@
+// Copilot: Exemple d'utilisation
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// Provider GPS pour AniSphère.
+/// Expose la position courante via un stream et l'état de connexion réseau.
+class GpsProvider with ChangeNotifier {
+  final Connectivity _connectivity;
+  Stream<Position> _positionStream = const Stream.empty();
+  bool _isConnected = false;
+
+  /// Flux de position courante.
+  Stream<Position> get positionStream => _positionStream;
+
+  /// Indique si une connexion réseau est active.
+  bool get isConnected => _isConnected;
+
+  GpsProvider({Connectivity? connectivity})
+      : _connectivity = connectivity ?? Connectivity();
+
+  /// Initialisation du flux de position et de l'écoute réseau.
+  Future<void> init() async {
+    _positionStream = Geolocator.getPositionStream();
+    final connectivity = await _connectivity.checkConnectivity();
+    _updateConnection(connectivity);
+    _connectivity.onConnectivityChanged.listen(_updateConnection);
+  }
+
+  void _updateConnection(ConnectivityResult result) {
+    final connected = result != ConnectivityResult.none;
+    if (connected != _isConnected) {
+      _isConnected = connected;
+      notifyListeners();
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   sensors_plus: ^6.1.1
   battery_plus: ^6.2.1
   pedometer: ^4.1.1
+  geolocator: ^14.0.1
   tflite_flutter: ^0.11.0
 
 dev_dependencies:

--- a/test/noyau/unit/gps_provider_test.dart
+++ b/test/noyau/unit/gps_provider_test.dart
@@ -1,0 +1,14 @@
+// Copilot Prompt : Test automatique généré pour gps_provider.dart (unit)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('gps_provider fonctionne (test auto)', () {
+    // TODO : compléter le test pour gps_provider.dart
+    expect(true, isTrue); // À remplacer par un vrai test
+  });
+}


### PR DESCRIPTION
## Summary
- create `GpsProvider` using `ChangeNotifier`
- expose position stream and connection status
- add placeholder unit test for provider
- document GPS provider
- add dependency on `geolocator`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c839a4fc483209ac6996eff1b5d2e