### PR TITLE
Remove local AppBars from core screens

### DIFF
--- a/lib/modules/noyau/screens/animals_screen.dart
+++ b/lib/modules/noyau/screens/animals_screen.dart
@@ -50,7 +50,6 @@ class _AnimalsScreenState extends State<AnimalsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Mes animaux")),
       floatingActionButton: FloatingActionButton(
         backgroundColor: const Color(0xFF183153),
         foregroundColor: Colors.white,

--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -78,10 +78,6 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Accueil'), // ✅ même format que les autres onglets
-        automaticallyImplyLeading: false,
-      ),
       body: SafeArea(
         child: loadingSummaries
             ? const Center(child: CircularProgressIndicator())

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -57,7 +57,6 @@ class _ModulesScreenState extends State<ModulesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Modules")),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),
         itemCount: _modulesInfo.length,

--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -45,7 +45,6 @@ class _ShareScreenState extends State<ShareScreen> {
     final isPremium = user?.iaPremium ?? false;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Partage')),
       body: ListView(
         padding: const EdgeInsets.all(24),
         children: [

--- a/test/noyau/widget/animals_screen_test.dart
+++ b/test/noyau/widget/animals_screen_test.dart
@@ -1,13 +1,35 @@
 // Copilot Prompt : Test automatique généré pour animals_screen.dart (widget)
+import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:anisphere/modules/noyau/models/animal_model.dart';
+import 'package:anisphere/modules/noyau/screens/animals_screen.dart';
 import '../../test_config.dart';
 
 void main() {
-  setUpAll(() async {
+  late Directory tempDir;
+
+  setUp(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(AnimalModelAdapter());
+    await Hive.openBox<AnimalModel>('animal_data');
   });
-  test('animals_screen fonctionne (test auto)', () {
-    // TODO : compléter le test pour animals_screen.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('animal_data');
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('renders without AppBar', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: AnimalsScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppBar), findsNothing);
+    expect(find.text('Aucun animal enregistré'), findsOneWidget);
   });
 }

--- a/test/noyau/widget/modules_screen_test.dart
+++ b/test/noyau/widget/modules_screen_test.dart
@@ -1,13 +1,20 @@
 // Copilot Prompt : Test automatique généré pour modules_screen.dart (widget)
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'package:anisphere/modules/noyau/screens/modules_screen.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('modules_screen fonctionne (test auto)', () {
-    // TODO : compléter le test pour modules_screen.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  testWidgets('renders without AppBar', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ModulesScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppBar), findsNothing);
+    expect(find.text('Santé'), findsOneWidget);
   });
 }

--- a/test/noyau/widget/share_screen_test.dart
+++ b/test/noyau/widget/share_screen_test.dart
@@ -1,13 +1,73 @@
 // Copilot Prompt : Test automatique généré pour share_screen.dart (widget)
+import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:hive/hive.dart';
+
+import 'package:anisphere/modules/noyau/models/user_model.dart';
+import 'package:anisphere/modules/noyau/models/share_history_model.dart';
+import 'package:anisphere/modules/noyau/providers/user_provider.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:anisphere/modules/noyau/services/auth_service.dart';
+import 'package:anisphere/modules/noyau/screens/share_screen.dart';
 import '../../test_config.dart';
 
+class _FakeUserProvider extends UserProvider {
+  final UserModel? _user;
+  _FakeUserProvider(this._user)
+      : super(UserService(skipHiveInit: true), AuthService());
+
+  @override
+  UserModel? get user => _user;
+}
+
 void main() {
-  setUpAll(() async {
+  late Directory tempDir;
+
+  setUp(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(ShareHistoryModelAdapter());
+    await Hive.openBox<ShareHistoryModel>('share_history');
   });
-  test('share_screen fonctionne (test auto)', () {
-    // TODO : compléter le test pour share_screen.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('share_history');
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('renders without AppBar', (tester) async {
+    final user = UserModel(
+      id: 'u1',
+      name: 'Test',
+      email: 't@test.com',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<UserProvider>.value(
+        value: _FakeUserProvider(user),
+        child: const MaterialApp(home: ShareScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppBar), findsNothing);
+    expect(find.text('Partager localement'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- rely on main AppBar for home, share, modules, and animals screens
- expect no AppBar in related widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e99a0be608320ad686d2114ea88fb