### PR TITLE
Fix _connectivityFuture creation

### DIFF
--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -30,7 +30,7 @@ class _ShareScreenState extends State<ShareScreen> {
     super.initState();
     _historyFuture = _historyService.getEntries();
     _connectivityFuture =
-        Connectivity().checkConnectivity().then((r) => [...[r]]);
+        Connectivity().checkConnectivity().then((r) => [r]);
   }
 
   Future<void> _refreshHistory() async {


### PR DESCRIPTION
## Summary
- fix ShareScreen connectivity future to return `List<ConnectivityResult>` directly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2aa64c083209f1522b5ffc8a11e