### PR TITLE
Fix offline detection using list connectivity results

### DIFF
--- a/lib/modules/noyau/services/ia_adaptation_service.dart
+++ b/lib/modules/noyau/services/ia_adaptation_service.dart
@@ -19,7 +19,7 @@ class IAAdaptationService {
     final battery = await sensors.getBatteryLevel();
     final connectivity = await sensors.getConnectivity();
     final isLowBattery = battery >= 0 && battery < 20;
-    final isOffline = connectivity == ConnectivityResult.none;
+    final isOffline = connectivity.contains(ConnectivityResult.none);
 
     return !isLowBattery && !isOffline;
   }

--- a/lib/modules/noyau/services/ia_context_enricher.dart
+++ b/lib/modules/noyau/services/ia_context_enricher.dart
@@ -20,9 +20,10 @@ class IAContextEnricher {
     try {
       final connectivity = await sensors.getConnectivity();
       await sensors.getBatteryLevel(); // charge la valeur en cache si besoin
+      final isOffline = connectivity.contains(ConnectivityResult.none);
 
       return IAContext(
-        isOffline: connectivity == ConnectivityResult.none,
+        isOffline: isOffline,
         isFirstLaunch: base.isFirstLaunch,
         hasAnimals: base.hasAnimals,
         animalCount: base.animalCount,


### PR DESCRIPTION
## Summary
- adjust IAAdaptationService to detect offline by checking list of results
- enrich IAContext using list-based offline detection

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6bcf06488320bf98d7dbd11f7988