### PR TITLE
Add legal screen with consent management

### DIFF
--- a/lib/modules/noyau/models/consent_entry.dart
+++ b/lib/modules/noyau/models/consent_entry.dart
@@ -1,0 +1,58 @@
+library;
+
+import 'package:hive/hive.dart';
+
+part 'consent_entry.g.dart';
+
+@HiveType(typeId: 60)
+enum ConsentAction {
+  @HiveField(0)
+  accepted,
+  @HiveField(1)
+  declined,
+  @HiveField(2)
+  exportRequested,
+  @HiveField(3)
+  deletionRequested,
+}
+
+@HiveType(typeId: 61)
+class ConsentEntry {
+  @HiveField(0)
+  final String id;
+  @HiveField(1)
+  final String userId;
+  @HiveField(2)
+  final ConsentAction action;
+  @HiveField(3)
+  final DateTime timestamp;
+
+  const ConsentEntry({
+    required this.id,
+    required this.userId,
+    required this.action,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'userId': userId,
+        'action': action.name,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory ConsentEntry.fromJson(Map<String, dynamic> json) {
+    ConsentAction act;
+    try {
+      act = ConsentAction.values.firstWhere((a) => a.name == json['action']);
+    } catch (_) {
+      act = ConsentAction.accepted;
+    }
+    return ConsentEntry(
+      id: json['id'] ?? '',
+      userId: json['userId'] ?? '',
+      action: act,
+      timestamp: DateTime.tryParse(json['timestamp'] ?? '') ?? DateTime.now(),
+    );
+  }
+}

--- a/lib/modules/noyau/models/consent_entry.g.dart
+++ b/lib/modules/noyau/models/consent_entry.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'consent_entry.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class ConsentActionAdapter extends TypeAdapter<ConsentAction> {
+  @override
+  final int typeId = 60;
+
+  @override
+  ConsentAction read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return ConsentAction.accepted;
+      case 1:
+        return ConsentAction.declined;
+      case 2:
+        return ConsentAction.exportRequested;
+      case 3:
+        return ConsentAction.deletionRequested;
+      default:
+        return ConsentAction.accepted;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, ConsentAction obj) {
+    switch (obj) {
+      case ConsentAction.accepted:
+        writer.writeByte(0);
+        break;
+      case ConsentAction.declined:
+        writer.writeByte(1);
+        break;
+      case ConsentAction.exportRequested:
+        writer.writeByte(2);
+        break;
+      case ConsentAction.deletionRequested:
+        writer.writeByte(3);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsentActionAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ConsentEntryAdapter extends TypeAdapter<ConsentEntry> {
+  @override
+  final int typeId = 61;
+
+  @override
+  ConsentEntry read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ConsentEntry(
+      id: fields[0] as String,
+      userId: fields[1] as String,
+      action: fields[2] as ConsentAction,
+      timestamp: fields[3] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ConsentEntry obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.userId)
+      ..writeByte(2)
+      ..write(obj.action)
+      ..writeByte(3)
+      ..write(obj.timestamp);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsentEntryAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/modules/noyau/providers/consent_provider.dart
+++ b/lib/modules/noyau/providers/consent_provider.dart
@@ -1,0 +1,36 @@
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../models/consent_entry.dart';
+import '../services/consent_service.dart';
+
+class ConsentProvider with ChangeNotifier {
+  final ConsentService _service;
+  List<ConsentEntry> _history = [];
+
+  List<ConsentEntry> get history => _history;
+  ConsentEntry? get lastEntry => _history.isNotEmpty ? _history.last : null;
+
+  bool get accepted => lastEntry?.action == ConsentAction.accepted;
+
+  ConsentProvider({ConsentService? service})
+      : _service = service ?? ConsentService();
+
+  Future<void> loadHistory() async {
+    _history = await _service.getHistory();
+    notifyListeners();
+  }
+
+  Future<void> addAction(ConsentAction action, String userId) async {
+    final entry = ConsentEntry(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      userId: userId,
+      action: action,
+      timestamp: DateTime.now(),
+    );
+    await _service.addEntry(entry);
+    _history.add(entry);
+    notifyListeners();
+  }
+}

--- a/lib/modules/noyau/screens/legal_screen.dart
+++ b/lib/modules/noyau/screens/legal_screen.dart
@@ -1,0 +1,137 @@
+// TODO: ajouter test
+library;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/consent_provider.dart';
+import '../providers/user_provider.dart';
+
+class LegalScreen extends StatefulWidget {
+  const LegalScreen({super.key});
+
+  @override
+  State<LegalScreen> createState() => _LegalScreenState();
+}
+
+class _LegalScreenState extends State<LegalScreen> {
+  Future<void> _accept() async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+    await Provider.of<ConsentProvider>(context, listen: false)
+        .addAction(ConsentAction.accepted, user.id);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  Future<void> _decline() async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+    await Provider.of<ConsentProvider>(context, listen: false)
+        .addAction(ConsentAction.declined, user.id);
+    if (!mounted) return;
+    Navigator.of(context).pop(false);
+  }
+
+  Future<void> _requestExport() async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+    await Provider.of<ConsentProvider>(context, listen: false)
+        .addAction(ConsentAction.exportRequested, user.id);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Demande d\'export envoy\u00e9e.')),
+    );
+  }
+
+  Future<void> _requestDeletion() async {
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user == null) return;
+    await Provider.of<ConsentProvider>(context, listen: false)
+        .addAction(ConsentAction.deletionRequested, user.id);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Demande de suppression envoy\u00e9e.')),
+    );
+  }
+
+  void _showHistory() {
+    final history =
+        Provider.of<ConsentProvider>(context, listen: false).history;
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Historique des consentements'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: history.length,
+            itemBuilder: (_, i) {
+              final entry = history[i];
+              return ListTile(
+                title: Text(entry.action.name),
+                subtitle: Text(entry.timestamp.toLocal().toString()),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Fermer'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('CGU & Confidentialit\u00e9')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            const Text(
+              'Conditions g\u00e9n\u00e9rales d\'utilisation',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            const Text('Voici les derni\u00e8res CGU...'),
+            const SizedBox(height: 24),
+            const Text(
+              'Politique de confidentialit\u00e9',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            const Text('Voici la politique de confidentialit\u00e9...'),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _accept,
+              child: const Text('Accepter'),
+            ),
+            ElevatedButton(
+              onPressed: _decline,
+              child: const Text('Refuser'),
+            ),
+            const Divider(height: 32),
+            ElevatedButton(
+              onPressed: _showHistory,
+              child: const Text('Voir l\'historique des consentements'),
+            ),
+            ElevatedButton(
+              onPressed: _requestExport,
+              child: const Text('Demander l\'export de mes donn\u00e9es'),
+            ),
+            ElevatedButton(
+              onPressed: _requestDeletion,
+              child: const Text('Demander la suppression de mes donn\u00e9es'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/services/consent_service.dart
+++ b/lib/modules/noyau/services/consent_service.dart
@@ -1,0 +1,57 @@
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../models/consent_entry.dart';
+
+class ConsentService {
+  static const String consentBoxName = 'consent_history';
+  Box<ConsentEntry>? _box;
+  final bool skipHiveInit;
+
+  ConsentService({Box<ConsentEntry>? testBox, this.skipHiveInit = false}) {
+    if (testBox != null) _box = testBox;
+  }
+
+  Future<void> init() async {
+    await _initHive();
+  }
+
+  Future<void> _initHive() async {
+    if (skipHiveInit || _box != null) return;
+    try {
+      _box = Hive.isBoxOpen(consentBoxName)
+          ? Hive.box<ConsentEntry>(consentBoxName)
+          : await Hive.openBox<ConsentEntry>(consentBoxName);
+      _log('📦 Boîte consent initialisée');
+    } catch (e) {
+      _log('❌ Erreur init Hive consent : $e');
+    }
+  }
+
+  Future<void> addEntry(ConsentEntry entry) async {
+    try {
+      await _initHive();
+      await _box?.put(entry.id, entry);
+    } catch (e) {
+      _log('❌ Erreur addEntry : $e');
+    }
+  }
+
+  Future<List<ConsentEntry>> getHistory() async {
+    try {
+      await _initHive();
+      return _box?.values.toList() ?? [];
+    } catch (e) {
+      _log('❌ Erreur getHistory : $e');
+      return [];
+    }
+  }
+
+  void _log(String m) {
+    if (kDebugMode) {
+      debugPrint('[ConsentService] $m');
+    }
+  }
+}

--- a/test/noyau/unit/consent_service_test.dart
+++ b/test/noyau/unit/consent_service_test.dart
@@ -1,0 +1,31 @@
+// Copilot Prompt : Test automatique pour consent_service.dart (unit)
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:mockito/mockito.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import 'package:anisphere/modules/noyau/models/consent_entry.dart';
+
+class MockBox extends Mock implements Box<ConsentEntry> {}
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('addEntry stores entry in Hive box', () async {
+    final mockBox = MockBox();
+    final service = ConsentService(testBox: mockBox, skipHiveInit: true);
+
+    final entry = ConsentEntry(
+      id: 'e1',
+      userId: 'u1',
+      action: ConsentAction.accepted,
+      timestamp: DateTime.now(),
+    );
+
+    await service.addEntry(entry);
+
+    verify(mockBox.put('e1', entry)).called(1);
+  });
+}

--- a/test/noyau/widget/legal_screen_test.dart
+++ b/test/noyau/widget/legal_screen_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/models/consent_entry.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
+import 'package:anisphere/modules/noyau/providers/consent_provider.dart';
+import 'package:anisphere/modules/noyau/providers/user_provider.dart';
+import 'package:anisphere/modules/noyau/screens/legal_screen.dart';
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:anisphere/modules/noyau/services/auth_service.dart';
+
+class _TestConsentProvider extends ConsentProvider {
+  ConsentAction? last;
+  _TestConsentProvider(ConsentService service) : super(service: service);
+  @override
+  Future<void> addAction(ConsentAction action, String userId) async {
+    last = action;
+  }
+}
+
+class _TestUserProvider extends UserProvider {
+  final UserModel? _testUser;
+  _TestUserProvider(this._testUser)
+      : super(UserService(skipHiveInit: true), AuthService());
+  @override
+  UserModel? get user => _testUser;
+}
+
+void main() {
+  late Directory tempDir;
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(ConsentEntryAdapter());
+    Hive.registerAdapter(ConsentActionAdapter());
+    await Hive.openBox<ConsentEntry>('consent_history');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('consent_history');
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('accept button records consent', (tester) async {
+    final service = ConsentService(
+      testBox: Hive.box<ConsentEntry>('consent_history'),
+      skipHiveInit: true,
+    );
+    final consentProvider = _TestConsentProvider(service);
+    final user = UserModel(
+      id: 'u1',
+      name: 'Test',
+      email: 't@test.com',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+    final userProvider = _TestUserProvider(user);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<UserProvider>.value(value: userProvider),
+          ChangeNotifierProvider<ConsentProvider>.value(value: consentProvider),
+        ],
+        child: const MaterialApp(home: LegalScreen()),
+      ),
+    );
+
+    await tester.tap(find.text('Accepter'));
+    await tester.pumpAndSettle();
+
+    expect(consentProvider.last, ConsentAction.accepted);
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -32,6 +32,7 @@
 | test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | ✅ |
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | ✅ |
+| test/noyau/unit/consent_service_test.dart | unit | package:anisphere/modules/noyau/services/consent_service.dart | ✅ |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | ✅ |
 | test/noyau/unit/ia_sync_service_test.dart | unit | package:anisphere/modules/noyau/services/ia_sync_service.dart | ✅ |
 | test/noyau/unit/cloud_notification_listener_test.dart | unit | package:anisphere/modules/noyau/services/cloud_notification_listener.dart | ✅ |
@@ -76,6 +77,7 @@
 | test/noyau/widget/animal_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_screen.dart | ✅ |
 | test/noyau/widget/animals_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animals_screen.dart | ✅ |
 | test/noyau/widget/login_screen_test.dart | widget | package:anisphere/modules/noyau/screens/login_screen.dart | ✅ |
+| test/noyau/widget/legal_screen_test.dart | widget | package:anisphere/modules/noyau/screens/legal_screen.dart | ✅ |
 | test/noyau/widget/support_screen_test.dart | widget | package:anisphere/modules/noyau/screens/support_screen.dart | ✅ |
 | test/noyau/widget/register_screen_test.dart | widget | package:anisphere/modules/noyau/screens/register_screen.dart | ✅ |
 | test/noyau/widget/biometric_setup_screen_test.dart | widget | package:anisphere/modules/noyau/screens/biometric_setup_screen.dart | ✅ |


### PR DESCRIPTION
## Summary
- add `ConsentEntry` model and adapters
- create `ConsentService` and provider for consent state
- implement `LegalScreen` to manage CGU & privacy actions
- add unit and widget tests
- track new tests in `test_tracker.md`

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dab02b6c08320a9d412f7bac7cf60