### PR TITLE
Add basic tests and update tracker

### DIFF
--- a/test/identite/unit/identity_model.g_test.dart
+++ b/test/identite/unit/identity_model.g_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour identity_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/identite/models/identity_model.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('identity_model.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour identity_model.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('IdentityModelAdapter typeId is 40', () {
+    expect(IdentityModelAdapter().typeId, 40);
   });
 }

--- a/test/noyau/unit/animal_model.g_test.dart
+++ b/test/noyau/unit/animal_model.g_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour animal_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('animal_model.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour animal_model.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('AnimalModelAdapter typeId is 1', () {
+    expect(AnimalModelAdapter().typeId, 1);
   });
 }

--- a/test/noyau/unit/animal_provider_test.dart
+++ b/test/noyau/unit/animal_provider_test.dart
@@ -1,13 +1,16 @@
 // Copilot Prompt : Test automatique généré pour animal_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/providers/animal_provider.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('animal_provider fonctionne (test auto)', () {
-    // TODO : compléter le test pour animal_provider.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('initial animals list is empty', () {
+    final provider =
+        AnimalProvider(animalService: AnimalService(skipHiveInit: true));
+    expect(provider.animals, isEmpty);
   });
 }

--- a/test/noyau/unit/animal_service_test.dart
+++ b/test/noyau/unit/animal_service_test.dart
@@ -1,13 +1,40 @@
 // Copilot Prompt : Test automatique généré pour animal_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('animal_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour animal_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('updateLocalAnimal stores and retrieves animal', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(AnimalModelAdapter());
+    final box = await Hive.openBox<AnimalModel>('test_animals');
+
+    final service =
+        AnimalService(testBox: box, skipHiveInit: true);
+    final animal = AnimalModel(
+      id: 'a1',
+      name: 'Rex',
+      species: 'dog',
+      breed: 'labrador',
+      imageUrl: '',
+      ownerId: 'u1',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    await service.updateLocalAnimal(animal);
+    final fetched = service.getAnimal('a1');
+
+    expect(fetched?.name, 'Rex');
+
+    await box.deleteFromDisk();
+    await dir.delete(recursive: true);
   });
 }

--- a/test/noyau/unit/app_initializer_test.dart
+++ b/test/noyau/unit/app_initializer_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour app_initializer.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/app_initializer.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('app_initializer fonctionne (test auto)', () {
-    // TODO : compléter le test pour app_initializer.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('AppInitializer exposes initialize method', () {
+    expect(AppInitializer.initialize, isA<Function>());
   });
 }

--- a/test/noyau/unit/auth_service_test.dart
+++ b/test/noyau/unit/auth_service_test.dart
@@ -1,13 +1,20 @@
 // Copilot Prompt : Test automatique généré pour auth_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/auth_service.dart';
+import '../../helpers/test_fakes.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('auth_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour auth_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('currentUser is null with FakeFirebaseAuth', () {
+    final service = AuthService(
+      firebaseAuth: FakeFirebaseAuth(),
+      userService: UserService(skipHiveInit: true, firestore: FakeFirestore()),
+    );
+    expect(service.currentUser, isNull);
   });
 }

--- a/test/noyau/unit/backup_service_test.dart
+++ b/test/noyau/unit/backup_service_test.dart
@@ -1,13 +1,47 @@
 // Copilot Prompt : Test automatique généré pour backup_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:anisphere/modules/noyau/services/backup_service.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.g.dart';
+import 'package:anisphere/modules/noyau/models/user_model.g.dart';
+import '../../helpers/test_fakes.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('backup_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour backup_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('performBackup returns false without user', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(AnimalModelAdapter());
+    Hive.registerAdapter(UserModelAdapter());
+    final animalBox = await Hive.openBox<AnimalModel>('animals');
+    final animalService =
+        AnimalService(testBox: animalBox, skipHiveInit: true);
+    final userService = UserService(
+      firestore: FakeFirestore(),
+      skipHiveInit: true,
+      testBox: await Hive.openBox<UserModel>('users'),
+    );
+
+    final backup = BackupService(
+      userService: userService,
+      animalService: animalService,
+      firebaseService: FakeFirebaseService(FakeFirestore()),
+    );
+
+    final result = await backup.performBackup();
+    expect(result, isFalse);
+
+    await animalBox.deleteFromDisk();
+    await Hive.box<UserModel>('users').deleteFromDisk();
+    await dir.delete(recursive: true);
   });
 }

