### PR TITLE
Remove stale part from consent service

### DIFF
--- a/lib/modules/noyau/services/consent_service.dart
+++ b/lib/modules/noyau/services/consent_service.dart
@@ -8,8 +8,6 @@ import 'package:hive/hive.dart';
 import '../models/consent_entry.dart';
 import 'local_storage_service.dart';
 
-part 'consent_service.g.dart';
-
 class ConsentService {
   static const _boxName = 'consent_history';
   Box<ConsentEntry>? _box;


### PR DESCRIPTION
## Summary
- clean up `ConsentService` by removing leftover generated part

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd9285948320aa87a4d044e0c409