### PR TITLE
Add core services docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ Missions / professionnels
 
 Chaque module embarque sa propre IA et son propre système de données.
 
+**Services transverses du noyau** : messagerie (`lib/modules/messagerie/services/messaging_service.dart`), partage (`lib/modules/noyau/services/local_sharing_service.dart`), commande vocale (`lib/modules/voice/speech_recognition_service.dart`), notifications (`lib/modules/noyau/services/notification_service.dart`), exports (`lib/modules/noyau/services/share_history_service.dart`).
+
 🔒 Sécurité et confidentialité
+
+
 
 Stockage local par défaut (aucune donnée personnelle dans le cloud sans consentement)
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -37,6 +37,14 @@ Le noyau est toujours accessible depuis les modules, mais les modules ne doivent
 
 Tous les tests sont regroupés dans /test et suivent la même hiérarchie que lib/
 
+### Services transverses du noyau
+- Messagerie : `lib/modules/messagerie/services/messaging_service.dart`
+- Partage local/cloud : `lib/modules/noyau/services/local_sharing_service.dart`, `cloud_sharing_service.dart`
+- Voix : `lib/modules/voice/speech_recognition_service.dart`
+- Notifications : `lib/modules/noyau/services/notification_service.dart`
+- Exports : `lib/modules/noyau/services/share_history_service.dart`
+- File offline : `lib/modules/noyau/services/offline_sync_queue.dart`
+
 
 ⚙️ Chapitre 3 — Automatisation du développement
 

--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -214,3 +214,13 @@ AniSphère repose sur une architecture modulaire, hybride et intelligente, taill
 
 ### Partage et synchronisation
 AniSphère dispose d'un service de partage local (Bluetooth, Wi‑Fi Direct, NFC, QR) et d'un service cloud. La détection automatique choisit le meilleur mode disponible; le partage cloud requiert un compte premium.
+
+### Services transverses du noyau
+Le noyau met à disposition plusieurs services communs accessibles par tous les modules :
+- **Messagerie interne** : `lib/modules/messagerie/services/messaging_service.dart` et sa file d'attente `offline_message_queue.dart`.
+- **Partage local et cloud** : `lib/modules/noyau/services/local_sharing_service.dart` et `cloud_sharing_service.dart`, avec suivi via `share_history_service.dart`.
+- **Commande vocale** : `lib/modules/voice/speech_recognition_service.dart` et `voice_command_analyzer.dart` pour déclencher rapidement des actions.
+- **Notifications intelligentes** : `lib/modules/noyau/services/notification_service.dart` connectée à l'IA maîtresse.
+- **Exports et historiques** : `lib/modules/noyau/noyau_module.dart` ainsi que `share_history_service.dart` pour générer des PDF ou archives.
+- **File de synchronisation offline** : `lib/modules/noyau/services/offline_sync_queue.dart`.
+Ces services garantissent la cohérence entre les modules et simplifient leur intégration.

--- a/docs/noyau.md
+++ b/docs/noyau.md
@@ -90,6 +90,14 @@ notifications/ : gestion des notifications locales et cloud.
 sharing/ : gestion du partage sécurisé et des exports.
 maintenance/ : détection des erreurs IA et maintenance automatique.
 onboarding/ : tutoriel et intégration de nouveaux utilisateurs.
+### Services transverses du noyau
+- **messagerie interne** : `lib/modules/messagerie/services/messaging_service.dart`
+- **partage local/cloud** : `lib/modules/noyau/services/local_sharing_service.dart`, `cloud_sharing_service.dart`
+- **commande vocale** : `lib/modules/voice/speech_recognition_service.dart`
+- **notifications intelligentes** : `lib/modules/noyau/services/notification_service.dart`
+- **exports / historique** : `lib/modules/noyau/services/share_history_service.dart`
+- **file de synchro offline** : `lib/modules/noyau/services/offline_sync_queue.dart`
+
  
 4. Évolutivité et modularité
 Le noyau fournit une API générique, permettant à chaque module de se connecter facilement à ses services sans avoir à gérer de logique métier spécifique.


### PR DESCRIPTION
## Summary
- document cross services in architecture & noyau docs
- add brief core services list in README_DEV and README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e970d1e3083208d9b761d32790367