### PR TITLE
Fix user_provider_test connectivity mock

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   fake_cloud_firestore: ^3.1.0
   hive_generator: ^2.0.1
+  connectivity_plus_platform_interface: ^2.0.1
 
 # ⚠️ Dépendances figées pour éviter les conflits
 dependency_overrides:

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -3,7 +3,6 @@ import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import '../../test_config.dart';
 import 'package:mockito/mockito.dart';
@@ -37,14 +36,15 @@ class MockAuthService extends Mock implements AuthService {}
 class MockUserService extends Mock implements UserService {}
 
 class FakeConnectivityPlatform extends ConnectivityPlatform {
-  ConnectivityResult result;
-  FakeConnectivityPlatform(this.result);
+  final List<ConnectivityResult> results;
+  FakeConnectivityPlatform(ConnectivityResult r) : results = [r];
 
   @override
-  Future<ConnectivityResult> checkConnectivity() async => result;
+  Future<List<ConnectivityResult>> checkConnectivity() async => results;
 
   @override
-  Stream<ConnectivityResult> get onConnectivityChanged => Stream.value(result);
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      Stream.value(results);
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- remove unused connectivity_plus import
- update fake connectivity mock for new multi-result API
- add connectivity_plus_platform_interface dev dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d791183708320b6341fa9b2c89308