### PR TITLE
Add module model and extend service

### DIFF
--- a/lib/modules/noyau/models/module_model.dart
+++ b/lib/modules/noyau/models/module_model.dart
@@ -1,0 +1,41 @@
+library;
+
+class ModuleModel {
+  final String id;
+  final String name;
+  final String description;
+  final String category;
+  final String? icon;
+  final bool premium;
+
+  const ModuleModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.category,
+    this.icon,
+    this.premium = false,
+  });
+
+  factory ModuleModel.fromMap(Map<String, dynamic> map) {
+    return ModuleModel(
+      id: map['id'] ?? '',
+      name: map['name'] ?? '',
+      description: map['description'] ?? '',
+      category: map['category'] ?? '',
+      icon: map['icon'],
+      premium: map['premium'] ?? false,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'category': category,
+      'icon': icon,
+      'premium': premium,
+    };
+  }
+}

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -6,14 +6,45 @@
 library;
 
 import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
 
 class ModulesService {
-  static const List<String> allModules = [
-    "Santé",
-    "Éducation",
-    "Dressage",
+  static const List<ModuleModel> availableModules = [
+    ModuleModel(
+      id: 'sante',
+      name: 'Santé',
+      description: 'Suivi santé et bien-être',
+      category: 'Santé',
+      icon: '🩺',
+    ),
+    ModuleModel(
+      id: 'education',
+      name: 'Éducation',
+      description: 'Apprentissage et conseils',
+      category: 'Éducation',
+      icon: '📚',
+    ),
+    ModuleModel(
+      id: 'dressage',
+      name: 'Dressage',
+      description: 'Entraînement avancé',
+      category: 'Dressage',
+      icon: '🎯',
+      premium: true,
+    ),
     // 🔽 Ajouter ici les modules futurs
   ];
+
+  static List<String> get moduleNames =>
+      availableModules.map((m) => m.name).toList();
+
+  static Iterable<String> get categories =>
+      availableModules.map((m) => m.category).toSet();
+
+  static List<ModuleModel> getModulesByCategory(String category) =>
+      availableModules.where((m) => m.category == category).toList();
+
+  static List<String> get allModules => moduleNames;
 
   /// 🔄 Récupère le statut d’un module : actif, premium, disponible
   static String getStatus(String moduleName) {

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -10,4 +10,21 @@ void main() {
   test('allModules contains Santé', () {
     expect(ModulesService.allModules, contains('Santé'));
   });
+
+  test('moduleNames matches availableModules', () {
+    final names = ModulesService.availableModules.map((m) => m.name).toList();
+    expect(ModulesService.moduleNames, names);
+  });
+
+  test('categories expose unique categories', () {
+    final unique =
+        ModulesService.availableModules.map((m) => m.category).toSet();
+    expect(ModulesService.categories, unique);
+  });
+
+  test('getModulesByCategory filters correctly', () {
+    final category = ModulesService.availableModules.first.category;
+    final modules = ModulesService.getModulesByCategory(category);
+    expect(modules.every((m) => m.category == category), isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- define `ModuleModel`
- switch modules service to new model list
- keep backwards compatibility through `allModules`
- add helper getters and unit tests

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9d6863c832092a4cc2abc965ce6