### PR TITLE
Add job provider

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -60,6 +60,7 @@
 | test/noyau/unit/user_provider_test.dart | unit | package:anisphere/modules/noyau/providers/user_provider.dart | ✅ |
 | test/noyau/unit/consent_provider_test.dart | unit | package:anisphere/modules/noyau/providers/consent_provider.dart | ✅ |
 | test/noyau/unit/animal_provider_test.dart | unit | package:anisphere/modules/noyau/providers/animal_provider.dart | ✅ |
+| test/noyau/unit/job_provider_test.dart | unit | package:anisphere/modules/noyau/providers/job_provider.dart | ✅ |
 | test/noyau/widget/ia_banner_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_banner.dart | ✅ |
 | test/noyau/widget/more_menu_test.dart | widget | package:anisphere/modules/noyau/widgets/more_menu.dart | ✅ |
 | test/noyau/widget/ia_chip_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_chip.dart | ✅ |

--- a/lib/modules/noyau/models/job_model.dart
+++ b/lib/modules/noyau/models/job_model.dart
@@ -1,0 +1,73 @@
+library;
+
+/// Possible states for a scheduled job.
+enum JobStatus { pending, running, completed, failed }
+
+/// Model representing a scheduled job.
+class JobModel {
+  final String id;
+  final String name;
+  JobStatus status;
+  final DateTime createdAt;
+  DateTime? startedAt;
+  DateTime? finishedAt;
+
+  JobModel({
+    required this.id,
+    required this.name,
+    this.status = JobStatus.pending,
+    DateTime? createdAt,
+    this.startedAt,
+    this.finishedAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  JobModel copyWith({
+    String? id,
+    String? name,
+    JobStatus? status,
+    DateTime? createdAt,
+    DateTime? startedAt,
+    DateTime? finishedAt,
+  }) {
+    return JobModel(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      startedAt: startedAt ?? this.startedAt,
+      finishedAt: finishedAt ?? this.finishedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'status': status.name,
+        'createdAt': createdAt.toIso8601String(),
+        'startedAt': startedAt?.toIso8601String(),
+        'finishedAt': finishedAt?.toIso8601String(),
+      };
+
+  factory JobModel.fromJson(Map<String, dynamic> json) {
+    JobStatus parsedStatus;
+    try {
+      parsedStatus = JobStatus.values
+          .firstWhere((e) => e.name == json['status']);
+    } catch (_) {
+      parsedStatus = JobStatus.pending;
+    }
+    return JobModel(
+      id: json['id'] ?? '',
+      name: json['name'] ?? '',
+      status: parsedStatus,
+      createdAt:
+          DateTime.tryParse(json['createdAt'] ?? '') ?? DateTime.now(),
+      startedAt: json['startedAt'] != null
+          ? DateTime.tryParse(json['startedAt'])
+          : null,
+      finishedAt: json['finishedAt'] != null
+          ? DateTime.tryParse(json['finishedAt'])
+          : null,
+    );
+  }
+}

--- a/lib/modules/noyau/providers/job_provider.dart
+++ b/lib/modules/noyau/providers/job_provider.dart
@@ -1,0 +1,51 @@
+library;
+
+import 'package:flutter/foundation.dart';
+
+import '../models/job_model.dart';
+import '../services/job_scheduler_service.dart';
+
+/// Provider exposing scheduled jobs and their status.
+class JobProvider with ChangeNotifier {
+  final JobSchedulerService _service;
+  List<JobModel> _jobs = [];
+
+  JobProvider({JobSchedulerService? service})
+      : _service = service ?? JobSchedulerService();
+
+  /// Public unmodifiable view of jobs.
+  List<JobModel> get jobs => List.unmodifiable(_jobs);
+
+  /// Jobs waiting to start.
+  List<JobModel> get pendingJobs =>
+      _jobs.where((j) => j.status == JobStatus.pending).toList();
+
+  /// Currently running jobs.
+  List<JobModel> get runningJobs =>
+      _jobs.where((j) => j.status == JobStatus.running).toList();
+
+  /// Successfully completed jobs.
+  List<JobModel> get completedJobs =>
+      _jobs.where((j) => j.status == JobStatus.completed).toList();
+
+  /// Jobs that ended in error.
+  List<JobModel> get failedJobs =>
+      _jobs.where((j) => j.status == JobStatus.failed).toList();
+
+  /// Load jobs from the [JobSchedulerService].
+  Future<void> loadJobs() async {
+    _jobs = await _service.getJobs();
+    notifyListeners();
+  }
+
+  /// Update or insert a job, notifying listeners of changes.
+  void updateJob(JobModel job) {
+    final index = _jobs.indexWhere((j) => j.id == job.id);
+    if (index >= 0) {
+      _jobs[index] = job;
+    } else {
+      _jobs.add(job);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/modules/noyau/services/job_scheduler_service.dart
+++ b/lib/modules/noyau/services/job_scheduler_service.dart
@@ -1,0 +1,11 @@
+library;
+
+import '../models/job_model.dart';
+
+/// Basic service returning scheduled jobs.
+class JobSchedulerService {
+  /// Retrieve all jobs (stub implementation).
+  Future<List<JobModel>> getJobs() async {
+    return [];
+  }
+}

--- a/test/noyau/unit/job_provider_test.dart
+++ b/test/noyau/unit/job_provider_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/providers/job_provider.dart';
+import 'package:anisphere/modules/noyau/models/job_model.dart';
+import 'package:anisphere/modules/noyau/services/job_scheduler_service.dart';
+
+class FakeJobSchedulerService extends JobSchedulerService {
+  int loadCalls = 0;
+  List<JobModel> jobs;
+  FakeJobSchedulerService(this.jobs);
+
+  @override
+  Future<List<JobModel>> getJobs() async {
+    loadCalls++;
+    return jobs;
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('loadJobs fetches jobs and notifies listeners', () async {
+    final fakeService = FakeJobSchedulerService([
+      JobModel(id: '1', name: 'test'),
+    ]);
+    final provider = JobProvider(service: fakeService);
+    var notified = false;
+    provider.addListener(() => notified = true);
+
+    await provider.loadJobs();
+
+    expect(fakeService.loadCalls, 1);
+    expect(provider.jobs.length, 1);
+    expect(notified, isTrue);
+  });
+
+  test('updateJob adds and updates jobs with notification', () {
+    final provider = JobProvider(service: FakeJobSchedulerService([]));
+    var count = 0;
+    provider.addListener(() => count++);
+
+    final job = JobModel(id: '1', name: 'a');
+    provider.updateJob(job);
+
+    expect(provider.jobs.first.id, '1');
+    expect(count, 1);
+
+    provider.updateJob(job.copyWith(status: JobStatus.running));
+    expect(provider.jobs.first.status, JobStatus.running);
+    expect(count, 2);
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -60,6 +60,7 @@
 | test/noyau/unit/user_provider_test.dart | unit | package:anisphere/modules/noyau/providers/user_provider.dart | ✅ |
 | test/noyau/unit/consent_provider_test.dart | unit | package:anisphere/modules/noyau/providers/consent_provider.dart | ✅ |
 | test/noyau/unit/animal_provider_test.dart | unit | package:anisphere/modules/noyau/providers/animal_provider.dart | ✅ |
+| test/noyau/unit/job_provider_test.dart | unit | package:anisphere/modules/noyau/providers/job_provider.dart | ✅ |
 | test/noyau/widget/ia_banner_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_banner.dart | ✅ |
 | test/noyau/widget/more_menu_test.dart | widget | package:anisphere/modules/noyau/widgets/more_menu.dart | ✅ |
 | test/noyau/widget/ia_chip_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_chip.dart | ✅ |


### PR DESCRIPTION
## Summary
- implement JobModel and JobSchedulerService stubs
- add JobProvider using ChangeNotifier
- test JobProvider notifier logic
- track new test in both tracker files

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2d6b9d083209bd52a781bbb2fff