--- a/test/noyau/unit/biometric_service_test.dart
+++ b/test/noyau/unit/biometric_service_test.dart
@@ -1,13 +1,22 @@
 // Copilot Prompt : Test automatique généré pour biometric_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/biometric_service.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:mockito/mockito.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('biometric_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour biometric_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('canCheckBiometrics returns false with fake auth', () async {
+    class FakeAuth extends Fake implements LocalAuthentication {
+      @override
+      Future<bool> get canCheckBiometrics async => false;
+    }
+
+    final service = BiometricService(auth: FakeAuth());
+    final result = await service.canCheckBiometrics();
+    expect(result, isFalse);
   });
 }

--- a/test/noyau/unit/consent_provider_test.dart
+++ b/test/noyau/unit/consent_provider_test.dart
@@ -1,14 +1,29 @@
 // Copilot Prompt : Test automatique généré pour consent_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/providers/consent_provider.dart';
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import 'package:anisphere/modules/noyau/models/consent_entry.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-  test('consent_provider fonctionne (test auto)', () {
-    // TODO : compléter le test pour consent_provider.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('addAction stores entry in history', () async {
+    class FakeService extends ConsentService {
+      List<ConsentEntry> entries = [];
+      @override
+      Future<List<ConsentEntry>> getHistory() async => entries;
+      @override
+      Future<void> addEntry(ConsentEntry entry) async {
+        entries.add(entry);
+      }
+    }
+
+    final provider = ConsentProvider(service: FakeService());
+    await provider.addAction(ConsentAction.accepted, 'u1');
+    expect(provider.history.length, 1);
+    expect(provider.accepted, isTrue);
   });
 }

--- a/test/noyau/unit/consent_service_test.dart
+++ b/test/noyau/unit/consent_service_test.dart
@@ -1,13 +1,25 @@
 // Copilot Prompt : Test automatique généré pour consent_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/consent_service.dart';
+import 'package:anisphere/modules/noyau/models/consent_entry.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('consent_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour consent_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('saveConsent persists acceptance', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(ConsentActionAdapter());
+    Hive.registerAdapter(ConsentEntryAdapter());
+    final service = ConsentService();
+    await service.saveConsent('terms');
+    final result = await service.hasConsent('terms');
+    expect(result, isTrue);
+    await Hive.deleteBoxFromDisk('consent_history');
+    await dir.delete(recursive: true);
   });
 }

--- a/test/noyau/unit/gps_provider_test.dart
+++ b/test/noyau/unit/gps_provider_test.dart
@@ -1,14 +1,16 @@
 // Copilot Prompt : Test automatique généré pour gps_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/providers/gps_provider.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-  test('gps_provider fonctionne (test auto)', () {
-    // TODO : compléter le test pour gps_provider.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('initial state is disconnected', () {
+    final provider = GpsProvider();
+    expect(provider.isConnected, isFalse);
+    expect(provider.positionStream, isNotNull);
   });
 }

--- a/test/noyau/unit/ia_channel_test.dart
+++ b/test/noyau/unit/ia_channel_test.dart
@@ -1,13 +1,14 @@
 // Copilot Prompt : Test automatique généré pour ia_channel.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_channel.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_channel fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_channel.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('IAChannel extension returns expected name', () {
+    expect(IAChannel.system.name, 'SYSTEM');
+    expect(IAChannel.notification.name, 'NOTIFICATION');
   });
 }

--- a/test/noyau/unit/ia_config_test.dart
+++ b/test/noyau/unit/ia_config_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour ia_config.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_config fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_config.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('maxLocalLogs greater than logsTrimTarget', () {
+    expect(IAConfig.maxLocalLogs, greaterThan(IAConfig.logsTrimTarget));
   });
 }

