### PR TITLE
Add offline GPS queue service and tests

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -112,6 +112,8 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - [06/2025] Ajout du `camera_service.dart` pour la capture et le pré-traitement des images.
 - [06/2025] Création du modèle `photo_model.dart` (métadonnées, stockage Hive).
 - [06/2025] Mise en place de `photo_upload_queue.dart` pour la synchronisation différée hors ligne.
+- [06/2025] Ajout de `offline_gps_queue.dart` pour enregistrer les traces GPS hors ligne et analyse IA.
+- [06/2025] Tests unitaires : `offline_gps_queue_test.dart`.
 - [06/2025] Tests unitaires : `camera_service_test.dart`, `photo_model_test.dart`, `photo_upload_queue_test.dart`.
 ---
 

--- a/lib/modules/noyau/logic/ia_gps_analyzer.dart
+++ b/lib/modules/noyau/logic/ia_gps_analyzer.dart
@@ -1,0 +1,40 @@
+library;
+
+import 'dart:math';
+import '../services/offline_gps_queue.dart';
+
+class IAGpsAnalyzer {
+  /// Analyse simple d'un lot de points GPS.
+  Future<Map<String, dynamic>> analyze(GpsBatch batch) async {
+    double distance = 0;
+    for (var i = 1; i < batch.points.length; i++) {
+      final p1 = batch.points[i - 1];
+      final p2 = batch.points[i];
+      distance += _haversine(p1.lat, p1.lon, p2.lat, p2.lon);
+    }
+    final duration = batch.points.isNotEmpty
+        ? batch.points.last.timestamp
+            .difference(batch.points.first.timestamp)
+            .inSeconds
+        : 0;
+    return {
+      'distance': distance,
+      'duration': duration,
+      'points': batch.points.length,
+    };
+  }
+
+  double _haversine(double lat1, double lon1, double lat2, double lon2) {
+    const r = 6371000.0;
+    final dLat = _deg2rad(lat2 - lat1);
+    final dLon = _deg2rad(lon2 - lon1);
+    final a =
+        sin(dLat / 2) * sin(dLat / 2) +
+        cos(_deg2rad(lat1)) * cos(_deg2rad(lat2)) *
+            sin(dLon / 2) * sin(dLon / 2);
+    final c = 2 * atan2(sqrt(a), sqrt(1 - a));
+    return r * c;
+  }
+
+  double _deg2rad(double deg) => deg * pi / 180.0;
+}

--- a/lib/modules/noyau/services/offline_gps_queue.dart
+++ b/lib/modules/noyau/services/offline_gps_queue.dart
@@ -1,0 +1,78 @@
+// Copilot Prompt : OfflineGpsQueue to store GPS tracks when offline, with IA analysis before upload and retry on failure.
+library;
+
+import 'package:hive/hive.dart';
+import 'package:flutter/foundation.dart';
+import '../logic/ia_gps_analyzer.dart';
+
+part 'offline_gps_queue.g.dart';
+
+@HiveType(typeId: 150)
+class GpsPoint {
+  @HiveField(0)
+  final double lat;
+
+  @HiveField(1)
+  final double lon;
+
+  @HiveField(2)
+  final DateTime timestamp;
+
+  GpsPoint(this.lat, this.lon, {DateTime? timestamp})
+      : timestamp = timestamp ?? DateTime.now();
+}
+
+@HiveType(typeId: 151)
+class GpsBatch {
+  @HiveField(0)
+  final List<GpsPoint> points;
+
+  @HiveField(1)
+  final DateTime createdAt;
+
+  GpsBatch({required this.points, DateTime? createdAt})
+      : createdAt = createdAt ?? DateTime.now();
+}
+
+class OfflineGpsQueue {
+  static const String _boxName = 'offline_gps_queue';
+
+  static Future<void> addBatch(GpsBatch batch) async {
+    final box = await Hive.openBox<GpsBatch>(_boxName);
+    await box.add(batch);
+    debugPrint('📥 Batch GPS ajouté (${batch.points.length} pts).');
+  }
+
+  static Future<List<GpsBatch>> getAllBatches() async {
+    final box = await Hive.openBox<GpsBatch>(_boxName);
+    return box.values.toList();
+  }
+
+  static Future<void> clearQueue() async {
+    final box = await Hive.openBox<GpsBatch>(_boxName);
+    await box.clear();
+    debugPrint('🧹 File GPS offline vidée.');
+  }
+
+  static Future<void> processQueue(
+    Future<void> Function(GpsBatch batch, Map<String, dynamic> analysis) handler,
+  ) async {
+    final box = await Hive.openBox<GpsBatch>(_boxName);
+    int index = 0;
+    while (index < box.length) {
+      final batch = box.getAt(index);
+      if (batch == null) {
+        index++;
+        continue;
+      }
+      try {
+        final analysis = await IAGpsAnalyzer().analyze(batch);
+        await handler(batch, analysis);
+        await box.deleteAt(index);
+      } catch (e) {
+        debugPrint('❌ Erreur traitement batch GPS: $e');
+        index++;
+      }
+    }
+  }
+}

