### PR TITLE
Add modules by category screen

### DIFF
--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -1,0 +1,64 @@
+library;
+
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/widgets/module_card.dart';
+
+class ModulesByCategoryScreen extends StatefulWidget {
+  final String category;
+  final List<Map<String, String>>? modules;
+
+  const ModulesByCategoryScreen({
+    super.key,
+    required this.category,
+    this.modules,
+  });
+
+  @override
+  State<ModulesByCategoryScreen> createState() => _ModulesByCategoryScreenState();
+}
+
+class _ModulesByCategoryScreenState extends State<ModulesByCategoryScreen> {
+  final ModulesService _service = ModulesService();
+  List<Map<String, String>> _modules = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.modules != null) {
+      _modules = widget.modules!;
+      _loading = false;
+    } else {
+      _loadModules();
+    }
+  }
+
+  Future<void> _loadModules() async {
+    final result = await _service.getModulesByCategory(widget.category);
+    if (!mounted) return;
+    setState(() {
+      _modules = result;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.category)),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: _modules.length,
+              itemBuilder: (context, index) {
+                final module = _modules[index];
+                return ModuleCard(
+                  name: module['name'] ?? '',
+                  description: module['description'],
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -15,6 +15,33 @@ class ModulesService {
     // 🔽 Ajouter ici les modules futurs
   ];
 
+  /// 📚 Association statique des catégories vers leurs modules.
+  static const Map<String, List<Map<String, String>>> _modulesByCategory = {
+    'Santé': [
+      {
+        'id': 'sante',
+        'name': 'Santé',
+        'description': 'Suivi des vaccins, visites, soins médicaux.',
+      },
+    ],
+    'Éducation': [
+      {
+        'id': 'education',
+        'name': 'Éducation',
+        'description':
+            'Programmes éducatifs IA et routines personnalisées.',
+      },
+    ],
+    'Dressage': [
+      {
+        'id': 'dressage',
+        'name': 'Dressage',
+        'description': 'Entraînement avancé, objectifs, IA comparative.',
+      },
+    ],
+    // 🔽 Ajouter ici d'autres catégories si nécessaire
+  };
+
   /// 🔄 Récupère le statut d’un module : actif, premium, disponible
   static String getStatus(String moduleName) {
     return LocalStorageService.get("module_status_$moduleName", defaultValue: "disponible");
@@ -65,5 +92,10 @@ class ModulesService {
   /// Méthode compatible IA pour activation rapide
   Future<void> setActive(String moduleName) async {
     await activate(moduleName);
+  }
+
+  /// 🔍 Récupère les modules d'une catégorie donnée.
+  Future<List<Map<String, String>>> getModulesByCategory(String category) async {
+    return _modulesByCategory[category] ?? [];
   }
 }

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,0 +1,33 @@
+library;
+
+import 'package:flutter/material.dart';
+
+class ModuleCard extends StatelessWidget {
+  final String name;
+  final String? description;
+  final VoidCallback? onTap;
+
+  const ModuleCard({
+    super.key,
+    required this.name,
+    this.description,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 2,
+      child: ListTile(
+        title: Text(
+          name,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        subtitle: description != null ? Text(description!) : null,
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/test/noyau/widget/modules_by_category_screen_test.dart
+++ b/test/noyau/widget/modules_by_category_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:anisphere/modules/noyau/screens/modules_by_category_screen.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  testWidgets('shows modules with AppBar title', (tester) async {
+    final modules = [
+      {'name': 'Test Module', 'description': 'demo'},
+    ];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ModulesByCategoryScreen(category: 'Demo', modules: modules),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Demo'), findsOneWidget);
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.text('Test Module'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add static module categories in `ModulesService`
- expose `getModulesByCategory` to fetch modules for a category
- add reusable `ModuleCard` widget
- create `ModulesByCategoryScreen` for listing modules
- test that `ModulesByCategoryScreen` shows modules and AppBar

## Testing
- `flutter test test/noyau/widget/modules_by_category_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9d91b10832099063156e79abf2b