### PR TITLE
Add setUser method and notify on empty load

### DIFF
--- a/lib/modules/noyau/providers/user_provider.dart
+++ b/lib/modules/noyau/providers/user_provider.dart
@@ -23,6 +23,12 @@ class UserProvider with ChangeNotifier {
 
   UserProvider(this._userService, this._authService);
 
+  /// Met à jour l'utilisateur actuel et notifie les listeners.
+  void setUser(UserModel user) {
+    _user = user;
+    notifyListeners();
+  }
+
   /// 📦 Chargement local ou distant
   Future<void> loadUser() async {
     try {
@@ -31,7 +37,11 @@ class UserProvider with ChangeNotifier {
 
       if (currentUser != null) {
         _user = await _fetchUser(currentUser.uid);
+        debugPrint('[loadUser] Chargement utilisateur depuis Hive : $_user');
         _logAndNotifyUserState(_user, "chargé");
+        if (_user == null) {
+          notifyListeners();
+        }
 
         // ✅ Synchronisation IA si premium
         if (_user?.iaPremium == true) {
@@ -39,6 +49,7 @@ class UserProvider with ChangeNotifier {
         }
       } else {
         debugPrint("⚠️ Aucun utilisateur connecté.");
+        notifyListeners();
       }
     } catch (e) {
       _logError("loadUser", e);


### PR DESCRIPTION
## Summary
- add `setUser` method to `UserProvider`
- ensure listeners are notified in `loadUser` even when no user is found
- log a debug message when loading a user from Hive

## Testing
- `dart format lib/modules/noyau/providers/user_provider.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9bb051c8320b5ee35e4af0d01ea