### PR TITLE
Add sharing connectivity and optimizer services

### DIFF
--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -176,6 +176,8 @@ Déclenchée uniquement si nécessaire (action critique, partage, backup cloud)
 Regroupée en lots compressés pour minimiser les accès
 
 Automatiquement différée par l’IA pour éviter les pics ou coûts inutiles
+Gestion dynamique des modes de partage via `SharingConnectivityManager`
+Optimisation des envois par `SharingIaOptimizer` (compression et déduplication)
 
 Données sensibles exclues du cloud (nom, prénom, téléphone)
 

--- a/docs/noyau.md
+++ b/docs/noyau.md
@@ -41,6 +41,8 @@ Partage sécurisé de profils, documents, ou informations animales via QR code, 
 Export de documents : PDF, rapports de santé, arbres généalogiques.
 Traçabilité des actions utilisateur (qui a partagé quoi, quand, et comment).
 Stockage Drive/Dropbox personnel : possibilité pour l’utilisateur de lier son cloud personnel (Google Drive, OneDrive, etc.) pour les exports ou sauvegardes.
+Gestion du mode de partage (offline, local-only, cloud-ready) via `SharingConnectivityManager`.
+Batchs optimisés et compressés grâce au `SharingIaOptimizer`.
 
 f. Notifications & Alertes IA
 

--- a/lib/modules/noyau/services/cloud_sharing_service.dart
+++ b/lib/modules/noyau/services/cloud_sharing_service.dart
@@ -1,0 +1,20 @@
+library;
+// TODO: ajouter test
+
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+
+import 'cloud_sync_service.dart';
+
+class CloudSharingService {
+  final CloudSyncService _syncService;
+
+  CloudSharingService({CloudSyncService? syncService})
+      : _syncService = syncService ?? CloudSyncService();
+
+  Future<void> uploadCompressed(List<int> gzipData) async {
+    final encoded = base64Encode(gzipData);
+    await _syncService.pushModuleData('sharing', {'data': encoded});
+    debugPrint('☁️ Données de partage envoyées au cloud');
+  }
+}

--- a/lib/modules/noyau/services/local_sharing_service.dart
+++ b/lib/modules/noyau/services/local_sharing_service.dart
@@ -1,0 +1,25 @@
+library;
+// TODO: ajouter test
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+class LocalSharingService {
+  static const String _boxName = 'local_sharing_queue';
+
+  Future<void> storeShare(Map<String, dynamic> data) async {
+    final box = await Hive.openBox<Map>(_boxName);
+    await box.add(data);
+    debugPrint('📥 Donnée de partage stockée localement');
+  }
+
+  Future<List<Map<String, dynamic>>> getPendingShares() async {
+    final box = await Hive.openBox<Map>(_boxName);
+    return box.values.map((e) => Map<String, dynamic>.from(e)).toList();
+  }
+
+  Future<void> clear() async {
+    final box = await Hive.openBox<Map>(_boxName);
+    await box.clear();
+  }
+}

--- a/lib/modules/noyau/services/sharing_connectivity_manager.dart
+++ b/lib/modules/noyau/services/sharing_connectivity_manager.dart
@@ -1,0 +1,59 @@
+library;
+
+import 'dart:async';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+
+import 'cloud_sync_service.dart';
+import 'local_sharing_service.dart';
+
+enum SharingMode { offline, localOnly, cloudReady }
+
+class SharingConnectivityManager {
+  final Connectivity _connectivity;
+  final CloudSyncService _cloudSyncService;
+  final LocalSharingService _localSharingService;
+
+  late final StreamSubscription<List<ConnectivityResult>> _sub;
+  final StreamController<SharingMode> _controller = StreamController.broadcast();
+
+  SharingMode _mode = SharingMode.offline;
+  SharingMode get mode => _mode;
+  Stream<SharingMode> get onModeChanged => _controller.stream;
+
+  SharingConnectivityManager({
+    Connectivity? connectivity,
+    CloudSyncService? cloudSyncService,
+    LocalSharingService? localSharingService,
+  })  : _connectivity = connectivity ?? Connectivity(),
+        _cloudSyncService = cloudSyncService ?? CloudSyncService(),
+        _localSharingService = localSharingService ?? LocalSharingService();
+
+  Future<void> init() async {
+    final results = await _connectivity.checkConnectivity();
+    _updateMode(results);
+    _sub = _connectivity.onConnectivityChanged.listen(_updateMode);
+  }
+
+  void _updateMode(List<ConnectivityResult> results) {
+    final connected = results.any((r) => r != ConnectivityResult.none);
+    final wifi = results.contains(ConnectivityResult.wifi);
+    final newMode = !connected
+        ? SharingMode.offline
+        : wifi
+            ? SharingMode.cloudReady
+            : SharingMode.localOnly;
+    if (newMode != _mode) {
+      _mode = newMode;
+      _controller.add(_mode);
+      if (_mode == SharingMode.cloudReady) {
+        _cloudSyncService.replayOfflineTasks();
+      }
+    }
+  }
+
+  void dispose() {
+    _sub.cancel();
+    _controller.close();
+  }
+}

