### PR TITLE
Switch to MainScreen as home

### DIFF
--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -92,7 +92,7 @@ L'intelligence artificielle locale est déployée dans le noyau selon un systèm
 * **ia\_logger.dart** : journalise les actions IA
 * **ia\_flag.dart / ia\_channel.dart / ia\_config.dart** : configuration, canaux, drapeaux IA
 
-L'appel principal se fait dans **main.dart > SplashScreen**, avec le Provider **IAContextProvider**.
+L'appel principal se fait dans **main.dart > MainScreen**, avec le Provider **IAContextProvider**.
 
 ## 📦 Modules externes (identite/, à venir : sante/, education/...)
 

--- a/docs/2__roadmap.md
+++ b/docs/2__roadmap.md
@@ -14,7 +14,7 @@ Stockage local (Hive) + synchronisation Firebase (animaux, utilisateur)
 
 Connexion et reconnexion automatique hors ligne
 
-Interface de base (Splash / Login / Home / Paramètres)
+Interface de base (Login / MainScreen / Paramètres)
 
 Structure modulaire activable
 

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -73,7 +73,7 @@
 | test/noyau/widget/user_profile_screen_test.dart | widget | package:anisphere/modules/noyau/screens/user_profile_screen.dart | ✅ |
 | test/noyau/widget/animal_form_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_form_screen.dart | ✅ |
 | test/noyau/widget/home_screen_test.dart | widget | package:anisphere/modules/noyau/screens/home_screen.dart | ✅ |
-| test/noyau/widget/splash_screen_test.dart | widget | package:anisphere/modules/noyau/screens/splash_screen.dart | ✅ |
+| test/noyau/widget/splash_screen_test.dart | widget | package:anisphere/modules/noyau/screens/main_screen.dart | ✅ |
 | test/noyau/widget/share_screen_test.dart | widget | package:anisphere/modules/noyau/screens/share_screen.dart | ✅ |
 | test/noyau/widget/qr_screen_test.dart | widget | package:anisphere/modules/noyau/screens/qr_screen.dart | ✅ |
 | test/noyau/widget/animal_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_screen.dart | ✅ |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:anisphere/firebase_options.dart';
-import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
+import 'package:anisphere/modules/noyau/screens/main_screen.dart';
 import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
@@ -141,7 +141,7 @@ class MyApp extends StatelessWidget {
       title: 'AniSphère',
       debugShowCheckedModeBanner: false,
       theme: appTheme,
-      home: const SplashScreen(),
+      home: const MainScreen(),
     );
   }
 }

--- a/test/noyau/integration/app_initializer_test.dart
+++ b/test/noyau/integration/app_initializer_test.dart
@@ -3,15 +3,15 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 
 import 'package:anisphere/main.dart';
-import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
+import 'package:anisphere/modules/noyau/screens/main_screen.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  testWidgets('App launches to SplashScreen', (WidgetTester tester) async {
+  testWidgets('App launches to MainScreen', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    expect(find.byType(SplashScreen), findsOneWidget);
+    expect(find.byType(MainScreen), findsOneWidget);
   });
 }

--- a/test/noyau/widget/splash_screen_test.dart
+++ b/test/noyau/widget/splash_screen_test.dart
@@ -2,18 +2,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
+import 'package:anisphere/modules/noyau/screens/main_screen.dart';
 import 'package:anisphere/theme.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  testWidgets('splash screen uses yellow ripple', (tester) async {
+  testWidgets('main screen uses yellow ripple', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: appTheme,
-        home: const SplashScreen(),
+        home: const MainScreen(),
       ),
     );
 


### PR DESCRIPTION
## Summary
- start the Flutter app on `MainScreen`
- adjust integration and widget tests
- note new entry point in the docs
- update test tracker

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e99a3fd508320970329974d64ec18