### PR TITLE
Add GPS service

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -113,6 +113,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 - [06/2025] Création du modèle `photo_model.dart` (métadonnées, stockage Hive).
 - [06/2025] Mise en place de `photo_upload_queue.dart` pour la synchronisation différée hors ligne.
 - [06/2025] Tests unitaires : `camera_service_test.dart`, `photo_model_test.dart`, `photo_upload_queue_test.dart`.
+- [06/2025] Création du `gps_service.dart` pour la localisation et la gestion du flux de positions.
 ---
 
 ## 🚩 Statut actuel du noyau (05/06/2025)

--- a/lib/modules/noyau/services/gps_service.dart
+++ b/lib/modules/noyau/services/gps_service.dart
@@ -1,0 +1,59 @@
+// Copilot Prompt : Service de localisation GPS pour AniSphère.
+// Gère l'autorisation de localisation et le flux de positions en continu.
+library;
+
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+
+class GpsService {
+  StreamSubscription<Position>? _subscription;
+  final StreamController<Position> _controller = StreamController.broadcast();
+
+  /// Flux des positions GPS actuelles.
+  Stream<Position> get positionStream => _controller.stream;
+
+  Future<bool> _ensurePermission() async {
+    // Copilot: vérifier et demander la permission GPS si besoin
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        debugPrint('❌ [GpsService] Permission localisation refusée');
+        return false;
+      }
+    }
+    if (permission == LocationPermission.deniedForever) {
+      debugPrint('❌ [GpsService] Permission localisation refusée définitivement');
+      return false;
+    }
+    return true;
+  }
+
+  Future<void> start() async {
+    // Copilot: démarrer l'écoute de la localisation
+    final hasPermission = await _ensurePermission();
+    if (!hasPermission) return;
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      debugPrint('❌ [GpsService] Service localisation désactivé');
+      return;
+    }
+    _subscription?.cancel();
+    _subscription = Geolocator.getPositionStream().listen(
+      (position) {
+        _controller.add(position);
+        debugPrint('📍 Position reçue: ${position.latitude}, ${position.longitude}');
+      },
+      onError: (e) {
+        debugPrint('❌ [GpsService] Erreur flux localisation: $e');
+      },
+    );
+  }
+
+  Future<void> stop() async {
+    // Copilot: arrêter l'écoute de la localisation
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   sensors_plus: ^6.1.1
   battery_plus: ^6.2.1
   pedometer: ^4.1.1
+  geolocator: ^10.0.1
   tflite_flutter: ^0.11.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add GPSService for continuous location stream with permission checks
- include geolocator dependency
- document GPS service in noyau_suivi

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c839eafb88320a2523ce79150dbd4