### PR TITLE
fix loading state in user profile screen

### DIFF
--- a/lib/modules/noyau/screens/user_profile_screen.dart
+++ b/lib/modules/noyau/screens/user_profile_screen.dart
@@ -19,7 +19,7 @@ class UserProfileScreen extends StatelessWidget {
 
     if (user == null) {
       return const Scaffold(
-        body: Center(child: Text("Aucun utilisateur connecté.")),
+        body: Center(child: CircularProgressIndicator()),
       );
     }
 


### PR DESCRIPTION
## Summary
- show a loading spinner while user data is null in `UserProfileScreen`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9bfca8c8320a4554787f42bebbe