--- a/test/noyau/unit/ia_context_provider_test.dart
+++ b/test/noyau/unit/ia_context_provider_test.dart
@@ -1,13 +1,17 @@
 // Copilot Prompt : Test automatique généré pour ia_context_provider.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/providers/ia_context_provider.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_context_provider fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_context_provider.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('update modifies context values', () {
+    final provider = IAContextProvider();
+    provider.update(isOffline: true, animalCount: 3);
+    expect(provider.context.isOffline, isTrue);
+    expect(provider.context.animalCount, 3);
   });
 }

--- a/test/noyau/unit/ia_context_test.dart
+++ b/test/noyau/unit/ia_context_test.dart
@@ -1,13 +1,15 @@
 // Copilot Prompt : Test automatique généré pour ia_context.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_context fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_context.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('IAContext.empty has default values', () {
+    const ctx = IAContext.empty();
+    expect(ctx.isFirstLaunch, isTrue);
+    expect(ctx.animalCount, 0);
   });
 }

--- a/test/noyau/unit/ia_executor_test.dart
+++ b/test/noyau/unit/ia_executor_test.dart
@@ -1,13 +1,58 @@
 // Copilot Prompt : Test automatique généré pour ia_executor.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_executor.dart';
+import 'package:anisphere/modules/noyau/logic/ia_master.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
+import 'package:anisphere/modules/noyau/services/notification_service.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
+import 'package:anisphere/modules/noyau/logic/ia_flag.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_executor fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_executor.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('executeAll triggers notification when needed', () async {
+    class FakeNotificationService extends NotificationService {
+      bool called = false;
+      @override
+      Future<void> sendLocalNotification({
+        required String title,
+        required String body,
+      }) async {
+        called = true;
+      }
+    }
+
+    class FakeModulesService extends ModulesService {
+      @override
+      Future<void> deactivateUnusedModules() async {}
+    }
+
+    class FakeAnimalService extends AnimalService {
+      FakeAnimalService() : super(skipHiveInit: true);
+      @override
+      Future<void> syncAnimalsWithCloud() async {}
+    }
+
+    final notif = FakeNotificationService();
+    final executor = IAExecutor(
+      iaMaster: IAMaster.test(),
+      notificationService: notif,
+      modulesService: FakeModulesService(),
+      animalService: FakeAnimalService(),
+    );
+
+    IAFlag.enableSuggestions = false;
+    final ctx = IAContext(
+      isOffline: false,
+      isFirstLaunch: false,
+      hasAnimals: true,
+      animalCount: 1,
+      lastSyncDate: DateTime.now().subtract(const Duration(days: 366)),
+    );
+    await executor.executeAll(ctx);
+    expect(notif.called, isTrue);
   });
 }

--- a/test/noyau/unit/ia_logger_test.dart
+++ b/test/noyau/unit/ia_logger_test.dart
@@ -1,13 +1,15 @@
 // Copilot Prompt : Test automatique généré pour ia_logger.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_logger.dart';
+import 'package:anisphere/modules/noyau/logic/ia_channel.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_logger fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_logger.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('getLogs returns empty list by default', () {
+    final logs = IALogger.getLogs();
+    expect(logs, isEmpty);
   });
 }

--- a/test/noyau/unit/ia_master_test.dart
+++ b/test/noyau/unit/ia_master_test.dart
@@ -1,13 +1,19 @@
 // Copilot Prompt : Test automatique généré pour ia_master.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_master.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_master fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_master.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('decideUXMode returns onboarding when first launch', () {
+    final master = IAMaster.test();
+    final mode = master.decideUXMode(
+      isFirstLaunch: true,
+      isOffline: false,
+      hasAnimals: true,
+    );
+    expect(mode, 'onboarding_mode');
   });
 }

--- a/test/noyau/unit/ia_metrics_collector.g_test.dart
+++ b/test/noyau/unit/ia_metrics_collector.g_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour ia_metrics_collector.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_metrics_collector.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_metrics_collector.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('IAMetricAdapter has typeId 101', () {
+    expect(IAMetricAdapter().typeId, 101);
   });
 }