--- a/lib/modules/noyau/services/sharing_ia_optimizer.dart
+++ b/lib/modules/noyau/services/sharing_ia_optimizer.dart
@@ -1,0 +1,64 @@
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'cloud_sharing_service.dart';
+import 'local_sharing_service.dart';
+import 'sharing_connectivity_manager.dart';
+
+class SharingIaOptimizer {
+  final CloudSharingService _cloudService;
+  final LocalSharingService _localService;
+  final SharingConnectivityManager _connectivity;
+  final Set<int> _hashCache = {};
+  StreamSubscription<SharingMode>? _sub;
+
+  SharingIaOptimizer({
+    CloudSharingService? cloudService,
+    LocalSharingService? localService,
+    SharingConnectivityManager? connectivity,
+  })  : _cloudService = cloudService ?? CloudSharingService(),
+        _localService = localService ?? LocalSharingService(),
+        _connectivity = connectivity ?? SharingConnectivityManager();
+
+  Future<void> init() async {
+    await _connectivity.init();
+    _sub = _connectivity.onModeChanged.listen((mode) {
+      if (mode == SharingMode.cloudReady) {
+        processPending();
+      }
+    });
+  }
+
+  Future<void> addData(Map<String, dynamic> data) async {
+    final jsonStr = jsonEncode(data);
+    final hash = jsonStr.hashCode;
+    if (_hashCache.contains(hash)) {
+      debugPrint('⚠️ Donnée en double ignorée');
+      return;
+    }
+    _hashCache.add(hash);
+    await _localService.storeShare(data);
+    if (_connectivity.mode == SharingMode.cloudReady) {
+      await processPending();
+    }
+  }
+
+  Future<void> processPending() async {
+    final entries = await _localService.getPendingShares();
+    for (final entry in entries) {
+      final compressed = gzip.encode(utf8.encode(jsonEncode(entry)));
+      await _cloudService.uploadCompressed(compressed);
+    }
+    await _localService.clear();
+  }
+
+  void dispose() {
+    _sub?.cancel();
+    _connectivity.dispose();
+  }
+}

--- a/test/noyau/unit/sharing_connectivity_manager_test.dart
+++ b/test/noyau/unit/sharing_connectivity_manager_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
+import 'package:anisphere/modules/noyau/services/sharing_connectivity_manager.dart';
+import '../../test_config.dart';
+
+class FakeConnectivityPlatform extends ConnectivityPlatform {
+  final List<ConnectivityResult> results;
+  FakeConnectivityPlatform(this.results);
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async => results;
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => Stream.value(results);
+}
+
+void main() {
+  late ConnectivityPlatform previous;
+
+  setUp(() async {
+    await initTestEnv();
+    previous = ConnectivityPlatform.instance;
+  });
+
+  tearDown(() {
+    ConnectivityPlatform.instance = previous;
+  });
+
+  test('wifi connectivity sets cloudReady mode', () async {
+    ConnectivityPlatform.instance = FakeConnectivityPlatform([ConnectivityResult.wifi]);
+    final manager = SharingConnectivityManager();
+    await manager.init();
+    expect(manager.mode, SharingMode.cloudReady);
+    manager.dispose();
+  });
+
+  test('no connectivity sets offline mode', () async {
+    ConnectivityPlatform.instance = FakeConnectivityPlatform([ConnectivityResult.none]);
+    final manager = SharingConnectivityManager();
+    await manager.init();
+    expect(manager.mode, SharingMode.offline);
+    manager.dispose();
+  });
+}

--- a/test/noyau/unit/sharing_ia_optimizer_test.dart
+++ b/test/noyau/unit/sharing_ia_optimizer_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
+import 'package:anisphere/modules/noyau/services/sharing_connectivity_manager.dart';
+import 'package:anisphere/modules/noyau/services/sharing_ia_optimizer.dart';
+import 'package:anisphere/modules/noyau/services/cloud_sharing_service.dart';
+import 'package:anisphere/modules/noyau/services/local_sharing_service.dart';
+import '../../test_config.dart';
+
+class FakeConnectivityPlatform extends ConnectivityPlatform {
+  final List<ConnectivityResult> results;
+  FakeConnectivityPlatform(this.results);
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async => results;
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged => Stream.value(results);
+}
+
+class FakeCloudSharingService extends CloudSharingService {
+  final List<List<int>> uploads = [];
+  FakeCloudSharingService() : super();
+  @override
+  Future<void> uploadCompressed(List<int> gzipData) async {
+    uploads.add(gzipData);
+  }
+}
+
+void main() {
+  late Directory tempDir;
+  late ConnectivityPlatform previous;
+
+  setUp(() async {
+    await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    previous = ConnectivityPlatform.instance;
+  });
+
+  tearDown(() async {
+    ConnectivityPlatform.instance = previous;
+    await Hive.deleteBoxFromDisk('local_sharing_queue');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('optimizer uploads data when cloudReady', () async {
+    ConnectivityPlatform.instance = FakeConnectivityPlatform([ConnectivityResult.wifi]);
+    final cloud = FakeCloudSharingService();
+    final connectivity = SharingConnectivityManager();
+    final optimizer = SharingIaOptimizer(
+      cloudService: cloud,
+      connectivity: connectivity,
+    );
+    await optimizer.init();
+    await optimizer.addData({'k': 'v'});
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(cloud.uploads.length, 1);
+    optimizer.dispose();
+  });
+
+  test('optimizer ignores duplicate data', () async {
+    ConnectivityPlatform.instance = FakeConnectivityPlatform([ConnectivityResult.wifi]);
+    final cloud = FakeCloudSharingService();
+    final optimizer = SharingIaOptimizer(cloudService: cloud);
+    await optimizer.init();
+    await optimizer.addData({'a': 1});
+    await optimizer.addData({'a': 1});
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(cloud.uploads.length, 1);
+    optimizer.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- add sharing connectivity manager and sharing IA optimizer services
- introduce LocalSharingService and CloudSharingService helpers
- document sync logic for dynamic sharing modes
- write unit tests for new sharing services

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db55c5dfc8320a1058f106e50268f