### PR TITLE
Add ModuleCard widget

### DIFF
--- a/lib/modules/noyau/models/module_model.dart
+++ b/lib/modules/noyau/models/module_model.dart
@@ -1,0 +1,13 @@
+library;
+
+class ModuleModel {
+  final String id;
+  final String name;
+  final String description;
+
+  const ModuleModel({
+    required this.id,
+    required this.name,
+    required this.description,
+  });
+}

--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -1,0 +1,93 @@
+library;
+
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/widgets/module_card.dart';
+
+class ModulesByCategoryScreen extends StatefulWidget {
+  const ModulesByCategoryScreen({super.key});
+
+  @override
+  State<ModulesByCategoryScreen> createState() => _ModulesByCategoryScreenState();
+}
+
+class _ModulesByCategoryScreenState extends State<ModulesByCategoryScreen> {
+  final ModulesService _modulesService = ModulesService();
+
+  final Map<String, List<ModuleModel>> _modules = {
+    'Général': const [
+      ModuleModel(
+        id: 'sante',
+        name: 'Santé',
+        description: 'Suivi des vaccins, visites, soins médicaux.',
+      ),
+      ModuleModel(
+        id: 'education',
+        name: 'Éducation',
+        description: 'Programmes éducatifs IA et routines personnalisées.',
+      ),
+    ],
+    'Compétences': const [
+      ModuleModel(
+        id: 'dressage',
+        name: 'Dressage',
+        description: 'Entraînement avancé, objectifs, IA comparative.',
+      ),
+    ],
+  };
+
+  Map<String, String> _statuses = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStatuses();
+  }
+
+  Future<void> _loadStatuses() async {
+    final status = await _modulesService.getAllStatuses();
+    setState(() {
+      _statuses = status;
+    });
+  }
+
+  Future<void> _activate(String id) async {
+    await _modulesService.setActive(id);
+    _loadStatuses();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: _modules.entries.map((entry) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                entry.key,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF183153),
+                ),
+              ),
+              const SizedBox(height: 8),
+              ...entry.value.map((m) {
+                final status = _statuses[m.id] ?? 'disponible';
+                return ModuleCard(
+                  module: m,
+                  status: status,
+                  onActivate: () => _activate(m.id),
+                );
+              }),
+              const SizedBox(height: 24),
+            ],
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -5,6 +5,8 @@
 library;
 import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
+import 'package:anisphere/modules/noyau/widgets/module_card.dart';
 
 class ModulesScreen extends StatefulWidget {
   const ModulesScreen({super.key});
@@ -16,22 +18,22 @@ class ModulesScreen extends StatefulWidget {
 class _ModulesScreenState extends State<ModulesScreen> {
   final ModulesService _modulesService = ModulesService();
 
-  final List<Map<String, String>> _modulesInfo = [
-    {
-      "id": "sante",
-      "name": "Santé",
-      "description": "Suivi des vaccins, visites, soins médicaux.",
-    },
-    {
-      "id": "education",
-      "name": "Éducation",
-      "description": "Programmes éducatifs IA et routines personnalisées.",
-    },
-    {
-      "id": "dressage",
-      "name": "Dressage",
-      "description": "Entraînement avancé, objectifs, IA comparative.",
-    },
+  final List<ModuleModel> _modulesInfo = const [
+    ModuleModel(
+      id: 'sante',
+      name: 'Santé',
+      description: 'Suivi des vaccins, visites, soins médicaux.',
+    ),
+    ModuleModel(
+      id: 'education',
+      name: 'Éducation',
+      description: 'Programmes éducatifs IA et routines personnalisées.',
+    ),
+    ModuleModel(
+      id: 'dressage',
+      name: 'Dressage',
+      description: 'Entraînement avancé, objectifs, IA comparative.',
+    ),
   ];
 
   Map<String, String> _statuses = {};
@@ -62,75 +64,13 @@ class _ModulesScreenState extends State<ModulesScreen> {
         itemCount: _modulesInfo.length,
         itemBuilder: (context, index) {
           final module = _modulesInfo[index];
-          final id = module["id"]!;
-          final status = _statuses[id] ?? "disponible";
-          return _buildModuleCard(module, status);
+          final status = _statuses[module.id] ?? 'disponible';
+          return ModuleCard(
+            module: module,
+            status: status,
+            onActivate: () => _activate(module.id),
+          );
         },
-      ),
-    );
-  }
-
-  Widget _buildModuleCard(Map<String, String> module, String status) {
-    final Color chipColor = switch (status) {
-      "actif" => const Color(0xFF183153),
-      "disponible" => Colors.grey,
-      "premium" => const Color(0xFFFBC02D),
-      _ => Colors.grey,
-    };
-
-    return Card(
-      margin: const EdgeInsets.only(bottom: 16),
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    module["name"]!,
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Color(0xFF183153),
-                    ),
-                  ),
-                ),
-                Chip(
-                  label: Text(
-                    status,
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                  backgroundColor: chipColor,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              module["description"]!,
-              style: const TextStyle(color: Color(0xFF3A3A3A)),
-            ),
-            const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton(
-                onPressed: (status == "disponible")
-                    ? () => _activate(module["id"]!)
-                    : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF183153),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.grey.shade300,
-                ),
-                child: Text(status == "disponible" ? "Activer" : "Découvrir"),
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,0 +1,102 @@
+library;
+
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
+
+class ModuleCard extends StatelessWidget {
+  final ModuleModel module;
+  final String status;
+  final VoidCallback? onTap;
+  final VoidCallback? onActivate;
+
+  const ModuleCard({
+    super.key,
+    required this.module,
+    required this.status,
+    this.onTap,
+    this.onActivate,
+  });
+
+  Color _chipColor() {
+    switch (status) {
+      case 'actif':
+        return const Color(0xFF183153);
+      case 'premium':
+        return const Color(0xFFFBC02D);
+      default:
+        return Colors.grey;
+    }
+  }
+
+  String _chipLabel() {
+    switch (status) {
+      case 'actif':
+        return 'Actif';
+      case 'premium':
+        return 'Premium';
+      default:
+        return 'Disponible';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      module.name,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF183153),
+                      ),
+                    ),
+                  ),
+                  Chip(
+                    label: Text(
+                      _chipLabel(),
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    backgroundColor: _chipColor(),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                module.description,
+                style: const TextStyle(color: Color(0xFF3A3A3A)),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: status == 'disponible' ? onActivate : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF183153),
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: Colors.grey.shade300,
+                  ),
+                  child:
+                      Text(status == 'disponible' ? 'Activer' : 'Découvrir'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ModuleModel` data class
- create `ModuleCard` widget using theme colors
- implement `ModulesByCategoryScreen` sample with categorized modules
- refactor `ModulesScreen` to use `ModuleCard`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9d83840832092b7604acf1fa982