### PR TITLE
Fix ModulesScreen conflict

### DIFF
--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -5,7 +5,6 @@
 library;
 import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
-import 'package:anisphere/modules/noyau/models/module_model.dart';
 import 'package:anisphere/modules/noyau/widgets/module_card.dart';
 
 class ModulesScreen extends StatefulWidget {
@@ -101,8 +100,13 @@ class _ModulesScreenState extends State<ModulesScreen> {
       ),
     );
   }
-<<<<<<< HEAD
-=======
 
->>>>>>> codex/ajouter-widget-module_card
+  Widget _buildModuleCard(Map<String, String> module, String status) {
+    return ModuleCard(
+      module: module,
+      status: status,
+      onActivate:
+          status == 'disponible' ? () => _activate(module['id']!) : null,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- clean merge conflict and remove unused import
- add _buildModuleCard helper using `ModuleCard`

## Testing
- `dart format lib/modules/noyau/screens/modules_screen.dart` *(fails: command not found)*
- `flutter analyze lib/modules/noyau/screens/modules_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f283e298c83208d9dfd8626787bb4