### PR TITLE
Implement modules getter and update screens

### DIFF
--- a/lib/modules/noyau/screens/feedback_settings_screen.dart
+++ b/lib/modules/noyau/screens/feedback_settings_screen.dart
@@ -4,7 +4,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../services/modules_service.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
 import '../providers/feedback_options_provider.dart';
 
 class FeedbackSettingsScreen extends StatefulWidget {

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -17,34 +17,16 @@ class ModulesScreen extends StatefulWidget {
 
 class _ModulesScreenState extends State<ModulesScreen> {
   final ModulesService _modulesService = ModulesService();
-
-  final Map<String, List<Map<String, String>>> _modulesByCategory = {
-    'Bien-être': [
-      {
-        "id": "sante",
-        "name": "Santé",
-        "description": "Suivi des vaccins, visites, soins médicaux.",
-      },
-      {
-        "id": "dressage",
-        "name": "Dressage",
-        "description": "Entraînement avancé, objectifs, IA comparative.",
-      },
-    ],
-    'Apprentissage': [
-      {
-        "id": "education",
-        "name": "Éducation",
-        "description": "Programmes éducatifs IA et routines personnalisées.",
-      },
-    ],
-  };
+  final Map<String, List<ModuleModel>> _modulesByCategory = {};
 
   Map<String, String> _statuses = {};
 
   @override
   void initState() {
     super.initState();
+    for (final m in ModulesService.modules) {
+      _modulesByCategory.putIfAbsent(m.category, () => []).add(m);
+    }
     _loadStatuses();
   }
 
@@ -85,11 +67,15 @@ class _ModulesScreenState extends State<ModulesScreen> {
                   itemCount: modules.length,
                   itemBuilder: (context, idx) {
                     final module = modules[idx];
-                    final id = module['id']!;
+                    final id = module.id;
                     final status = _statuses[id] ?? 'disponible';
                     return SizedBox(
                       width: 220,
-                      child: _buildModuleCard(module, status),
+                      child: ModuleCard(
+                        module: module,
+                        status: status,
+                        onActivate: () => _activate(id),
+                      ),
                     );
                   },
                 ),
@@ -101,8 +87,4 @@ class _ModulesScreenState extends State<ModulesScreen> {
       ),
     );
   }
-<<<<<<< HEAD
-=======
-
->>>>>>> codex/ajouter-widget-module_card
 }

--- a/lib/modules/noyau/screens/security_settings_screen.dart
+++ b/lib/modules/noyau/screens/security_settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
 import '../models/security_settings_model.dart';
-import '../services/modules_service.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
 
 class SecuritySettingsScreen extends StatefulWidget {
   const SecuritySettingsScreen({super.key});

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -15,51 +15,42 @@ class ModulesService {
       name: 'Santé',
       description: 'Suivi santé et bien-être',
       category: 'Santé',
-      icon: '🩺',
     ),
     ModuleModel(
       id: 'education',
       name: 'Éducation',
       description: 'Apprentissage et conseils',
       category: 'Éducation',
-      icon: '📚',
     ),
     ModuleModel(
       id: 'dressage',
       name: 'Dressage',
       description: 'Entraînement avancé',
       category: 'Dressage',
-      icon: '🎯',
-      premium: true,
+      isPremium: true,
     ),
     // 🔽 Ajouter ici les modules futurs
   ];
 
+  /// Getter exposant la liste des modules disponibles.
+  static List<ModuleModel> get modules => List.unmodifiable(availableModules);
+
+  /// Liste des identifiants de modules utilisée pour le stockage local.
+  static List<String> get allModules =>
+      modules.map((m) => m.id).toList(growable: false);
+
   /// 📦 Liste détaillée des modules par catégorie.
-  static const Map<String, List<Map<String, String>>> modulesByCategory = {
-    'Général': [
-      {
-        'id': 'sante',
-        'name': 'Santé',
-        'description': 'Suivi des vaccins, visites, soins médicaux.',
-      },
-      {
-        'id': 'education',
-        'name': 'Éducation',
-        'description': 'Programmes éducatifs IA et routines personnalisées.',
-      },
-      {
-        'id': 'dressage',
-        'name': 'Dressage',
-        'description': 'Entraînement avancé, objectifs, IA comparative.',
-      },
-    ],
-  };
+  static Map<String, List<ModuleModel>> get modulesByCategory {
+    final Map<String, List<ModuleModel>> result = {};
+    for (final module in modules) {
+      result.putIfAbsent(module.category, () => []).add(module);
+    }
+    return result;
+  }
 
   /// 🔍 Retourne la liste des modules pour une catégorie donnée.
-  static Future<List<Map<String, String>>> getModulesByCategory(
-      String category) async {
-    return modulesByCategory[category] ?? <Map<String, String>>[];
+  static List<ModuleModel> getModulesByCategory(String category) {
+    return modulesByCategory[category] ?? <ModuleModel>[];
   }
 
   /// 🔄 Récupère le statut d’un module : actif, premium, disponible
@@ -115,8 +106,4 @@ class ModulesService {
     await activate(moduleName);
   }
 
-  /// 🔍 Récupère les modules d'une catégorie donnée.
-  Future<List<Map<String, String>>> getModulesByCategory(String category) async {
-    return _modulesByCategory[category] ?? [];
-  }
 }

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,9 +1,10 @@
 library;
 
 import 'package:flutter/material.dart';
+import '../models/module_model.dart';
 
 class ModuleCard extends StatelessWidget {
-  final Map<String, String> module;
+  final ModuleModel module;
   final String status;
   final VoidCallback? onActivate;
 
@@ -37,7 +38,7 @@ class ModuleCard extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    module['name']!,
+                    module.name,
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
@@ -56,7 +57,7 @@ class ModuleCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Text(
-              module['description']!,
+              module.description,
               style: const TextStyle(color: Color(0xFF3A3A3A)),
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- define `modules` and `allModules` getters in `ModulesService`
- refactor to return `ModuleModel` objects per category
- update `ModuleCard` to accept a `ModuleModel`
- use new model list in `ModulesScreen`
- fix imports in feedback and security settings screens

## Testing
- `flutter format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f28430e4c83209476a75670fd5daf