--- a/test/noyau/unit/ia_rule_engine_test.dart
+++ b/test/noyau/unit/ia_rule_engine_test.dart
@@ -1,13 +1,16 @@
 // Copilot Prompt : Test automatique généré pour ia_rule_engine.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_rule_engine.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_rule_engine fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_rule_engine.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('evaluate suggests adding animal when none present', () {
+    final ctx = IAContext.empty();
+    final actions = IARuleEngine.evaluate(ctx);
+    expect(actions, contains('suggest_add_animal'));
   });
 }

--- a/test/noyau/unit/ia_rules_test.dart
+++ b/test/noyau/unit/ia_rules_test.dart
@@ -1,13 +1,25 @@
 // Copilot Prompt : Test automatique généré pour ia_rules.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_rules.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_rules fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_rules.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('isAnimalInactive detects outdated update date', () {
+    final animal = AnimalModel(
+      id: 'a1',
+      name: 'Test',
+      species: 'dog',
+      breed: '',
+      imageUrl: '',
+      ownerId: 'u1',
+      createdAt: DateTime.now().subtract(const Duration(days: 20)),
+      updatedAt: DateTime.now().subtract(const Duration(days: 20)),
+    );
+    expect(IARules.isAnimalInactive(animal, threshold: const Duration(days: 7)),
+        isTrue);
   });
 }

--- a/test/noyau/unit/ia_scheduler_test.dart
+++ b/test/noyau/unit/ia_scheduler_test.dart
@@ -1,13 +1,57 @@
 // Copilot Prompt : Test automatique généré pour ia_scheduler.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/logic/ia_scheduler.dart';
+import 'package:anisphere/modules/noyau/logic/ia_executor.dart';
+import 'package:anisphere/modules/noyau/logic/ia_master.dart';
+import 'package:anisphere/modules/noyau/logic/ia_context.dart';
+import 'package:anisphere/modules/noyau/services/notification_service.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/services/animal_service.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_scheduler fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_scheduler.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('triggerNow calls syncCloudIA when premium user', () async {
+    class FakeMaster extends IAMaster {
+      FakeMaster() : super.test();
+      bool called = false;
+      @override
+      Future<void> syncCloudIA(String userId) async {
+        called = true;
+      }
+    }
+
+    final scheduler = IAScheduler(
+      executor: IAExecutor(
+        iaMaster: FakeMaster(),
+        notificationService: NotificationService(),
+        modulesService: ModulesService(),
+        animalService: AnimalService(skipHiveInit: true),
+      ),
+      iaMaster: FakeMaster(),
+      user: UserModel(
+        id: 'u1',
+        name: 'n',
+        email: 'e',
+        phone: '',
+        profilePicture: '',
+        profession: '',
+        ownedSpecies: const {},
+        ownedAnimals: const [],
+        preferences: const {},
+        moduleRoles: const {},
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        activeModules: const [],
+        role: 'user',
+        iaPremium: true,
+      ),
+    );
+    final ctx = IAContext.empty();
+    await scheduler.triggerNow(ctx);
+    expect((scheduler.iaMaster as FakeMaster).called, isTrue);
   });
 }

--- a/test/noyau/unit/ia_sync_service_test.dart
+++ b/test/noyau/unit/ia_sync_service_test.dart
@@ -1,13 +1,44 @@
 // Copilot Prompt : Test automatique généré pour ia_sync_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/ia_sync_service.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_sync_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_sync_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('syncAnimal completes without premium', () async {
+    final service = IASyncService.instance;
+    final user = UserModel(
+      id: 'u1',
+      name: 'n',
+      email: 'e',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+    final animal = AnimalModel(
+      id: 'a',
+      name: 'A',
+      species: 's',
+      breed: '',
+      imageUrl: '',
+      ownerId: 'u1',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await service.syncAnimal(animal, user);
+    expect(true, isTrue);
   });
 }

--- a/test/noyau/unit/maintenance_service_test.dart
+++ b/test/noyau/unit/maintenance_service_test.dart
@@ -1,13 +1,25 @@
 // Copilot Prompt : Test automatique généré pour maintenance_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/maintenance_service.dart';
