### PR TITLE
Fix connectivity check for sign out

### DIFF
--- a/lib/modules/noyau/providers/user_provider.dart
+++ b/lib/modules/noyau/providers/user_provider.dart
@@ -107,8 +107,8 @@ class UserProvider with ChangeNotifier {
       }
 
       final connectivity = await Connectivity().checkConnectivity();
-      if (connectivity == ConnectivityResult.wifi ||
-          connectivity == ConnectivityResult.mobile) {
+      if (connectivity.contains(ConnectivityResult.wifi) ||
+          connectivity.contains(ConnectivityResult.mobile)) {
         await _authService.signOut();
         debugPrint("✅ Déconnexion Firebase !");
       } else {

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -37,14 +37,15 @@ class MockAuthService extends Mock implements AuthService {}
 class MockUserService extends Mock implements UserService {}
 
 class FakeConnectivityPlatform extends ConnectivityPlatform {
-  ConnectivityResult result;
-  FakeConnectivityPlatform(this.result);
+  List<ConnectivityResult> results;
+  FakeConnectivityPlatform(this.results);
 
   @override
-  Future<ConnectivityResult> checkConnectivity() async => result;
+  Future<List<ConnectivityResult>> checkConnectivity() async => results;
 
   @override
-  Stream<ConnectivityResult> get onConnectivityChanged => Stream.value(result);
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      Stream.value(results);
 }
 
 void main() {
@@ -88,7 +89,7 @@ void main() {
     expect(provider.user, isNotNull);
 
     ConnectivityPlatform.instance =
-        FakeConnectivityPlatform(ConnectivityResult.wifi);
+        FakeConnectivityPlatform([ConnectivityResult.wifi]);
     await provider.signOut();
     expect(service.initCalled, isTrue);
     expect(service.deleteCalled, isTrue);
@@ -126,7 +127,7 @@ void main() {
 
     await provider.updateUser(user);
     ConnectivityPlatform.instance =
-        FakeConnectivityPlatform(ConnectivityResult.wifi);
+        FakeConnectivityPlatform([ConnectivityResult.wifi]);
     await provider.signOut();
 
     verify(mockService.init()).called(1);
@@ -166,7 +167,7 @@ void main() {
 
     await provider.updateUser(user);
     ConnectivityPlatform.instance =
-        FakeConnectivityPlatform(ConnectivityResult.none);
+        FakeConnectivityPlatform([ConnectivityResult.none]);
     await provider.signOut();
 
     verify(mockService.init()).called(1);


### PR DESCRIPTION
## Summary
- update `UserProvider.signOut` to match the new `checkConnectivity` API
- adapt unit tests to expect a list of `ConnectivityResult`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d790ec0548320b9efbcf3382852e7