### PR TITLE
Add feedback sound and haptic services

### DIFF
--- a/lib/modules/noyau/services/feedback_sound_service.dart
+++ b/lib/modules/noyau/services/feedback_sound_service.dart
@@ -1,0 +1,55 @@
+// Copilot Prompt : FeedbackSoundService pour AniSphère.
+// Joue des sons de retour utilisateur (succès, erreur, alerte, validation).
+// Les modules peuvent enregistrer ou remplacer leurs propres sons dynamiquement.
+library;
+// TODO: ajouter test
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/foundation.dart';
+
+/// Type de son jouable par [FeedbackSoundService].
+class FeedbackSoundType {
+  final String name;
+  const FeedbackSoundType(this.name);
+
+  static const success = FeedbackSoundType('success');
+  static const error = FeedbackSoundType('error');
+  static const alert = FeedbackSoundType('alert');
+  static const validation = FeedbackSoundType('validation');
+
+  @override
+  bool operator ==(Object other) =>
+      other is FeedbackSoundType && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
+}
+
+/// Service qui gère la lecture de sons de feedback.
+class FeedbackSoundService {
+  final AudioPlayer _player;
+  final Map<FeedbackSoundType, String> _sounds = {
+    FeedbackSoundType.success: 'assets/sounds/success.mp3',
+    FeedbackSoundType.error: 'assets/sounds/error.mp3',
+    FeedbackSoundType.alert: 'assets/sounds/alert.mp3',
+    FeedbackSoundType.validation: 'assets/sounds/validation.mp3',
+  };
+
+  FeedbackSoundService({AudioPlayer? player}) : _player = player ?? AudioPlayer();
+
+  /// Enregistre ou remplace un son pour [type].
+  void registerSound(FeedbackSoundType type, String assetPath) {
+    _sounds[type] = assetPath;
+  }
+
+  /// Joue le son associé au [type] s'il existe.
+  Future<void> play(FeedbackSoundType type) async {
+    final path = _sounds[type];
+    if (path == null) return;
+    try {
+      await _player.play(AssetSource(path));
+    } catch (e) {
+      debugPrint('Erreur lecture son : $e');
+    }
+  }
+}

--- a/lib/modules/noyau/services/haptic_feedback_service.dart
+++ b/lib/modules/noyau/services/haptic_feedback_service.dart
@@ -1,0 +1,57 @@
+// Copilot Prompt : HapticFeedbackService pour AniSphère.
+// Fournit des vibrations prédéfinies (léger, moyen, fort, sélection).
+// Permet aussi de passer un motif personnalisé pour un retour précis.
+library;
+// TODO: ajouter test
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:vibration/vibration.dart';
+
+/// Type de vibration utilisable par [HapticFeedbackService].
+class FeedbackHapticType {
+  final String name;
+  final List<int>? pattern;
+
+  const FeedbackHapticType._(this.name, [this.pattern]);
+
+  static const light = FeedbackHapticType._('light');
+  static const medium = FeedbackHapticType._('medium');
+  static const heavy = FeedbackHapticType._('heavy');
+  static const selection = FeedbackHapticType._('selection');
+
+  const FeedbackHapticType.custom(List<int> pattern)
+      : name = 'custom',
+        pattern = pattern;
+}
+
+/// Service gérant les retours haptiques.
+class HapticFeedbackService {
+  /// Déclenche la vibration associée au [type].
+  static Future<void> vibrate(FeedbackHapticType type) async {
+    try {
+      switch (type.name) {
+        case 'light':
+          await HapticFeedback.lightImpact();
+          break;
+        case 'medium':
+          await HapticFeedback.mediumImpact();
+          break;
+        case 'heavy':
+          await HapticFeedback.heavyImpact();
+          break;
+        case 'selection':
+          await HapticFeedback.selectionClick();
+          break;
+        default:
+          if (type.pattern != null && (await Vibration.hasVibrator() ?? false)) {
+            await Vibration.vibrate(pattern: type.pattern);
+          } else {
+            await HapticFeedback.vibrate();
+          }
+      }
+    } catch (e) {
+      debugPrint('Erreur vibration : $e');
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,10 @@ dependencies:
   speech_to_text: ^6.6.0
   google_speech: ^2.0.0
 
+  # Retour sonores & haptiques
+  audioplayers: ^5.2.1
+  vibration: ^1.8.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add `FeedbackSoundService` with dynamic sound registration
- add `HapticFeedbackService` for predefined and custom vibrations
- include audio & vibration packages

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e936183308320a45d333fdd04ef07