### PR TITLE
Add modules by category screen

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -69,6 +69,7 @@
 | test/noyau/widget/ia_suggestion_card_test.dart | widget | package:anisphere/modules/noyau/widgets/ia_suggestion_card.dart | ✅ |
 | test/noyau/widget/notification_icon_test.dart | widget | package:anisphere/modules/noyau/widgets/notification_icon.dart | ✅ |
 | test/noyau/widget/modules_screen_test.dart | widget | package:anisphere/modules/noyau/screens/modules_screen.dart | ✅ |
+| test/noyau/widget/modules_by_category_screen_test.dart | widget | package:anisphere/modules/noyau/screens/modules_by_category_screen.dart | ✅ |
 | test/noyau/widget/main_screen_test.dart | widget | package:anisphere/modules/noyau/screens/main_screen.dart | ✅ |
 | test/noyau/widget/animal_profile_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_profile_screen.dart | ✅ |
 | test/noyau/widget/user_profile_screen_test.dart | widget | package:anisphere/modules/noyau/screens/user_profile_screen.dart | ✅ |

--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -1,0 +1,74 @@
+library;
+
+import 'package:flutter/material.dart';
+import '../services/modules_service.dart';
+import '../widgets/module_card.dart';
+
+class ModulesByCategoryScreen extends StatefulWidget {
+  final String category;
+  final List<Map<String, String>>? modules;
+
+  const ModulesByCategoryScreen({
+    super.key,
+    required this.category,
+    this.modules,
+  });
+
+  @override
+  State<ModulesByCategoryScreen> createState() => _ModulesByCategoryScreenState();
+}
+
+class _ModulesByCategoryScreenState extends State<ModulesByCategoryScreen> {
+  final ModulesService _modulesService = ModulesService();
+  List<Map<String, String>> _modules = [];
+  Map<String, String> _statuses = {};
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.modules != null) {
+      _modules = widget.modules!;
+      _loadStatuses();
+    } else {
+      _loadModules();
+    }
+  }
+
+  Future<void> _loadModules() async {
+    final mods = await _modulesService.getModulesByCategory(widget.category);
+    setState(() => _modules = mods);
+    _loadStatuses();
+  }
+
+  Future<void> _loadStatuses() async {
+    final status = await _modulesService.getAllStatuses();
+    if (!mounted) return;
+    setState(() => _statuses = status);
+  }
+
+  Future<void> _activate(String id) async {
+    await _modulesService.setActive(id);
+    _loadStatuses();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.category)),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _modules.length,
+        itemBuilder: (context, index) {
+          final module = _modules[index];
+          final id = module['id']!;
+          final status = _statuses[id] ?? 'disponible';
+          return ModuleCard(
+            module: module,
+            status: status,
+            onActivate: () => _activate(id),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -15,6 +15,33 @@ class ModulesService {
     // 🔽 Ajouter ici les modules futurs
   ];
 
+  /// 📦 Liste détaillée des modules par catégorie.
+  static const Map<String, List<Map<String, String>>> modulesByCategory = {
+    'Général': [
+      {
+        'id': 'sante',
+        'name': 'Santé',
+        'description': 'Suivi des vaccins, visites, soins médicaux.',
+      },
+      {
+        'id': 'education',
+        'name': 'Éducation',
+        'description': 'Programmes éducatifs IA et routines personnalisées.',
+      },
+      {
+        'id': 'dressage',
+        'name': 'Dressage',
+        'description': 'Entraînement avancé, objectifs, IA comparative.',
+      },
+    ],
+  };
+
+  /// 🔍 Retourne la liste des modules pour une catégorie donnée.
+  static Future<List<Map<String, String>>> getModulesByCategory(
+      String category) async {
+    return modulesByCategory[category] ?? <Map<String, String>>[];
+  }
+
   /// 🔄 Récupère le statut d’un module : actif, premium, disponible
   static String getStatus(String moduleName) {
     return LocalStorageService.get("module_status_$moduleName", defaultValue: "disponible");

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,0 +1,80 @@
+library;
+
+import 'package:flutter/material.dart';
+
+class ModuleCard extends StatelessWidget {
+  final Map<String, String> module;
+  final String status;
+  final VoidCallback? onActivate;
+
+  const ModuleCard({
+    super.key,
+    required this.module,
+    required this.status,
+    this.onActivate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final Color chipColor = switch (status) {
+      'actif' => const Color(0xFF183153),
+      'disponible' => Colors.grey,
+      'premium' => const Color(0xFFFBC02D),
+      _ => Colors.grey,
+    };
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      color: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    module['name']!,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Color(0xFF183153),
+                    ),
+                  ),
+                ),
+                Chip(
+                  label: Text(
+                    status,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  backgroundColor: chipColor,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              module['description']!,
+              style: const TextStyle(color: Color(0xFF3A3A3A)),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: (status == 'disponible') ? onActivate : null,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF183153),
+                  foregroundColor: Colors.white,
+                  disabledBackgroundColor: Colors.grey.shade300,
+                ),
+                child: Text(status == 'disponible' ? 'Activer' : 'Découvrir'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/noyau/widget/modules_by_category_screen_test.dart
+++ b/test/noyau/widget/modules_by_category_screen_test.dart
@@ -1,0 +1,22 @@
+// Copilot Prompt : Test automatique généré pour modules_by_category_screen.dart (widget)
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:anisphere/modules/noyau/screens/modules_by_category_screen.dart';
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  testWidgets('renders AppBar with category title', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: ModulesByCategoryScreen(category: 'Général'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.text('Général'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- show modules filtered by category
- new `ModuleCard` widget for displaying a module
- support modules by category in `ModulesService`
- widget test and update `docs/test_tracker.md`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef9dd7a888320bf545d1013f14fc7