### PR TITLE
Cleanup fake_cloud_firestore imports

### DIFF
--- a/test/noyau/unit/auth_service_test.dart
+++ b/test/noyau/unit/auth_service_test.dart
@@ -4,7 +4,6 @@ import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import '../../helpers/test_fakes.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/noyau/unit/backup_service_test.dart
+++ b/test/noyau/unit/backup_service_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'dart:io';
 import 'package:hive/hive.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:anisphere/modules/noyau/services/backup_service.dart';
 import 'package:anisphere/modules/noyau/services/animal_service.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';


### PR DESCRIPTION
## Summary
- remove unused fake cloud firestore imports in some core tests
- revert user_service_test to keep package import since it doesn't use the helper alias

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c52c8d8832091721ad6405f16f4