### PR TITLE
Fix FakeCloudSharingService override signature

### DIFF
--- a/test/noyau/unit/sharing_ia_optimizer_test.dart
+++ b/test/noyau/unit/sharing_ia_optimizer_test.dart
@@ -20,7 +20,7 @@ class FakeCloudSharingService extends CloudSharingService {
   final List<List<int>> uploads = [];
   FakeCloudSharingService() : super();
   @override
-  Future<void> uploadCompressed(List<int> gzipData) async {
+  Future<void> uploadCompressed(List<int> gzipData, {double cost = 0}) async {
     uploads.add(gzipData);
   }
 }


### PR DESCRIPTION
## Summary
- fix FakeCloudSharingService override to include cost parameter

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2b35f70832089ea44e3db720770