### PR TITLE
Ensure user info loads after initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,13 +131,28 @@ void main() async {
           create: (_) => FeedbackOptionsProvider()..load(),
         ),
       ],
-      child: const MyApp(),
+      child: MyApp(),
     ),
   );
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class MyApp extends StatefulWidget {
+  MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+    // Providers are available here; load the current user after init.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Provider.of<UserProvider>(context, listen: false).loadUser();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/test/noyau/integration/app_initializer_test.dart
+++ b/test/noyau/integration/app_initializer_test.dart
@@ -10,7 +10,7 @@ void main() {
     await initTestEnv();
   });
   testWidgets('App launches to MainScreen', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
 
     expect(find.byType(MainScreen), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- make `MyApp` stateful so we can load user data once the providers are ready
- call `Provider.of<UserProvider>(context, listen: false).loadUser()` in `initState`
- adjust integration test to create `MyApp()` without the `const` constructor

## Testing
- `flutter test` *(fails: `flutter` command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9bcbac08320894e4d5011238991