### PR TITLE
Add feedback settings provider and screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'package:anisphere/modules/noyau/models/sync_metrics_model.dart';
 import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
     as offline_queue;
 import 'package:anisphere/modules/noyau/models/share_history_model.dart';
+import 'package:anisphere/modules/noyau/providers/feedback_options_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -125,6 +126,9 @@ void main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => PhotoProvider()..init(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => FeedbackOptionsProvider()..load(),
         ),
       ],
       child: const MyApp(),

--- a/lib/modules/noyau/providers/feedback_options_provider.dart
+++ b/lib/modules/noyau/providers/feedback_options_provider.dart
@@ -1,0 +1,57 @@
+// Copilot Prompt: "FeedbackOptionsProvider manages global audio and haptic settings across modules."
+library;
+
+import 'package:flutter/foundation.dart';
+import '../services/local_storage_service.dart';
+import '../services/modules_service.dart';
+
+class FeedbackOptionsProvider with ChangeNotifier {
+  static const _enabledKey = 'feedback_enabled';
+  static const _volumeKey = 'feedback_volume';
+  static const _intensityKey = 'feedback_intensity';
+
+  bool _enabled = true;
+  double _volume = 1.0;
+  double _intensity = 1.0;
+  final Map<String, bool> _moduleToggles = {};
+
+  bool get enabled => _enabled;
+  double get volume => _volume;
+  double get intensity => _intensity;
+  Map<String, bool> get moduleToggles => Map.unmodifiable(_moduleToggles);
+
+  Future<void> load() async {
+    _enabled = LocalStorageService.get(_enabledKey, defaultValue: true);
+    _volume = LocalStorageService.get(_volumeKey, defaultValue: 1.0);
+    _intensity = LocalStorageService.get(_intensityKey, defaultValue: 1.0);
+    for (final module in ModulesService.allModules) {
+      _moduleToggles[module] =
+          LocalStorageService.get('feedback_module_$module', defaultValue: true);
+    }
+    notifyListeners();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    _enabled = value;
+    await LocalStorageService.set(_enabledKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setVolume(double value) async {
+    _volume = value;
+    await LocalStorageService.set(_volumeKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setIntensity(double value) async {
+    _intensity = value;
+    await LocalStorageService.set(_intensityKey, value);
+    notifyListeners();
+  }
+
+  Future<void> toggleModule(String module, bool value) async {
+    _moduleToggles[module] = value;
+    await LocalStorageService.set('feedback_module_$module', value);
+    notifyListeners();
+  }
+}

--- a/lib/modules/noyau/screens/feedback_settings_screen.dart
+++ b/lib/modules/noyau/screens/feedback_settings_screen.dart
@@ -1,0 +1,69 @@
+// Copilot Prompt: "FeedbackSettingsScreen allows users to configure audio and haptic feedback for each module."
+library;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/modules_service.dart';
+import '../providers/feedback_options_provider.dart';
+
+class FeedbackSettingsScreen extends StatefulWidget {
+  const FeedbackSettingsScreen({super.key});
+
+  @override
+  State<FeedbackSettingsScreen> createState() => _FeedbackSettingsScreenState();
+}
+
+class _FeedbackSettingsScreenState extends State<FeedbackSettingsScreen> {
+  late FeedbackOptionsProvider _provider;
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = Provider.of<FeedbackOptionsProvider>(context, listen: false);
+    _provider.load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Feedback')),
+      body: Consumer<FeedbackOptionsProvider>(
+        builder: (context, options, _) => ListView(
+          padding: const EdgeInsets.all(24),
+          children: [
+            SwitchListTile(
+              title: const Text('Activer le feedback'),
+              value: options.enabled,
+              onChanged: options.setEnabled,
+            ),
+            ListTile(
+              title: const Text('Volume'),
+              subtitle: Slider(
+                value: options.volume,
+                onChanged: options.enabled ? options.setVolume : null,
+              ),
+            ),
+            ListTile(
+              title: const Text('Intensité haptique'),
+              subtitle: Slider(
+                value: options.intensity,
+                onChanged: options.enabled ? options.setIntensity : null,
+              ),
+            ),
+            const Divider(),
+            const Text('Modules',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            ...ModulesService.allModules.map(
+              (m) => CheckboxListTile(
+                title: Text(m),
+                value: options.moduleToggles[m] ?? true,
+                onChanged: (v) => options.toggleModule(m, v ?? true),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../services/local_storage_service.dart';
 import '../services/backup_service.dart';
 import '../providers/user_provider.dart';
 import '../services/animal_service.dart';
+import 'feedback_settings_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -118,6 +119,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text("Recevoir des alertes intelligentes"),
             value: iaNotifications,
             onChanged: (val) => _updatePreference("ia_notifications", val),
+          ),
+          ListTile(
+            leading: const Icon(Icons.vibration, color: Color(0xFF183153)),
+            title: const Text('Feedback audio/haptique'),
+            subtitle: const Text('Configurer les sons et vibrations'),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const FeedbackSettingsScreen()),
+              );
+            },
           ),
           const Divider(),
           const Text("Sauvegarde & restauration", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF183153))),


### PR DESCRIPTION
## Summary
- create `FeedbackOptionsProvider` to persist global feedback settings
- add UI to configure feedback options via `FeedbackSettingsScreen`
- link feedback settings from main Settings screen
- register the new provider in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e93625c808320a4a8a246f416497f