### PR TITLE
Add GPS analyzer service and tests

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -113,6 +113,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - [06/2025] Création du modèle `photo_model.dart` (métadonnées, stockage Hive).
 - [06/2025] Mise en place de `photo_upload_queue.dart` pour la synchronisation différée hors ligne.
 - [06/2025] Tests unitaires : `camera_service_test.dart`, `photo_model_test.dart`, `photo_upload_queue_test.dart`.
+- [06/2025] Ajout du service `ia_gps_analyzer.dart` (compression Douglas‑Peucker, détection arrêts/anomalies) et tests associés.
 ---
 
 ## 🚩 Statut actuel du noyau (05/06/2025)

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -34,6 +34,7 @@
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | ✅ |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | À faire |
 | test/noyau/unit/ia_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/ia_sync_service.dart | À faire |
+| test/noyau/unit/ia_gps_analyzer_test.dart | unit | package:anisphere/modules/noyau/services/ia_gps_analyzer.dart | ✅ |
 | test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | ✅ |
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | À faire |
 | test/photos/unit/camera_service_test.dart | unit | package:anisphere/modules/photos/services/camera_service.dart | À faire |

--- a/lib/modules/noyau/models/gps_point.dart
+++ b/lib/modules/noyau/models/gps_point.dart
@@ -1,0 +1,10 @@
+// Copilot Prompt : Modèle simple pour point GPS (latitude, longitude, timestamp).
+library;
+
+class GPSPoint {
+  final double lat;
+  final double lon;
+  final DateTime time;
+
+  const GPSPoint({required this.lat, required this.lon, required this.time});
+}

--- a/lib/modules/noyau/services/ia_gps_analyzer.dart
+++ b/lib/modules/noyau/services/ia_gps_analyzer.dart
@@ -1,0 +1,108 @@
+// Copilot Prompt : Service d'analyse GPS avec compression et détection d'anomalies.
+library;
+
+import 'dart:math';
+
+import '../models/gps_point.dart';
+
+class IAGPSAnalyzer {
+  const IAGPSAnalyzer();
+
+  // Copilot: compresse un trajet avec l'algorithme Douglas-Peucker.
+  List<GPSPoint> compressPath(List<GPSPoint> path, {double epsilon = 0.0001}) {
+    if (path.length < 3) return path;
+    final keep = List<bool>.filled(path.length, false);
+    keep[0] = true;
+    keep[path.length - 1] = true;
+    _douglasPeucker(path, 0, path.length - 1, epsilon, keep);
+    final result = <GPSPoint>[];
+    for (var i = 0; i < path.length; i++) {
+      if (keep[i]) result.add(path[i]);
+    }
+    return result;
+  }
+
+  // Copilot: récursion Douglas-Peucker.
+  void _douglasPeucker(
+      List<GPSPoint> path, int start, int end, double epsilon, List<bool> keep) {
+    double maxDist = 0;
+    int index = start;
+    for (var i = start + 1; i < end; i++) {
+      final d = _perpendicularDistance(path[i], path[start], path[end]);
+      if (d > maxDist) {
+        maxDist = d;
+        index = i;
+      }
+    }
+    if (maxDist > epsilon && index != start) {
+      keep[index] = true;
+      _douglasPeucker(path, start, index, epsilon, keep);
+      _douglasPeucker(path, index, end, epsilon, keep);
+    }
+  }
+
+  // Copilot: distance perpendiculaire à la ligne.
+  double _perpendicularDistance(GPSPoint p, GPSPoint start, GPSPoint end) {
+    final dx = end.lon - start.lon;
+    final dy = end.lat - start.lat;
+    if (dx == 0 && dy == 0) return _distance(p, start);
+    final nume = (dy * p.lon) - (dx * p.lat) + (end.lon * start.lat) - (end.lat * start.lon);
+    final deno = sqrt(dx * dx + dy * dy);
+    return nume.abs() / deno;
+  }
+
+  // Copilot: calcule la distance haversine entre deux points.
+  double _distance(GPSPoint a, GPSPoint b) {
+    const r = 6371000.0;
+    final dLat = _deg2rad(b.lat - a.lat);
+    final dLon = _deg2rad(b.lon - a.lon);
+    final la1 = _deg2rad(a.lat);
+    final la2 = _deg2rad(b.lat);
+    final h = sin(dLat / 2) * sin(dLat / 2) +
+        cos(la1) * cos(la2) * sin(dLon / 2) * sin(dLon / 2);
+    return 2 * r * atan2(sqrt(h), sqrt(1 - h));
+  }
+
+  double _deg2rad(double d) => d * pi / 180;
+
+  // Copilot: tague les arrêts sur un trajet.
+  List<int> tagStops(
+    List<GPSPoint> path, {
+    double speedThreshold = 0.5,
+    Duration minStopDuration = const Duration(minutes: 1),
+  }) {
+    final stops = <int>[];
+    var start = -1;
+    for (var i = 1; i < path.length; i++) {
+      final dist = _distance(path[i], path[i - 1]);
+      final secs = path[i].time.difference(path[i - 1].time).inSeconds;
+      final speed = secs > 0 ? dist / secs : 0;
+      if (speed <= speedThreshold) {
+        start = start == -1 ? i - 1 : start;
+      } else {
+        if (start != -1) {
+          final duration = path[i - 1].time.difference(path[start].time);
+          if (duration >= minStopDuration) stops.add(start);
+          start = -1;
+        }
+      }
+    }
+    if (start != -1) {
+      final duration = path.last.time.difference(path[start].time);
+      if (duration >= minStopDuration) stops.add(start);
+    }
+    return stops;
+  }
+
+  // Copilot: détecte les anomalies de distance excessive.
+  List<int> tagAnomalies(List<GPSPoint> path, {double distanceThreshold = 1000}) {
+    final anomalies = <int>[];
+    for (var i = 1; i < path.length; i++) {
+      final dist = _distance(path[i], path[i - 1]);
+      if (dist > distanceThreshold) {
+        anomalies.add(i);
+      }
+    }
+    return anomalies;
+  }
+}

