### PR TITLE
Fix generic usage in user_provider_test

### DIFF
--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -101,7 +101,8 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any)).thenAnswer((_) async => true);
+    when(mockService.updateUser(any<UserModel>()))
+        .thenAnswer((_) async => true);
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
     final provider = UserProvider(mockService, mockAuth);
@@ -140,7 +141,8 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any)).thenAnswer((_) async => true);
+    when(mockService.updateUser(any<UserModel>()))
+        .thenAnswer((_) async => true);
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
     final provider = UserProvider(mockService, mockAuth);


### PR DESCRIPTION
## Summary
- specify `any<UserModel>()` when stubbing `updateUser` in `user_provider_test`

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6bd05c148320b4a38571474313a3