### PR TITLE
Update ripple theme color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:anisphere/theme.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -137,22 +138,7 @@ class MyApp extends StatelessWidget {
       navigatorKey: NavigationService.navigatorKey,
       title: 'AniSphère',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        scaffoldBackgroundColor: const Color(0xFFF5F5F5),
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF183153),
-          primary: const Color(0xFF183153),
-          secondary: const Color(0xFFFBC02D),
-        ),
-        useMaterial3: true,
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFF183153),
-          foregroundColor: Colors.white,
-        ),
-        textTheme: const TextTheme(
-          bodyMedium: TextStyle(color: Color(0xFF3A3A3A)),
-        ),
-      ),
+      theme: appTheme,
       home: const SplashScreen(),
     );
   }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Application-wide theme settings.
+final ThemeData appTheme = ThemeData(
+  scaffoldBackgroundColor: const Color(0xFFF5F5F5),
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: const Color(0xFF183153),
+    primary: const Color(0xFF183153),
+    secondary: const Color(0xFFFBC02D),
+  ),
+  useMaterial3: true,
+  highlightColor: const Color(0xFFFBC02D),
+  splashColor: const Color(0xFFFBC02D),
+  appBarTheme: const AppBarTheme(
+    backgroundColor: Color(0xFF183153),
+    foregroundColor: Colors.white,
+  ),
+  textTheme: const TextTheme(
+    bodyMedium: TextStyle(color: Color(0xFF3A3A3A)),
+  ),
+);

--- a/test/noyau/widget/splash_screen_test.dart
+++ b/test/noyau/widget/splash_screen_test.dart
@@ -1,14 +1,26 @@
 // Copilot Prompt : Test automatique généré pour splash_screen.dart (widget)
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
+import 'package:anisphere/theme.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('splash_screen fonctionne (test auto)', () {
-    const screen = SplashScreen();
-    expect(screen, isA<SplashScreen>());
+  testWidgets('splash screen uses yellow ripple', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme,
+        home: const SplashScreen(),
+      ),
+    );
+
+    final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    final theme = materialApp.theme!;
+
+    expect(theme.highlightColor, const Color(0xFFFBC02D));
+    expect(theme.splashColor, const Color(0xFFFBC02D));
   });
 }


### PR DESCRIPTION
## Summary
- centralize theming in `lib/theme.dart`
- use the new theme in `main.dart`
- validate highlight and splash colors in `splash_screen_test.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db516eb508320b3adcba25e8414e3