### PR TITLE
Fix share screen context mount check

### DIFF
--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -71,7 +71,7 @@ class _ShareScreenState extends State<ShareScreen> {
           ElevatedButton(
             onPressed: () async {
               await LocalSharingService().share('default');
-              if (!mounted) return;
+              if (!context.mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(content: Text('Partage local effectué')),
               );
@@ -83,7 +83,7 @@ class _ShareScreenState extends State<ShareScreen> {
             onPressed: isPremium
                 ? () async {
                     await CloudSharingService().share('default');
-                    if (!mounted) return;
+                    if (!context.mounted) return;
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Partage cloud effectué')),
                     );


### PR DESCRIPTION
## Summary
- ensure context is mounted before showing snackbars in Share screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd9210f88320925f0f77021cc15b