### PR TITLE
Fix imports in generated model tests

### DIFF
--- a/test/identite/unit/identity_model.g_test.dart
+++ b/test/identite/unit/identity_model.g_test.dart
@@ -1,7 +1,7 @@
 // Copilot Prompt : Test automatique généré pour identity_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/identite/models/identity_model.g.dart';
+import 'package:anisphere/modules/identite/models/identity_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/animal_model.g_test.dart
+++ b/test/noyau/unit/animal_model.g_test.dart
@@ -1,7 +1,7 @@
 // Copilot Prompt : Test automatique généré pour animal_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/animal_model.g.dart';
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/ia_metrics_collector.g_test.dart
+++ b/test/noyau/unit/ia_metrics_collector.g_test.dart
@@ -1,7 +1,7 @@
 // Copilot Prompt : Test automatique généré pour ia_metrics_collector.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.g.dart';
+import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/photo_task.g_test.dart
+++ b/test/noyau/unit/photo_task.g_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/services/offline_photo_queue.g.dart';
+import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/user_model.g_test.dart
+++ b/test/noyau/unit/user_model.g_test.dart
@@ -1,7 +1,7 @@
 // Copilot Prompt : Test automatique généré pour user_model.g.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/models/user_model.g.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
 
 void main() {
   setUpAll(() async {


### PR DESCRIPTION
## Summary
- import main model files instead of `.g.dart` files in unit tests

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c504a48832086b276c532e8d434