### PR TITLE
Fix outdated messaging test note

### DIFF
--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -69,11 +69,11 @@ Système de Sphères : prototype en cours (monnaie d’échange & entraide)
 Profils publics : prévu (carte interactive, filtres)
 
 Historique des échanges : prévu (réputation, avis)
-✉️ Messagerie — À démarrer
+✉️ Messagerie — En cours
 
-Conversation privée : à définir (Firestore messages)
+Conversation privée : en développement (Firestore messages)
 
-Tests module messagerie : à créer (unit/widget).
+Tests module messagerie : terminés (unit/widget/intégration).
 🔗 Partage — Suivi du module
 Partage local (QR code + export) : terminé
 Sauvegarde cloud premium : en cours


### PR DESCRIPTION
## Summary
- update the global task board to show messaging tests exist

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e970a227c83209ee98512f41dc34c