### PR TITLE
Add SyncTaskAdapter encoding test

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -21,7 +21,7 @@
 | test/noyau/unit/user_model.g_test.dart | unit | package:anisphere/modules/noyau/models/user_model.g.dart | À faire |
 | test/noyau/unit/modules_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_service.dart | À faire |
 | test/noyau/unit/auth_service_test.dart | unit | package:anisphere/modules/noyau/services/auth_service.dart | À faire |
-| test/noyau/unit/offline_sync_queue.g_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.g.dart | À faire |
+| test/noyau/unit/offline_sync_queue.g_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.g.dart | ✅ |
 | test/noyau/unit/maintenance_service_test.dart | unit | package:anisphere/modules/noyau/services/maintenance_service.dart | À faire |
 | test/noyau/unit/qr_service_test.dart | unit | package:anisphere/modules/noyau/services/qr_service.dart | ✅ |
 | test/noyau/unit/user_service_test.dart | unit | package:anisphere/modules/noyau/services/user_service.dart | À faire |

--- a/test/noyau/unit/offline_sync_queue.g_test.dart
+++ b/test/noyau/unit/offline_sync_queue.g_test.dart
@@ -2,12 +2,39 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 
+import 'dart:io';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
+
 void main() {
+  late Directory tempDir;
+
   setUpAll(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(SyncTaskAdapter());
+    await Hive.openBox<SyncTask>('offline_sync_queue');
   });
-  test('offline_sync_queue.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour offline_sync_queue.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk('offline_sync_queue');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('SyncTaskAdapter encodes and decodes SyncTask', () async {
+    final task = SyncTask(
+      type: 'demo',
+      data: {'foo': 'bar'},
+      timestamp: DateTime.now(),
+    );
+
+    final box = await Hive.openBox<SyncTask>('offline_sync_queue');
+    await box.add(task);
+
+    final stored = box.getAt(0);
+    expect(stored?.type, equals('demo'));
+    expect(stored?.data, equals({'foo': 'bar'}));
+    expect(stored?.timestamp.toIso8601String(), task.timestamp.toIso8601String());
   });
 }


### PR DESCRIPTION
## Summary
- replace placeholder with SyncTaskAdapter encoding/decoding test
- mark the test as done in the tracker

## Testing
- `flutter test test/noyau/unit/offline_sync_queue.g_test.dart --dart-define=CI=true` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c8cc6b36083209558111b95dd559d