### PR TITLE
Add SyncMetricsModel

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -85,6 +85,7 @@
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
 | test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
 | test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |
+| test/noyau/unit/sync_metrics_model_test.dart | unit | package:anisphere/modules/noyau/models/sync_metrics_model.dart | ✅ |
 | test/messagerie/unit/messaging_service_test.dart | unit | package:anisphere/modules/messagerie/services/messaging_service.dart | À faire |
 | test/messagerie/unit/offline_message_queue_test.dart | unit | package:anisphere/modules/messagerie/services/offline_message_queue.dart | À faire |
 | test/messagerie/unit/ia_message_analyzer_test.dart | unit | package:anisphere/modules/messagerie/services/ia_message_analyzer.dart | À faire |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:anisphere/modules/messagerie/models/conversation_model.dart';
 import 'package:anisphere/modules/messagerie/services/offline_message_queue.dart';
 import 'package:anisphere/modules/noyau/providers/photo_provider.dart';
 import 'package:anisphere/modules/noyau/models/photo_model.dart';
+import 'package:anisphere/modules/noyau/models/sync_metrics_model.dart';
 import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
     as offline_queue;
 
@@ -60,6 +61,7 @@ void main() async {
     Hive.registerAdapter(QueuedMessageAdapter());
     Hive.registerAdapter(ConversationModelAdapter());
     Hive.registerAdapter(PhotoModelAdapter());
+    Hive.registerAdapter(SyncMetricsModelAdapter());
     Hive.registerAdapter(offline_queue.PhotoTaskAdapter());
     await LocalStorageService.init();
     assert(() {

--- a/lib/modules/noyau/models/sync_metrics_model.dart
+++ b/lib/modules/noyau/models/sync_metrics_model.dart
@@ -1,0 +1,58 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'sync_metrics_model.g.dart';
+
+@HiveType(typeId: 25)
+class SyncMetricsModel {
+  @HiveField(0)
+  final String operation;
+
+  @HiveField(1)
+  final DateTime timestamp;
+
+  @HiveField(2)
+  final bool success;
+
+  @HiveField(3)
+  final String details;
+
+  const SyncMetricsModel({
+    required this.operation,
+    required this.timestamp,
+    required this.success,
+    required this.details,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'operation': operation,
+        'timestamp': timestamp.toIso8601String(),
+        'success': success,
+        'details': details,
+      };
+
+  factory SyncMetricsModel.fromJson(Map<String, dynamic> json) {
+    return SyncMetricsModel(
+      operation: json['operation'] ?? '',
+      timestamp:
+          DateTime.tryParse(json['timestamp'] ?? '') ?? DateTime.now(),
+      success: json['success'] ?? false,
+      details: json['details'] ?? '',
+    );
+  }
+
+  SyncMetricsModel copyWith({
+    String? operation,
+    DateTime? timestamp,
+    bool? success,
+    String? details,
+  }) {
+    return SyncMetricsModel(
+      operation: operation ?? this.operation,
+      timestamp: timestamp ?? this.timestamp,
+      success: success ?? this.success,
+      details: details ?? this.details,
+    );
+  }
+}

--- a/lib/modules/noyau/models/sync_metrics_model.g.dart
+++ b/lib/modules/noyau/models/sync_metrics_model.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sync_metrics_model.dart';
+
+class SyncMetricsModelAdapter extends TypeAdapter<SyncMetricsModel> {
+  @override
+  final int typeId = 25;
+
+  @override
+  SyncMetricsModel read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SyncMetricsModel(
+      operation: fields[0] as String,
+      timestamp: fields[1] as DateTime,
+      success: fields[2] as bool,
+      details: fields[3] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SyncMetricsModel obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.operation)
+      ..writeByte(1)
+      ..write(obj.timestamp)
+      ..writeByte(2)
+      ..write(obj.success)
+      ..writeByte(3)
+      ..write(obj.details);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SyncMetricsModelAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/noyau/unit/sync_metrics_model_test.dart
+++ b/test/noyau/unit/sync_metrics_model_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/models/sync_metrics_model.dart';
+
+import '../../test_config.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive
+      ..init(tempDir.path)
+      ..registerAdapter(SyncMetricsModelAdapter());
+  });
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk('sync_metrics');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('toJson/fromJson round trip', () {
+    final metric = SyncMetricsModel(
+      operation: 'upload_animal',
+      timestamp: DateTime.parse('2024-01-01T00:00:00Z'),
+      success: true,
+      details: 'ok',
+    );
+    final json = metric.toJson();
+    final copy = SyncMetricsModel.fromJson(json);
+    expect(copy.operation, metric.operation);
+    expect(copy.timestamp.toIso8601String(), metric.timestamp.toIso8601String());
+    expect(copy.success, metric.success);
+    expect(copy.details, metric.details);
+  });
+
+  test('Hive adapter saves and retrieves object', () async {
+    final box = await Hive.openBox<SyncMetricsModel>('sync_metrics');
+    final metric = SyncMetricsModel(
+      operation: 'sync_user',
+      timestamp: DateTime.now(),
+      success: false,
+      details: 'network error',
+    );
+    await box.put('m1', metric);
+
+    final read = box.get('m1');
+
+    expect(read, isNotNull);
+    expect(read!.operation, metric.operation);
+    expect(read.success, metric.success);
+    expect(read.details, metric.details);
+    expect(read.timestamp.toIso8601String(), metric.timestamp.toIso8601String());
+
+    await box.close();
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -78,7 +78,9 @@
 | test/noyau/widget/support_screen_test.dart | widget | package:anisphere/modules/noyau/screens/support_screen.dart | À faire |
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | À faire |
 | test/noyau/widget/notifications_screen_test.dart | widget | package:anisphere/modules/noyau/screens/notifications_screen.dart | ✅ |
-| test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire || test/messagerie/unit/messaging_service_test.dart | unit | package:anisphere/modules/messagerie/services/messaging_service.dart | À faire |
+| test/noyau/widget/settings_screen_test.dart | widget | package:anisphere/modules/noyau/screens/settings_screen.dart | À faire |
+| test/noyau/unit/sync_metrics_model_test.dart | unit | package:anisphere/modules/noyau/models/sync_metrics_model.dart | ✅ |
+| test/messagerie/unit/messaging_service_test.dart | unit | package:anisphere/modules/messagerie/services/messaging_service.dart | À faire |
 | test/messagerie/unit/offline_message_queue_test.dart | unit | package:anisphere/modules/messagerie/services/offline_message_queue.dart | À faire |
 | test/messagerie/unit/ia_message_analyzer_test.dart | unit | package:anisphere/modules/messagerie/services/ia_message_analyzer.dart | À faire |
 | test/messagerie/widget/chat_screen_widget_test.dart | widget | package:anisphere/modules/messagerie/screens/chat_screen.dart | À faire |


### PR DESCRIPTION
## Summary
- add `SyncMetricsModel` for tracking sync operations via Hive
- register SyncMetricsModel adapter during initialization
- cover new model with a unit test
- track test in docs

## Testing
- `flutter test test/noyau/unit/sync_metrics_model_test.dart` *(fails: `flutter` not found)*
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d68f9a2188320a4bd76c09be9bdf0