### PR TITLE
Handle notification redirection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'package:anisphere/modules/noyau/services/notification_service.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
+import 'package:anisphere/modules/noyau/services/navigation_service.dart';
 import 'package:anisphere/modules/noyau/logic/ia_master.dart';
 import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
 import 'package:anisphere/modules/messagerie/models/message_model.dart';
@@ -131,6 +132,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: NavigationService.navigatorKey,
       title: 'AniSphère',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(

--- a/lib/modules/noyau/services/cloud_notification_listener.dart
+++ b/lib/modules/noyau/services/cloud_notification_listener.dart
@@ -10,6 +10,9 @@ import 'package:flutter/foundation.dart';
 import '../services/notification_service.dart';
 import '../models/notification_feedback_model.dart';
 import '../logic/ia_master.dart';
+import 'navigation_service.dart';
+import '../../messagerie/screens/message_list_screen.dart';
+import '../screens/notifications_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 class CloudNotificationListener {
@@ -42,10 +45,21 @@ class CloudNotificationListener {
         createdAt: message.sentTime ?? DateTime.now(),
       );
       IAMaster.instance.pushNotificationFeedback(feedback);
-      // TODO : Ajouter redirection ou comportement contextuel
+      processNotificationData(message.data);
     });
 
     debugPrint("☁️ CloudNotificationListener initialisé.");
+  }
+
+  /// Handles navigation or actions based on notification content.
+  static void processNotificationData(Map<String, dynamic> data) {
+    final module = data['module'] as String? ?? '';
+    final type = data['type'] as String? ?? '';
+    if (module == 'messagerie' || type == 'message') {
+      NavigationService.push(const MessageListScreen());
+    } else if (module == 'noyau' || type == 'notification') {
+      NavigationService.push(const NotificationsScreen());
+    }
   }
 
   /// 🧪 Token utile pour debug / lien Firestore si besoin

--- a/lib/modules/noyau/services/navigation_service.dart
+++ b/lib/modules/noyau/services/navigation_service.dart
@@ -1,0 +1,20 @@
+library;
+
+import 'package:flutter/material.dart';
+
+/// Provides global navigation without requiring a BuildContext.
+class NavigationService {
+  static final GlobalKey<NavigatorState> navigatorKey =
+      GlobalKey<NavigatorState>();
+
+  /// Pushes the given widget onto the navigation stack if possible.
+  static Future<void> push(Widget page) async {
+    final state = navigatorKey.currentState;
+    if (state != null) {
+      await state.push(MaterialPageRoute(builder: (_) => page));
+    }
+  }
+
+  /// Returns the global navigation context if available.
+  static BuildContext? get context => navigatorKey.currentContext;
+}

--- a/test/noyau/unit/cloud_notification_listener_test.dart
+++ b/test/noyau/unit/cloud_notification_listener_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/noyau/services/cloud_notification_listener.dart';
+import 'package:anisphere/modules/noyau/services/navigation_service.dart';
+import 'package:flutter/material.dart';
 import '../../test_config.dart';
 
 void main() {
@@ -27,5 +29,18 @@ void main() {
     final token = await CloudNotificationListener.getToken();
     expect(token, 'token_123');
     expect(log.any((c) => c.method.contains('getToken')), isTrue);
+  });
+
+  testWidgets('processNotificationData navigates to MessageListScreen',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: NavigationService.navigatorKey,
+      home: const SizedBox(),
+    ));
+
+    CloudNotificationListener.processNotificationData({'module': 'messagerie'});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Messagerie'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add NavigationService to expose a global navigator
- redirect to message or notifications screens when opening push
- wire global navigator into `MaterialApp`
- test redirection logic for cloud notifications

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684c8cc3a3c88320af419fc82d8f4b7d