### PR TITLE
Update mock expectations in unit tests

### DIFF
--- a/test/noyau/unit/cgu_manager_test.dart
+++ b/test/noyau/unit/cgu_manager_test.dart
@@ -35,7 +35,8 @@ void main() {
 
   setUp(() {
     mockConfig = MockRemoteConfig();
-    when(mockConfig.setDefaults(any)).thenAnswer((_) async {});
+    when(mockConfig.setDefaults(any<Map<String, dynamic>>()))
+        .thenAnswer((_) async {});
     when(mockConfig.fetchAndActivate()).thenAnswer((_) async => true);
     when(mockConfig.getString('cgu_version')).thenReturn('2');
     when(mockConfig.getString('privacy_version')).thenReturn('3');

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(() => mockService.updateUser(any<UserModel>()))
+    when(mockService.updateUser(any<UserModel>()))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
@@ -141,7 +141,7 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(() => mockService.updateUser(any<UserModel>()))
+    when(mockService.updateUser(any<UserModel>()))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 


### PR DESCRIPTION
## Summary
- specify map type when setting remote config defaults in tests
- remove unnecessary mocktail function syntax in user provider tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db2eaadc8832099bf15d7473d47eb