### PR TITLE
Fix IAContext test final variable

### DIFF
--- a/test/noyau/unit/ia_context_test.dart
+++ b/test/noyau/unit/ia_context_test.dart
@@ -8,7 +8,7 @@ void main() {
     await initTestEnv();
   });
   test('IAContext.empty has default values', () {
-    const ctx = IAContext.empty();
+    final ctx = IAContext.empty();
     expect(ctx.isFirstLaunch, isTrue);
     expect(ctx.animalCount, 0);
   });


### PR DESCRIPTION
## Summary
- use `final` instead of `const` for `IAContext.empty()` in unit test

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c51e4c08320ada0a027d000ca90