### PR TITLE
Fix local sharing service mapping

### DIFF
--- a/lib/modules/noyau/services/local_sharing_service.dart
+++ b/lib/modules/noyau/services/local_sharing_service.dart
@@ -2,7 +2,6 @@ library;
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
@@ -61,7 +60,7 @@ class LocalSharingService {
   Future<List<Map<String, dynamic>>> getPendingShares() async {
     final box = await _openBox();
     return box.values
-        .map((e) => Map<String, dynamic>.from(e as Map))
+        .map((e) => Map<String, dynamic>.from(e))
         .toList();
   }
 


### PR DESCRIPTION
## Summary
- remove redundant `foundation.dart` import
- fix map cast in `getPendingShares`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2acab048320975c336d8fc1be13