### PR TITLE
Fix CloudSharingService test instantiation

### DIFF
--- a/test/noyau/unit/cloud_sharing_service_test.dart
+++ b/test/noyau/unit/cloud_sharing_service_test.dart
@@ -1,20 +1,8 @@
-import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/noyau/services/cloud_sharing_service.dart';
-import 'package:anisphere/modules/noyau/services/cloud_drive_service.dart';
-import 'package:anisphere/modules/noyau/services/premium_sharing_checker.dart';
 import 'package:anisphere/modules/noyau/services/share_history_service.dart';
 import 'package:anisphere/modules/noyau/models/share_history_model.dart';
 
-class FakeChecker extends PremiumSharingChecker {
-  @override
-  bool canUseCloudSharing() => true;
-}
-
-class FakeDriveService extends CloudDriveService {
-  @override
-  Future<bool> uploadFile(File file) async => true;
-}
 
 class FakeHistoryService extends ShareHistoryService {
   final List<ShareHistoryModel> entries = [];
@@ -32,8 +20,6 @@ void main() {
   test('share enregistre une entrée cloud', () async {
     final history = FakeHistoryService();
     final service = CloudSharingService(
-      driveService: FakeDriveService(),
-      checker: FakeChecker(),
       historyService: history,
     );
 


### PR DESCRIPTION
## Summary
- update `CloudSharingService` test to match new constructor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2b1f21c8320af57c5f4c2120754