### PR TITLE
Fix mock argument matchers

### DIFF
--- a/test/noyau/unit/cloud_sync_service_test.dart
+++ b/test/noyau/unit/cloud_sync_service_test.dart
@@ -94,7 +94,7 @@ void main() {
   test('pushAnimalData queues task on failure', () async {
     final mock = MockFirebaseService();
     expect(mock, isNotNull); // FIXED: flutter analyze
-    when(mock.saveAnimal(any<AnimalModel>(), forTraining: true))
+    when(mock.saveAnimal(argThat(isA<AnimalModel>()), forTraining: true))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
     final service = CloudSyncService(firebaseService: mock);
     final animal = AnimalModel(
@@ -119,9 +119,9 @@ void main() {
   test('replayOfflineTasks flushes queued tasks', () async {
     final failing = MockFirebaseService();
     expect(failing, isNotNull); // FIXED: flutter analyze
-    when(failing.saveAnimal(any<AnimalModel>(), forTraining: true))
+    when(failing.saveAnimal(argThat(isA<AnimalModel>()), forTraining: true))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
-    when(failing.saveUser(any<UserModel>(), forTraining: true))
+    when(failing.saveUser(argThat(isA<UserModel>()), forTraining: true))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
     when(failing.sendModuleData(any<String>(), any<Map<String, dynamic>>()))
         .thenAnswer((_) async => throw Exception('fail')); // FIXED: flutter analyze
@@ -162,9 +162,9 @@ void main() {
 
     final success = MockFirebaseService();
     expect(success, isNotNull); // FIXED: flutter analyze
-    when(success.saveAnimal(any<AnimalModel>(), forTraining: true))
+    when(success.saveAnimal(argThat(isA<AnimalModel>()), forTraining: true))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
-    when(success.saveUser(any<UserModel>(), forTraining: true))
+    when(success.saveUser(argThat(isA<UserModel>()), forTraining: true))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(success.sendModuleData(any<String>(), any<Map<String, dynamic>>())).thenAnswer((_) async {});
 

--- a/test/noyau/unit/user_provider_test.dart
+++ b/test/noyau/unit/user_provider_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any<UserModel>()))
+    when(mockService.updateUser(argThat(isA<UserModel>())))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 
@@ -141,7 +141,7 @@ void main() {
 
     when(mockService.init()).thenAnswer((_) async {});
     when(mockService.deleteUserLocally()).thenAnswer((_) async {});
-    when(mockService.updateUser(any<UserModel>()))
+    when(mockService.updateUser(argThat(isA<UserModel>())))
         .thenAnswer((_) async => true); // FIXED: flutter analyze
     when(mockAuth.signOut()).thenAnswer((_) async {});
 


### PR DESCRIPTION
## Summary
- switch to `argThat(isA<AnimalModel>())` or `argThat(isA<UserModel>())` in unit tests

## Testing
- `flutter test --coverage` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2b32ef48320abede1a028d212c0