### PR TITLE
Fix biometric guard test box opening

### DIFF
--- a/test/noyau/widget/biometric_guard_test.dart
+++ b/test/noyau/widget/biometric_guard_test.dart
@@ -18,8 +18,12 @@ void main() {
     Hive
       ..init(tempDir.path)
       ..registerAdapter(SecuritySettingsModelAdapter());
-    await Hive.openBox<SecuritySettingsModel>('securitySettings')
-        .put('settings', const SecuritySettingsModel(biometricEnabled: true, encryptedPin: '1234', protectedModules: []));
+    final box = await Hive.openBox<SecuritySettingsModel>('securitySettings');
+    await box.put(
+      'settings',
+      const SecuritySettingsModel(
+          biometricEnabled: true, encryptedPin: '1234', protectedModules: []),
+    );
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall call) async {
       if (call.method == 'authenticate') return true;


### PR DESCRIPTION
## Summary
- open the Hive box before calling `put` in biometric guard widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d791325c08320b47a35936c15d61d