### PR TITLE
Add CGU manager service

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -38,6 +38,7 @@
 | test/noyau/unit/offline_sync_queue_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.dart | ✅ |
 | test/noyau/unit/storage_sync_queue_test.dart | unit | package:anisphere/modules/noyau/storage/storage_sync_queue.dart | ✅ |
 | test/noyau/unit/firebase_service_test.dart | unit | package:anisphere/modules/noyau/services/firebase_service.dart | ✅ |
+| test/noyau/unit/cgu_manager_test.dart | unit | package:anisphere/modules/noyau/services/cgu_manager.dart | ✅ |
 | test/noyau/unit/cloud_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_sync_service.dart | ✅ |
 | test/noyau/unit/cloud_drive_service_test.dart | unit | package:anisphere/modules/noyau/services/cloud_drive_service.dart | ✅ |
 | test/noyau/unit/biometric_service_test.dart | unit | package:anisphere/modules/noyau/services/biometric_service.dart | ✅ |

--- a/lib/modules/noyau/screens/legal_screen.dart
+++ b/lib/modules/noyau/screens/legal_screen.dart
@@ -1,0 +1,26 @@
+library;
+
+import 'package:flutter/material.dart';
+import '../services/cgu_manager.dart';
+
+/// Écran affichant les CGU et la politique de confidentialité.
+/// Simple placeholder pour acceptation des versions actuelles.
+class LegalScreen extends StatelessWidget {
+  const LegalScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('CGU & Confidentialité')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () async {
+            await CguManager().acceptCurrent();
+            Navigator.of(context).pop();
+          },
+          child: const Text("J'accepte"),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/services/cgu_manager.dart
+++ b/lib/modules/noyau/services/cgu_manager.dart
@@ -1,0 +1,68 @@
+// Service de gestion des versions CGU et Politique de confidentialité.
+// Lit les versions depuis le stockage local ou Firebase Remote Config.
+// Forcera l'affichage de LegalScreen si l'utilisateur n'a pas accepté
+// la dernière version disponible.
+library;
+
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'local_storage_service.dart';
+import '../screens/legal_screen.dart';
+import 'navigation_service.dart';
+
+class CguManager {
+  static const _acceptedCguKey = 'accepted_cgu_version';
+  static const _acceptedPrivacyKey = 'accepted_privacy_version';
+
+  static const _remoteCguKey = 'cgu_version';
+  static const _remotePrivacyKey = 'privacy_version';
+
+  final FirebaseRemoteConfig _remoteConfig;
+
+  CguManager({FirebaseRemoteConfig? remoteConfig})
+      : _remoteConfig = remoteConfig ?? FirebaseRemoteConfig.instance;
+
+  Future<String> _getVersion(String remoteKey) async {
+    try {
+      await _remoteConfig.setDefaults({remoteKey: '1'});
+      await _remoteConfig.fetchAndActivate();
+      final value = _remoteConfig.getString(remoteKey);
+      if (value.isNotEmpty) {
+        await LocalStorageService.set(remoteKey, value);
+        return value;
+      }
+    } catch (e) {
+      debugPrint('❌ RemoteConfig $remoteKey: $e');
+    }
+    return LocalStorageService.get(remoteKey, defaultValue: '1') as String;
+  }
+
+  Future<String> get currentCguVersion => _getVersion(_remoteCguKey);
+  Future<String> get currentPrivacyVersion => _getVersion(_remotePrivacyKey);
+
+  Future<void> acceptCurrent() async {
+    final cgu = await currentCguVersion;
+    final privacy = await currentPrivacyVersion;
+    await LocalStorageService.set(_acceptedCguKey, cgu);
+    await LocalStorageService.set(_acceptedPrivacyKey, privacy);
+  }
+
+  Future<void> ensureLatestAccepted() async {
+    final acceptedCgu =
+        LocalStorageService.get(_acceptedCguKey, defaultValue: '') as String;
+    final acceptedPrivacy =
+        LocalStorageService.get(_acceptedPrivacyKey, defaultValue: '') as String;
+    final cgu = await currentCguVersion;
+    final privacy = await currentPrivacyVersion;
+
+    if (acceptedCgu != cgu || acceptedPrivacy != privacy) {
+      if (NavigationService.context != null) {
+        await NavigationService.push(const LegalScreen());
+      } else {
+        debugPrint('❌ Navigation context indisponible pour LegalScreen');
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   cloud_firestore: ^5.6.9
   firebase_storage: ^12.4.7
   firebase_messaging: ^15.2.7
+  firebase_remote_config: ^5.4.5
   firebase_data_connect: ^0.1.5+1
   uuid: ^4.0.0
 

--- a/test/noyau/unit/cgu_manager_test.dart
+++ b/test/noyau/unit/cgu_manager_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mockito/mockito.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+
+import 'package:anisphere/modules/noyau/services/cgu_manager.dart';
+import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
+import 'package:anisphere/modules/noyau/screens/legal_screen.dart';
+import 'package:anisphere/modules/noyau/services/navigation_service.dart';
+
+import '../../test_config.dart';
+
+class MockRemoteConfig extends Mock implements FirebaseRemoteConfig {}
+
+void main() {
+  late Directory tempDir;
+  late MockRemoteConfig mockConfig;
+
+  setUpAll(() async {
+    await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await LocalStorageService.init();
+  });
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk('users');
+    await Hive.deleteBoxFromDisk('animals');
+    await Hive.deleteBoxFromDisk('settings');
+    await tempDir.delete(recursive: true);
+  });
+
+  setUp(() {
+    mockConfig = MockRemoteConfig();
+    when(mockConfig.setDefaults(any)).thenAnswer((_) async {});
+    when(mockConfig.fetchAndActivate()).thenAnswer((_) async => true);
+    when(mockConfig.getString('cgu_version')).thenReturn('2');
+    when(mockConfig.getString('privacy_version')).thenReturn('3');
+  });
+
+  test('acceptCurrent stores versions from Remote Config', () async {
+    final manager = CguManager(remoteConfig: mockConfig);
+
+    await manager.acceptCurrent();
+
+    expect(LocalStorageService.get('accepted_cgu_version'), '2');
+    expect(LocalStorageService.get('accepted_privacy_version'), '3');
+  });
+
+  testWidgets('ensureLatestAccepted navigates to LegalScreen when outdated',
+      (tester) async {
+    await LocalStorageService.set('accepted_cgu_version', '1');
+    await LocalStorageService.set('accepted_privacy_version', '1');
+
+    final manager = CguManager(remoteConfig: mockConfig);
+
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: NavigationService.navigatorKey,
+      home: const SizedBox(),
+    ));
+
+    await manager.ensureLatestAccepted();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LegalScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `CguManager` to check CGU & privacy policy versions via Remote Config
- provide `ensureLatestAccepted` and `acceptCurrent`
- add placeholder `LegalScreen`
- include unit tests
- register `firebase_remote_config` dependency
- update `test_tracker.md`

## Testing
- `flutter test test/noyau/unit/cgu_manager_test.dart -r compact` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dab019528832088f54315bc2c8c6f