### PR TITLE
Fix tests for flutter analyze

### DIFF
--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -93,9 +93,9 @@ void main() {
 
   test('pushAnimalData queues task on failure', () async {
     final mock = MockFirebaseService();
-    when(mock.saveAnimal(any<AnimalModel>(),
-            forTraining: anyNamed<bool>('forTraining')))
-        .thenAnswer((_) async => throw Exception('fail'));
+    expect(mock, isNotNull); // FIXED: flutter analyze
+    when(mock.saveAnimal(any<AnimalModel>(), forTraining: true))
+        .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
     final service = CloudSyncService(firebaseService: mock);
     final animal = AnimalModel(
       id: 'a1',
@@ -118,14 +118,13 @@ void main() {
 
   test('replayOfflineTasks flushes queued tasks', () async {
     final failing = MockFirebaseService();
-    when(failing.saveAnimal(any<AnimalModel>(),
-            forTraining: anyNamed<bool>('forTraining')))
-        .thenAnswer((_) async => throw Exception('fail'));
-    when(failing.saveUser(any<UserModel>(),
-            forTraining: anyNamed<bool>('forTraining')))
-        .thenAnswer((_) async => throw Exception('fail'));
+    expect(failing, isNotNull); // FIXED: flutter analyze
+    when(failing.saveAnimal(any<AnimalModel>(), forTraining: true))
+        .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
+    when(failing.saveUser(any<UserModel>(), forTraining: true))
+        .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
     when(failing.sendModuleData(any<String>(), any<Map<String, dynamic>>()))
-        .thenAnswer((_) async => throw Exception('fail'));
+        .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
 
     final service = CloudSyncService(firebaseService: failing);
 
@@ -162,18 +161,18 @@ void main() {
     await service.pushModuleData('demo', {'v': 1});
 
     final success = MockFirebaseService();
-    when(success.saveAnimal(any<AnimalModel>(), forTraining: anyNamed<bool>('forTraining')))
-        .thenAnswer((_) async => true);
-    when(success.saveUser(any<UserModel>(), forTraining: anyNamed<bool>('forTraining')))
-        .thenAnswer((_) async => true);
+    expect(success, isNotNull); // FIXED: flutter analyze
+    when(success.saveAnimal(any<AnimalModel>(), forTraining: true))
+        .thenAnswer((_) async => true); // FIXED: flutter analyze
+    when(success.saveUser(any<UserModel>(), forTraining: true))
+        .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(success.sendModuleData(any<String>(), any<Map<String, dynamic>>())).thenAnswer((_) async {});
 
     final replay = CloudSyncService(firebaseService: success);
     await replay.replayOfflineTasks();
 
-    verify(success.saveAnimal(any<AnimalModel>(), forTraining: anyNamed<bool>('forTraining')))
-        .called(1);
-    verify(success.saveUser(any<UserModel>(), forTraining: anyNamed<bool>('forTraining'))).called(1);
+    verify(success.saveAnimal(any<AnimalModel>(), forTraining: true)).called(1); // FIXED: flutter analyze
+    verify(success.saveUser(any<UserModel>(), forTraining: true)).called(1); // FIXED: flutter analyze
     verify(success.sendModuleData('demo', any<Map<String, dynamic>>())).called(1);
 
     final remaining = await OfflineSyncQueue.getAllTasks();

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -101,8 +101,8 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any<UserModel>()))
-        .thenAnswer((_) async => true);
+    when(() => mockService.updateUser(any<UserModel>()))
+        .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
     final provider = UserProvider(mockService, mockAuth);
@@ -141,8 +141,8 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any<UserModel>()))
-        .thenAnswer((_) async => true);
+    when(() => mockService.updateUser(any<UserModel>()))
+        .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
     final provider = UserProvider(mockService, mockAuth);


### PR DESCRIPTION
## Summary
- fix `cloud_sync_service_test.dart` by ensuring mocks are not null and removing invalid generics
- fix mock stubs in `user_provider_test.dart`

## Testing
- `flutter analyze` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d7ba007548320b435f4ec390a6bf9