### PR TITLE
Implement sharing queue services

### DIFF
--- a/lib/modules/noyau/services/cloud_sharing_service.dart
+++ b/lib/modules/noyau/services/cloud_sharing_service.dart
@@ -1,15 +1,26 @@
 library;
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 
 import '../models/share_history_model.dart';
 import 'share_history_service.dart';
+import 'premium_sharing_checker.dart';
+import 'cloud_drive_service.dart';
 
 class CloudSharingService {
   final ShareHistoryService _historyService;
+  final PremiumSharingChecker _checker;
+  final CloudDriveService _driveService;
 
-  CloudSharingService({ShareHistoryService? historyService})
-      : _historyService = historyService ?? ShareHistoryService();
+  CloudSharingService({
+    ShareHistoryService? historyService,
+    PremiumSharingChecker? checker,
+    CloudDriveService? driveService,
+  })  : _historyService = historyService ?? ShareHistoryService(),
+        _checker = checker ?? PremiumSharingChecker(),
+        _driveService = driveService ?? CloudDriveService();
 
   Future<void> share(String data, {double cost = 0}) async {
     try {
@@ -33,5 +44,45 @@ class CloudSharingService {
         ),
       );
     }
+  }
+
+  /// Upload une donnée compressée en GZip vers le cloud.
+  Future<void> uploadCompressed(List<int> gzipData) async {
+    final tmp = File(
+        '${Directory.systemTemp.path}/share_${DateTime.now().millisecondsSinceEpoch}.gz');
+    await tmp.writeAsBytes(gzipData);
+    await uploadFile(tmp, useWebDav: true);
+    await tmp.delete();
+  }
+
+  /// Upload un fichier et retourne son URL si succès.
+  Future<String?> uploadFile(File file, {bool useWebDav = false}) async {
+    if (!_checker.canUseCloudSharing()) {
+      return null;
+    }
+    try {
+      final success = await _driveService.uploadFile(file);
+      await _historyService.addEntry(
+        ShareHistoryModel(
+          mode: 'cloud_file',
+          date: DateTime.now(),
+          success: success,
+        ),
+      );
+      if (success) {
+        final name = file.uri.pathSegments.last;
+        return 'https://example.com/$name';
+      }
+    } catch (e) {
+      await _historyService.addEntry(
+        ShareHistoryModel(
+          mode: 'cloud_file',
+          date: DateTime.now(),
+          success: false,
+          feedback: e.toString(),
+        ),
+      );
+    }
+    return null;
   }
 }

--- a/lib/modules/noyau/services/local_sharing_service.dart
+++ b/lib/modules/noyau/services/local_sharing_service.dart
@@ -1,12 +1,18 @@
 library;
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
 
 import '../models/share_history_model.dart';
 import 'share_history_service.dart';
+import 'qr_service.dart';
 
 class LocalSharingService {
   final ShareHistoryService _historyService;
+  static const String _boxName = 'local_sharing_queue';
 
   LocalSharingService({ShareHistoryService? historyService})
       : _historyService = historyService ?? ShareHistoryService();
@@ -31,5 +37,37 @@ class LocalSharingService {
         ),
       );
     }
+  }
+
+  /// Génère un QR code pour partager localement [data].
+  Widget shareViaQR(String data) {
+    return QRService.generateQRCode(data);
+  }
+
+  Future<Box<Map>> _openBox() async {
+    if (Hive.isBoxOpen(_boxName)) {
+      return Hive.box<Map>(_boxName);
+    }
+    return await Hive.openBox<Map>(_boxName);
+  }
+
+  /// Stocke un partage en attente d'envoi cloud.
+  Future<void> storeShare(Map<String, dynamic> data) async {
+    final box = await _openBox();
+    await box.add(data);
+  }
+
+  /// Récupère les partages en attente.
+  Future<List<Map<String, dynamic>>> getPendingShares() async {
+    final box = await _openBox();
+    return box.values
+        .map((e) => Map<String, dynamic>.from(e as Map))
+        .toList();
+  }
+
+  /// Vide la file de partage local.
+  Future<void> clear() async {
+    final box = await _openBox();
+    await box.clear();
   }
 }


### PR DESCRIPTION
## Summary
- add pending share queue logic in `LocalSharingService`
- support QR generation for local sharing
- extend `CloudSharingService` with file upload helpers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd93495483209958a2f4bcd4477f