### PR TITLE
Add consent service using Hive

### DIFF
--- a/lib/modules/noyau/services/cgu_manager.dart
+++ b/lib/modules/noyau/services/cgu_manager.dart
@@ -1,0 +1,7 @@
+library;
+
+/// Manages the current Terms of Service (CGU) version.
+class CguManager {
+  /// Latest CGU version accepted by the app.
+  static const String latestVersion = '1.0';
+}

--- a/lib/modules/noyau/services/consent_service.dart
+++ b/lib/modules/noyau/services/consent_service.dart
@@ -1,0 +1,116 @@
+library;
+
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hive/hive.dart';
+
+import 'cgu_manager.dart';
+
+part 'consent_service.g.dart';
+
+@HiveType(typeId: 170)
+class ConsentEntry {
+  @HiveField(0)
+  final String type;
+
+  @HiveField(1)
+  final String module;
+
+  @HiveField(2)
+  final String version;
+
+  @HiveField(3)
+  final String scope;
+
+  @HiveField(4)
+  final String cguVersion;
+
+  @HiveField(5)
+  final DateTime timestamp;
+
+  const ConsentEntry({
+    required this.type,
+    required this.module,
+    required this.version,
+    required this.scope,
+    required this.cguVersion,
+    required this.timestamp,
+  });
+}
+
+class ConsentService {
+  static const _boxName = 'consents';
+  static const _secureKeyName = 'hive_aes_key';
+  static const _secureStorage = FlutterSecureStorage();
+
+  static HiveAesCipher? _cipher;
+  static Box<ConsentEntry>? _box;
+
+  static Future<HiveAesCipher> _getCipher() async {
+    if (_cipher != null) return _cipher!;
+    final stored = await _secureStorage.read(key: _secureKeyName);
+    List<int> key;
+    if (stored == null) {
+      key = Hive.generateSecureKey();
+      await _secureStorage.write(key: _secureKeyName, value: base64UrlEncode(key));
+    } else {
+      key = base64Url.decode(stored);
+    }
+    _cipher = HiveAesCipher(key);
+    return _cipher!;
+  }
+
+  static Future<Box<ConsentEntry>> _openBox() async {
+    if (_box?.isOpen ?? false) return _box!;
+    final cipher = await _getCipher();
+    if (!Hive.isAdapterRegistered(ConsentEntryAdapter().typeId)) {
+      Hive.registerAdapter(ConsentEntryAdapter());
+    }
+    _box = await Hive.openBox<ConsentEntry>(_boxName, encryptionCipher: cipher);
+    return _box!;
+  }
+
+  /// Save a consent entry with the latest CGU version.
+  static Future<void> recordConsent(
+    String type,
+    String module,
+    String version,
+    String scope,
+  ) async {
+    final box = await _openBox();
+    final entry = ConsentEntry(
+      type: type,
+      module: module,
+      version: version,
+      scope: scope,
+      cguVersion: CguManager.latestVersion,
+      timestamp: DateTime.now(),
+    );
+    await box.put('${type}_${module}', entry);
+    debugPrint('✅ Consent recorded: $type - $module');
+  }
+
+  /// Check if consent exists for given type and module.
+  static Future<bool> hasConsent(String type, String module) async {
+    final box = await _openBox();
+    final entry = box.get('${type}_${module}');
+    return entry != null && entry.cguVersion == CguManager.latestVersion;
+  }
+
+  /// Revoke consent and optionally delete related data.
+  static Future<void> revokeConsent(
+    String type,
+    String module, {
+    Future<void> Function()? onDelete,
+  }) async {
+    final box = await _openBox();
+    await box.delete('${type}_${module}');
+    debugPrint('🚫 Consent revoked: $type - $module');
+    if (onDelete != null) {
+      await onDelete();
+    }
+  }
+}
+
+// TODO: ajouter test

--- a/lib/modules/noyau/services/consent_service.g.dart
+++ b/lib/modules/noyau/services/consent_service.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'consent_service.dart';
+
+class ConsentEntryAdapter extends TypeAdapter<ConsentEntry> {
+  @override
+  final int typeId = 170;
+
+  @override
+  ConsentEntry read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ConsentEntry(
+      type: fields[0] as String,
+      module: fields[1] as String,
+      version: fields[2] as String,
+      scope: fields[3] as String,
+      cguVersion: fields[4] as String,
+      timestamp: fields[5] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ConsentEntry obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.type)
+      ..writeByte(1)
+      ..write(obj.module)
+      ..writeByte(2)
+      ..write(obj.version)
+      ..writeByte(3)
+      ..write(obj.scope)
+      ..writeByte(4)
+      ..write(obj.cguVersion)
+      ..writeByte(5)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsentEntryAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/test/noyau/unit/consent_service_test.dart
+++ b/test/noyau/unit/consent_service_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import '../../test_config.dart';
+
+void main() {
+  const keyName = 'hive_aes_key';
+  const secureStorage = FlutterSecureStorage();
+  late Directory tempDir;
+
+  setUp(() async {
+    await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await secureStorage.delete(key: keyName);
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('consents');
+    await tempDir.delete(recursive: true);
+    await secureStorage.delete(key: keyName);
+  });
+
+  test('record and revoke consent', () async {
+    await ConsentService.recordConsent('gps', 'noyau', '1.0', 'location');
+    final has = await ConsentService.hasConsent('gps', 'noyau');
+    expect(has, isTrue);
+
+    var box = await Hive.openBox('consents');
+    expect(box.length, 1);
+
+    await ConsentService.revokeConsent('gps', 'noyau');
+    final hasAfter = await ConsentService.hasConsent('gps', 'noyau');
+    expect(hasAfter, isFalse);
+    box = await Hive.openBox('consents');
+    expect(box.isEmpty, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add `CguManager` to provide latest CGU version
- implement new `ConsentService` with Hive encrypted storage
- generate adapter for `ConsentEntry`
- create unit test skeleton for `ConsentService`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684daaffb4b88320962f4078d8932909