### PR TITLE
Fix mock argument matchers

### DIFF
--- a/test/noyau/unit/cgu_manager_test.dart
+++ b/test/noyau/unit/cgu_manager_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   setUp(() {
     mockConfig = MockRemoteConfig();
-    when(mockConfig.setDefaults(any<Map<String, dynamic>>()))
+    when(mockConfig.setDefaults(argThat(isA<Map<String, dynamic>>())))
         .thenAnswer((_) async {});
     when(mockConfig.fetchAndActivate()).thenAnswer((_) async => true);
     when(mockConfig.getString('cgu_version')).thenReturn('2');

--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -123,7 +123,8 @@ void main() {
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
     when(failing.saveUser(any<UserModel>(), forTraining: true))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
-    when(failing.sendModuleData(any<String>(), any<Map<String, dynamic>>()))
+    when(failing.sendModuleData(any<String>(),
+            argThat(isA<Map<String, dynamic>>())))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
 
     final service = CloudSyncService(firebaseService: failing);
@@ -166,14 +167,17 @@ void main() {
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(success.saveUser(any<UserModel>(), forTraining: true))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
-    when(success.sendModuleData(any<String>(), any<Map<String, dynamic>>())).thenAnswer((_) async {});
+    when(success.sendModuleData(any<String>(),
+            argThat(isA<Map<String, dynamic>>())))
+        .thenAnswer((_) async {});
 
     final replay = CloudSyncService(firebaseService: success);
     await replay.replayOfflineTasks();
 
     verify(success.saveAnimal(any<AnimalModel>(), forTraining: true)).called(1); // FIXED: flutter analyze
     verify(success.saveUser(any<UserModel>(), forTraining: true)).called(1); // FIXED: flutter analyze
-    verify(success.sendModuleData('demo', any<Map<String, dynamic>>())).called(1);
+    verify(success.sendModuleData('demo', argThat(isA<Map<String, dynamic>>())))
+        .called(1);
 
     final remaining = await OfflineSyncQueue.getAllTasks();
     expect(remaining.isEmpty, isTrue);


### PR DESCRIPTION
## Summary
- tweak mocked RemoteConfig to use typed matcher
- adjust CloudSyncService tests to use `argThat` for type safety

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2b014748320aba176c4a22bb508