### PR TITLE
Fix consent hooks test

### DIFF
--- a/test/noyau/widget/consent_hooks_test.dart
+++ b/test/noyau/widget/consent_hooks_test.dart
@@ -3,12 +3,16 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/hooks/consent_hooks.dart';
 import 'package:anisphere/modules/noyau/screens/legal_screen.dart';
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import 'package:mockito/mockito.dart';
 
-class FakeConsentService extends ConsentService {
+class FakeConsentService extends Fake implements ConsentService {
   bool has = false;
   bool saved = false;
+
   @override
   Future<bool> hasConsent(String type) async => has;
+
   @override
   Future<void> saveConsent(String type) async {
     saved = true;


### PR DESCRIPTION
## Summary
- import consent service for consent hook tests
- implement `FakeConsentService` with `Fake` from Mockito

## Testing
- `flutter test test/noyau/widget/consent_hooks_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db2e8b7308320843dff1f04614d24