+import 'package:anisphere/modules/noyau/logic/ia_master.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('maintenance_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour maintenance_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('runStartupChecks calls cleanOldLogs', () async {
+    bool called = false;
+    class FakeMaster extends IAMaster {
+      FakeMaster() : super.test();
+      @override
+      Future<void> cleanOldLogs() async {
+        called = true;
+      }
+    }
+
+    final service = MaintenanceService(ia: FakeMaster());
+    await service.runStartupChecks();
+    expect(called, isTrue);
   });
 }

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour modules_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('modules_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour modules_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('allModules contains Santé', () {
+    expect(ModulesService.allModules, contains('Santé'));
   });
 }

--- a/test/noyau/unit/photo_task.g_test.dart
+++ b/test/noyau/unit/photo_task.g_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/offline_photo_queue.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-  test('photo_task.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour photo_task.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('PhotoTaskAdapter has correct typeId', () {
+    expect(PhotoTaskAdapter().typeId, 132);
   });
 }

--- a/test/noyau/unit/support_model_test.dart
+++ b/test/noyau/unit/support_model_test.dart
@@ -1,13 +1,24 @@
 // Copilot Prompt : Test automatique généré pour support_model.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/models/support_ticket_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('support_model fonctionne (test auto)', () {
-    // TODO : compléter le test pour support_model.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('toJson and fromJson preserve fields', () {
+    final ticket = SupportTicketModel(
+      id: '1',
+      userId: 'u',
+      type: SupportTicketType.bug,
+      message: 'm',
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 2),
+    );
+    final map = ticket.toJson();
+    final copy = SupportTicketModel.fromJson(map);
+    expect(copy.id, '1');
+    expect(copy.type, SupportTicketType.bug);
   });
 }

--- a/test/noyau/unit/user_model.g_test.dart
+++ b/test/noyau/unit/user_model.g_test.dart
@@ -1,13 +1,13 @@
 // Copilot Prompt : Test automatique généré pour user_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/models/user_model.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('user_model.g fonctionne (test auto)', () {
-    // TODO : compléter le test pour user_model.g.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('UserModelAdapter typeId is 0', () {
+    expect(UserModelAdapter().typeId, 0);
   });
 }

--- a/test/noyau/unit/user_model_test.dart
+++ b/test/noyau/unit/user_model_test.dart
@@ -1,13 +1,33 @@
 // Copilot Prompt : Test automatique généré pour user_model.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('user_model fonctionne (test auto)', () {
-    // TODO : compléter le test pour user_model.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('toJson/fromJson round trip', () {
+    final user = UserModel(
+      id: 'u1',
+      name: 'name',
+      email: 'e',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+    final json = user.toJson();
+    final copy = UserModel.fromJson(json);
+    expect(copy.id, 'u1');
+    expect(copy.email, 'e');
   });
 }

--- a/test/noyau/unit/user_service_test.dart
+++ b/test/noyau/unit/user_service_test.dart
@@ -1,13 +1,44 @@
 // Copilot Prompt : Test automatique généré pour user_service.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:anisphere/modules/noyau/models/user_model.g.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('user_service fonctionne (test auto)', () {
-    // TODO : compléter le test pour user_service.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  test('getUserFromHive retrieves stored user', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserModelAdapter());
+    final box = await Hive.openBox<UserModel>('users');
+    final service = UserService(testBox: box, firestore: FakeFirestore(), skipHiveInit: true);
+    final user = UserModel(
+      id: 'u1',
+      name: 'n',
+      email: 'e',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+    await service.saveUserLocally(user);
+    final fetched = service.getUserFromHive();
+    expect(fetched?.id, 'u1');
+    await box.deleteFromDisk();
+    await dir.delete(recursive: true);
   });
 }


### PR DESCRIPTION
## Summary
- add simple assertions in `test/noyau/unit` and `test/identite/unit`
- remove leftover TODO comments
- attempt to refresh test tracker

## Testing
- `flutter test` *(fails: command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5ee2091883209f3c75f1edfde984