### PR TITLE
Add context.mounted checks after biometric verification

### DIFF
--- a/lib/modules/noyau/screens/login_screen.dart
+++ b/lib/modules/noyau/screens/login_screen.dart
@@ -34,12 +34,15 @@ class LoginScreenState extends State<LoginScreen> {
 
     final auth = Provider.of<UserProvider>(context, listen: false).authService;
     if (!await auth.verifyBiometric()) {
+      if (!context.mounted) return;
       setState(() {
         _errorMessage = "Authentification biométrique requise.";
         _isLoading = false;
       });
       return;
     }
+
+    if (!context.mounted) return;
 
     final success = await Provider.of<UserProvider>(context, listen: false)
         .signInWithEmail(
@@ -71,12 +74,15 @@ class LoginScreenState extends State<LoginScreen> {
 
     final auth = Provider.of<UserProvider>(context, listen: false).authService;
     if (!await auth.verifyBiometric()) {
+      if (!context.mounted) return;
       setState(() {
         _errorMessage = "Authentification biométrique requise.";
         _isLoading = false;
       });
       return;
     }
+
+    if (!context.mounted) return;
 
     final success = await Provider.of<UserProvider>(context, listen: false)
         .signInWithGoogle();
@@ -105,12 +111,15 @@ class LoginScreenState extends State<LoginScreen> {
 
     final auth = Provider.of<UserProvider>(context, listen: false).authService;
     if (!await auth.verifyBiometric()) {
+      if (!context.mounted) return;
       setState(() {
         _errorMessage = "Authentification biométrique requise.";
         _isLoading = false;
       });
       return;
     }
+
+    if (!context.mounted) return;
 
     final success = await Provider.of<UserProvider>(context, listen: false)
         .signInWithApple();

--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -50,11 +50,13 @@ class ShareScreen extends StatelessWidget {
             onPressed: () async {
               final auth = Provider.of<UserProvider>(context, listen: false).authService;
               if (!await auth.verifyBiometric()) {
+                if (!context.mounted) return;
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Vérification biométrique échouée')),
                 );
                 return;
               }
+              if (!context.mounted) return;
               // Action d'export future
               ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                 content: Text("Export IA à venir"),


### PR DESCRIPTION
## Summary
- ensure widget is still mounted after biometric auth in login flow
- guard share screen context before using ScaffoldMessenger

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d790f7e5483209a444b45d6ffd30e