### PR TITLE
Fix signOut connectivity check

### DIFF
--- a/lib/modules/noyau/providers/user_provider.dart
+++ b/lib/modules/noyau/providers/user_provider.dart
@@ -99,7 +99,6 @@ class UserProvider with ChangeNotifier {
   }
 
   /// 🔓 Déconnexion
-  // TODO: ajouter test
   Future<void> signOut() async {
     try {
       await _userService.init(); // Hive ready
@@ -108,8 +107,8 @@ class UserProvider with ChangeNotifier {
       }
 
       final connectivity = await Connectivity().checkConnectivity();
-      if (connectivity.contains(ConnectivityResult.wifi) ||
-          connectivity.contains(ConnectivityResult.mobile)) {
+      if (connectivity == ConnectivityResult.wifi ||
+          connectivity == ConnectivityResult.mobile) {
         await _authService.signOut();
         debugPrint("✅ Déconnexion Firebase !");
       } else {

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -3,6 +3,8 @@ import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import '../../test_config.dart';
 import 'package:mockito/mockito.dart';
 
@@ -34,9 +36,30 @@ class MockAuthService extends Mock implements AuthService {}
 
 class MockUserService extends Mock implements UserService {}
 
+class FakeConnectivityPlatform extends ConnectivityPlatform {
+  ConnectivityResult result;
+  FakeConnectivityPlatform(this.result);
+
+  @override
+  Future<ConnectivityResult> checkConnectivity() async => result;
+
+  @override
+  Stream<ConnectivityResult> get onConnectivityChanged => Stream.value(result);
+}
+
 void main() {
+  late ConnectivityPlatform previous;
+
   setUpAll(() async {
     await initTestEnv();
+  });
+
+  setUp(() {
+    previous = ConnectivityPlatform.instance;
+  });
+
+  tearDown(() {
+    ConnectivityPlatform.instance = previous;
   });
 
   test('signOut clears user and deletes local data', () async {
@@ -64,6 +87,8 @@ void main() {
     await provider.updateUser(user);
     expect(provider.user, isNotNull);
 
+    ConnectivityPlatform.instance =
+        FakeConnectivityPlatform(ConnectivityResult.wifi);
     await provider.signOut();
     expect(service.initCalled, isTrue);
     expect(service.deleteCalled, isTrue);
@@ -99,11 +124,52 @@ void main() {
     );
 
     await provider.updateUser(user);
+    ConnectivityPlatform.instance =
+        FakeConnectivityPlatform(ConnectivityResult.wifi);
     await provider.signOut();
 
     verify(mockService.init()).called(1);
     verify(mockService.deleteUserLocally()).called(1);
     verify(mockAuth.signOut()).called(1);
+    expect(provider.user, isNull);
+  });
+
+  test('signOut does not call AuthService.signOut when offline', () async {
+    final mockAuth = MockAuthService();
+    final mockService = MockUserService();
+
+    when(mockService.init()).thenAnswer((_) async {});
+    when(mockService.deleteUserLocally()).thenAnswer((_) async {});
+    when(mockService.updateUser(any)).thenAnswer((_) async => true);
+    when(mockAuth.signOut()).thenAnswer((_) async {});
+
+    final provider = UserProvider(mockService, mockAuth);
+    final user = UserModel(
+      id: 'u1',
+      name: 'Test',
+      email: 't@test.com',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+
+    await provider.updateUser(user);
+    ConnectivityPlatform.instance =
+        FakeConnectivityPlatform(ConnectivityResult.none);
+    await provider.signOut();
+
+    verify(mockService.init()).called(1);
+    verify(mockService.deleteUserLocally()).called(1);
+    verifyNever(mockAuth.signOut());
     expect(provider.user, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- fix wifi/mobile check in `UserProvider.signOut`
- ensure connectivity is faked in `user_provider_test`
- add test verifying offline signout doesn't call Firebase

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d68f2f904832095ec6c5a8269b53b