--- a/test/noyau/unit/ia_gps_analyzer_test.dart
+++ b/test/noyau/unit/ia_gps_analyzer_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/modules/noyau/services/ia_gps_analyzer.dart';
+import 'package:anisphere/modules/noyau/models/gps_point.dart';
+
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('compressPath reduces points', () {
+    final analyzer = IAGPSAnalyzer();
+    final now = DateTime.now();
+    final path = [
+      GPSPoint(lat: 0, lon: 0, time: now),
+      GPSPoint(lat: 0.1, lon: 0, time: now),
+      GPSPoint(lat: 0.2, lon: 0, time: now),
+      GPSPoint(lat: 0.3, lon: 0, time: now),
+    ];
+    final compressed = analyzer.compressPath(path);
+    expect(compressed.length, 2);
+  });
+
+  test('tagStops detects pause', () {
+    final analyzer = IAGPSAnalyzer();
+    final now = DateTime.now();
+    final path = [
+      GPSPoint(lat: 0, lon: 0, time: now),
+      GPSPoint(lat: 0, lon: 0, time: now.add(const Duration(seconds: 30))),
+      GPSPoint(lat: 0, lon: 0, time: now.add(const Duration(seconds: 90))),
+      GPSPoint(lat: 0, lon: 0.001, time: now.add(const Duration(seconds: 91))),
+    ];
+    final stops = analyzer.tagStops(path,
+        speedThreshold: 0.1, minStopDuration: const Duration(seconds: 60));
+    expect(stops, contains(0));
+  });
+
+  test('tagAnomalies detects big jumps', () {
+    final analyzer = IAGPSAnalyzer();
+    final now = DateTime.now();
+    final path = [
+      GPSPoint(lat: 0, lon: 0, time: now),
+      GPSPoint(lat: 0, lon: 0.001, time: now.add(const Duration(seconds: 10))),
+      GPSPoint(lat: 50, lon: 0, time: now.add(const Duration(seconds: 20))),
+    ];
+    final anomalies = analyzer.tagAnomalies(path, distanceThreshold: 1000);
+    expect(anomalies, contains(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add `ia_gps_analyzer.dart` with path compression and tagging
- create simple `GPSPoint` model
- write unit tests for compression, stops and anomalies
- document new service in `noyau_suivi.md`
- track test in `test_tracker.md`

## Testing
- `flutter test test/noyau/unit/ia_gps_analyzer_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c839a9c448320abd284e7de3b6606