### PR TITLE
Handle failed tasks in OfflineSyncQueue

### DIFF
--- a/lib/modules/noyau/services/offline_sync_queue.dart
+++ b/lib/modules/noyau/services/offline_sync_queue.dart
@@ -48,13 +48,18 @@ class OfflineSyncQueue {
   static Future<void> processQueue(Function(SyncTask) process) async {
     final box = await Hive.openBox<SyncTask>(_boxName);
     final tasks = box.values.toList();
+    final failedTasks = <SyncTask>[];
     for (final task in tasks) {
       try {
         await process(task);
       } catch (e) {
         debugPrint("❌ Erreur lors du traitement de ${task.type} : $e");
+        failedTasks.add(task);
       }
     }
-    await clearQueue();
+    await box.clear();
+    for (final task in failedTasks) {
+      await box.add(task);
+    }
   }
 }

--- a/test/noyau/unit/offline_sync_queue_test.dart
+++ b/test/noyau/unit/offline_sync_queue_test.dart
@@ -39,6 +39,17 @@ void main() {
     expect(box.isEmpty, true);
   });
 
+  test('processQueue retains failed tasks', () async {
+    final task = SyncTask(type: 'fail', data: {}, timestamp: DateTime.now());
+    await OfflineSyncQueue.addTask(task);
+    await OfflineSyncQueue.processQueue((t) async {
+      throw Exception('boom');
+    });
+    final box = await Hive.openBox<SyncTask>('offline_sync_queue');
+    expect(box.length, 1);
+    expect(box.getAt(0)?.type, 'fail');
+  });
+
   test('clearQueue removes all tasks', () async {
     final task = SyncTask(type: 'clear', data: {}, timestamp: DateTime.now());
     await OfflineSyncQueue.addTask(task);


### PR DESCRIPTION
## Summary
- collect failed tasks while processing the offline sync queue
- requeue the failed tasks after clearing the queue
- test failing task retention in OfflineSyncQueue

## Testing
- `flutter test test/noyau/unit/offline_sync_queue_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8cc71cc48320927f9497b2d1ed76