### PR TITLE
Fix consent context mounted check

### DIFF
--- a/lib/modules/noyau/hooks/consent_hooks.dart
+++ b/lib/modules/noyau/hooks/consent_hooks.dart
@@ -12,6 +12,7 @@ ConsentService consentService = ConsentService();
 /// Si ce n'est pas le cas, affiche [LegalScreen] et retourne le résultat.
 Future<bool> ensureConsent(BuildContext context, String type) async {
   final has = await consentService.hasConsent(type);
+  if (!context.mounted) return false;
   if (has) return true;
 
   final accepted = await Navigator.of(context).push<bool>(


### PR DESCRIPTION
## Summary
- check if context is mounted before navigating for consent

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db2ecfad0832092efdc1387d0b339