### PR TITLE
Add ModuleCard widget and new screen

### DIFF
--- a/lib/modules/noyau/models/module_model.dart
+++ b/lib/modules/noyau/models/module_model.dart
@@ -1,0 +1,27 @@
+library;
+
+class ModuleModel {
+  final String id;
+  final String name;
+  final String description;
+
+  const ModuleModel({
+    required this.id,
+    required this.name,
+    required this.description,
+  });
+
+  factory ModuleModel.fromMap(Map<String, String> map) {
+    return ModuleModel(
+      id: map['id'] ?? '',
+      name: map['name'] ?? '',
+      description: map['description'] ?? '',
+    );
+  }
+
+  Map<String, String> toMap() => {
+        'id': id,
+        'name': name,
+        'description': description,
+      };
+}

--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -1,0 +1,86 @@
+library;
+
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
+import 'package:anisphere/modules/noyau/widgets/module_card.dart';
+
+class ModulesByCategoryScreen extends StatefulWidget {
+  const ModulesByCategoryScreen({super.key});
+
+  @override
+  State<ModulesByCategoryScreen> createState() => _ModulesByCategoryScreenState();
+}
+
+class _ModulesByCategoryScreenState extends State<ModulesByCategoryScreen> {
+  final ModulesService _modulesService = ModulesService();
+
+  final Map<String, List<ModuleModel>> _modulesByCategory = const {
+    'Bien-être': [
+      ModuleModel(
+        id: 'sante',
+        name: 'Santé',
+        description: 'Suivi des vaccins, visites, soins médicaux.',
+      ),
+    ],
+    'Apprentissage': [
+      ModuleModel(
+        id: 'education',
+        name: 'Éducation',
+        description: 'Programmes éducatifs IA et routines personnalisées.',
+      ),
+      ModuleModel(
+        id: 'dressage',
+        name: 'Dressage',
+        description: 'Entraînement avancé, objectifs, IA comparative.',
+      ),
+    ],
+  };
+
+  Map<String, String> _statuses = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStatuses();
+  }
+
+  Future<void> _loadStatuses() async {
+    final status = await _modulesService.getAllStatuses();
+    setState(() => _statuses = status);
+  }
+
+  Future<void> _activate(String id) async {
+    await _modulesService.setActive(id);
+    _loadStatuses();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Modules par catégorie')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: _modulesByCategory.entries
+            .expand((entry) => [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Text(
+                      entry.key,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  ...entry.value.map((m) {
+                    final status = _statuses[m.id] ?? 'disponible';
+                    return ModuleCard(
+                      module: m,
+                      status: status,
+                      onActivate: () => _activate(m.id),
+                    );
+                  }),
+                ])
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -5,6 +5,8 @@
 library;
 import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
+import 'package:anisphere/modules/noyau/widgets/module_card.dart';
 
 class ModulesScreen extends StatefulWidget {
   const ModulesScreen({super.key});
@@ -16,22 +18,22 @@ class ModulesScreen extends StatefulWidget {
 class _ModulesScreenState extends State<ModulesScreen> {
   final ModulesService _modulesService = ModulesService();
 
-  final List<Map<String, String>> _modulesInfo = [
-    {
-      "id": "sante",
-      "name": "Santé",
-      "description": "Suivi des vaccins, visites, soins médicaux.",
-    },
-    {
-      "id": "education",
-      "name": "Éducation",
-      "description": "Programmes éducatifs IA et routines personnalisées.",
-    },
-    {
-      "id": "dressage",
-      "name": "Dressage",
-      "description": "Entraînement avancé, objectifs, IA comparative.",
-    },
+  final List<ModuleModel> _modulesInfo = const [
+    ModuleModel(
+      id: 'sante',
+      name: 'Santé',
+      description: 'Suivi des vaccins, visites, soins médicaux.',
+    ),
+    ModuleModel(
+      id: 'education',
+      name: 'Éducation',
+      description: 'Programmes éducatifs IA et routines personnalisées.',
+    ),
+    ModuleModel(
+      id: 'dressage',
+      name: 'Dressage',
+      description: 'Entraînement avancé, objectifs, IA comparative.',
+    ),
   ];
 
   Map<String, String> _statuses = {};
@@ -62,76 +64,15 @@ class _ModulesScreenState extends State<ModulesScreen> {
         itemCount: _modulesInfo.length,
         itemBuilder: (context, index) {
           final module = _modulesInfo[index];
-          final id = module["id"]!;
-          final status = _statuses[id] ?? "disponible";
-          return _buildModuleCard(module, status);
+          final status = _statuses[module.id] ?? 'disponible';
+          return ModuleCard(
+            module: module,
+            status: status,
+            onActivate: () => _activate(module.id),
+          );
         },
       ),
     );
   }
 
-  Widget _buildModuleCard(Map<String, String> module, String status) {
-    final Color chipColor = switch (status) {
-      "actif" => const Color(0xFF183153),
-      "disponible" => Colors.grey,
-      "premium" => const Color(0xFFFBC02D),
-      _ => Colors.grey,
-    };
-
-    return Card(
-      margin: const EdgeInsets.only(bottom: 16),
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    module["name"]!,
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Color(0xFF183153),
-                    ),
-                  ),
-                ),
-                Chip(
-                  label: Text(
-                    status,
-                    style: const TextStyle(color: Colors.white),
-                  ),
-                  backgroundColor: chipColor,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              module["description"]!,
-              style: const TextStyle(color: Color(0xFF3A3A3A)),
-            ),
-            const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton(
-                onPressed: (status == "disponible")
-                    ? () => _activate(module["id"]!)
-                    : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF183153),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.grey.shade300,
-                ),
-                child: Text(status == "disponible" ? "Activer" : "Découvrir"),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,0 +1,90 @@
+library;
+
+import 'package:flutter/material.dart';
+import '../models/module_model.dart';
+
+class ModuleCard extends StatelessWidget {
+  final ModuleModel module;
+  final String status;
+  final VoidCallback? onTap;
+  final VoidCallback? onActivate;
+
+  const ModuleCard({
+    super.key,
+    required this.module,
+    required this.status,
+    this.onTap,
+    this.onActivate,
+  });
+
+  Color _chipColor(BuildContext context) {
+    switch (status) {
+      case 'actif':
+        return Theme.of(context).primaryColor;
+      case 'premium':
+        return const Color(0xFFFBC02D);
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      module.name,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF183153),
+                      ),
+                    ),
+                  ),
+                  Chip(
+                    label: Text(
+                      status,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    backgroundColor: _chipColor(context),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                module.description,
+                style: const TextStyle(color: Color(0xFF3A3A3A)),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: status == 'disponible' ? onActivate : onTap,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF183153),
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: Colors.grey.shade300,
+                  ),
+                  child: Text(status == 'disponible' ? 'Activer' : 'Découvrir'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `ModuleModel`
- add `ModuleCard` widget for displaying module info
- refactor `ModulesScreen` to use `ModuleCard`
- add `ModulesByCategoryScreen` using the new widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9dc9e3883209e7f222b0a72f991