--- a/lib/modules/noyau/services/offline_gps_queue.g.dart
+++ b/lib/modules/noyau/services/offline_gps_queue.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'offline_gps_queue.dart';
+
+class GpsPointAdapter extends TypeAdapter<GpsPoint> {
+  @override
+  final int typeId = 150;
+
+  @override
+  GpsPoint read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return GpsPoint(
+      fields[0] as double,
+      fields[1] as double,
+      timestamp: fields[2] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, GpsPoint obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.lat)
+      ..writeByte(1)
+      ..write(obj.lon)
+      ..writeByte(2)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GpsPointAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class GpsBatchAdapter extends TypeAdapter<GpsBatch> {
+  @override
+  final int typeId = 151;
+
+  @override
+  GpsBatch read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return GpsBatch(
+      points: (fields[0] as List).cast<GpsPoint>(),
+      createdAt: fields[1] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, GpsBatch obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.points)
+      ..writeByte(1)
+      ..write(obj.createdAt);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GpsBatchAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/noyau/unit/offline_gps_queue_test.dart
+++ b/test/noyau/unit/offline_gps_queue_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/offline_gps_queue.dart';
+import 'package:anisphere/modules/noyau/logic/ia_gps_analyzer.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(GpsPointAdapter());
+    Hive.registerAdapter(GpsBatchAdapter());
+    await Hive.openBox<GpsBatch>('offline_gps_queue');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('offline_gps_queue');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('addBatch stores batch in Hive box', () async {
+    final batch = GpsBatch(points: [GpsPoint(1.0, 2.0)]);
+    await OfflineGpsQueue.addBatch(batch);
+    final box = await Hive.openBox<GpsBatch>('offline_gps_queue');
+    expect(box.length, 1);
+    expect(box.getAt(0)?.points.first.lat, 1.0);
+  });
+
+  test('processQueue keeps failed batches for retry', () async {
+    final batch1 = GpsBatch(points: [GpsPoint(0.0, 0.0)]);
+    final batch2 = GpsBatch(points: [GpsPoint(1.0, 1.0)]);
+    await OfflineGpsQueue.addBatch(batch1);
+    await OfflineGpsQueue.addBatch(batch2);
+
+    var attempts = 0;
+    await OfflineGpsQueue.processQueue((b, a) async {
+      attempts++;
+      if (b == batch1) throw Exception('fail');
+    });
+
+    final box = await Hive.openBox<GpsBatch>('offline_gps_queue');
+    expect(attempts, 2);
+    expect(box.length, 1);
+    expect(box.getAt(0)?.points.first.lat, 0.0);
+
+    await OfflineGpsQueue.processQueue((b, a) async {
+      attempts++;
+    });
+    final box2 = await Hive.openBox<GpsBatch>('offline_gps_queue');
+    expect(box2.isEmpty, true);
+  });
+
+  test('processQueue provides analysis', () async {
+    final batch = GpsBatch(points: [GpsPoint(0.0, 0.0), GpsPoint(0.0, 0.1)]);
+    await OfflineGpsQueue.addBatch(batch);
+    Map<String, dynamic>? info;
+    await OfflineGpsQueue.processQueue((b, analysis) async {
+      info = analysis;
+    });
+    expect(info?['points'], 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add `offline_gps_queue.dart` for storing GPS batches offline
- create `IAGpsAnalyzer` to analyze tracks before upload
- support Hive adapters in `offline_gps_queue.g.dart`
- unit tests for GPS queue behaviour
- document new service in `docs/noyau_suivi.md`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c839ceb4083208de44621f1ff1c86