### PR TITLE
Add signOut verification test for UserProvider

### DIFF
--- a/lib/modules/noyau/providers/user_provider.dart
+++ b/lib/modules/noyau/providers/user_provider.dart
@@ -12,7 +12,6 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import '../models/user_model.dart';
 import '../services/user_service.dart';
 import '../services/auth_service.dart';
-import 'package:anisphere/modules/noyau/services/firebase_service.dart';
 import 'package:anisphere/modules/noyau/logic/ia_master.dart'; // 👈 IA ajoutée
 
 class UserProvider with ChangeNotifier {
@@ -111,7 +110,7 @@ class UserProvider with ChangeNotifier {
       final connectivity = await Connectivity().checkConnectivity();
       if (connectivity.contains(ConnectivityResult.wifi) ||
           connectivity.contains(ConnectivityResult.mobile)) {
-        await FirebaseService().signOut();
+        await _authService.signOut();
         debugPrint("✅ Déconnexion Firebase !");
       } else {
         debugPrint("⚠️ Déconnexion locale (pas de réseau).");

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import '../../test_config.dart';
+import 'package:mockito/mockito.dart';
 
 class FakeUserService extends UserService {
   bool initCalled = false;
@@ -28,6 +29,10 @@ class FakeUserService extends UserService {
     deleteCalled = true;
   }
 }
+
+class MockAuthService extends Mock implements AuthService {}
+
+class MockUserService extends Mock implements UserService {}
 
 void main() {
   setUpAll(() async {
@@ -62,6 +67,43 @@ void main() {
     await provider.signOut();
     expect(service.initCalled, isTrue);
     expect(service.deleteCalled, isTrue);
+    expect(provider.user, isNull);
+  });
+
+  test('signOut calls AuthService.signOut and removes user locally', () async {
+    final mockAuth = MockAuthService();
+    final mockService = MockUserService();
+
+    when(mockService.init()).thenAnswer((_) async {});
+    when(mockService.deleteUserLocally()).thenAnswer((_) async {});
+    when(mockService.updateUser(any)).thenAnswer((_) async => true);
+    when(mockAuth.signOut()).thenAnswer((_) async {});
+
+    final provider = UserProvider(mockService, mockAuth);
+    final user = UserModel(
+      id: 'u1',
+      name: 'Test',
+      email: 't@test.com',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+
+    await provider.updateUser(user);
+    await provider.signOut();
+
+    verify(mockService.init()).called(1);
+    verify(mockService.deleteUserLocally()).called(1);
+    verify(mockAuth.signOut()).called(1);
     expect(provider.user, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- verify UserProvider calls AuthService.signOut and clears local data
- update signOut implementation to use AuthService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8cc2b7bc8320b14e668b41352bb2