### PR TITLE
Fix legal consent navigation

### DIFF
--- a/lib/modules/noyau/services/cgu_manager.dart
+++ b/lib/modules/noyau/services/cgu_manager.dart
@@ -59,7 +59,9 @@ class CguManager {
 
     if (acceptedCgu != cgu || acceptedPrivacy != privacy) {
       if (NavigationService.context != null) {
-        await NavigationService.push(const LegalScreen());
+        await NavigationService.push(
+          const LegalScreen(consentType: 'general'), // or an enum value
+        );
       } else {
         debugPrint('❌ Navigation context indisponible pour LegalScreen');
       }


### PR DESCRIPTION
## Summary
- pass consent type to `LegalScreen` when launching it

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684db2e99c48832081c52ab4117503d3