### PR TITLE
Fix sign up local persistence

### DIFF
--- a/lib/modules/noyau/services/auth_service.dart
+++ b/lib/modules/noyau/services/auth_service.dart
@@ -59,6 +59,7 @@ class AuthService {
       );
 
       await _userService.saveUserToFirebase(newUser);
+      await _userService.saveUserLocally(newUser);
       return newUser;
     } catch (e) {
       _logError("signUpWithEmail", e);


### PR DESCRIPTION
## Summary
- persist new user in Hive after signup

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9bfe5b083208ce2e251dd8af669