### PR TITLE
Add module getters and update tests

### DIFF
--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -35,6 +35,13 @@ class ModulesService {
     // 🔽 Ajouter ici les modules futurs
   ];
 
+  /// Liste statique des modules disponibles.
+  static List<ModuleModel> get modules => availableModules;
+
+  /// Liste statique des identifiants de modules.
+  static List<String> get allModules =>
+      modules.map((m) => m.id).toList();
+
   /// 📦 Liste détaillée des modules par catégorie.
   static const Map<String, List<Map<String, String>>> modulesByCategory = {
     'Général': [
@@ -113,10 +120,5 @@ class ModulesService {
   /// Méthode compatible IA pour activation rapide
   Future<void> setActive(String moduleName) async {
     await activate(moduleName);
-  }
-
-  /// 🔍 Récupère les modules d'une catégorie donnée.
-  Future<List<Map<String, String>>> getModulesByCategory(String category) async {
-    return _modulesByCategory[category] ?? [];
   }
 }

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -24,24 +24,24 @@ void main() {
     await tempDir.delete(recursive: true);
   });
 
-  test('allModules contains Santé', () {
-    expect(ModulesService.allModules, contains('Santé'));
+  test('allModules contains sante', () {
+    expect(ModulesService.allModules, contains('sante'));
   });
 
   test('activate and getStatus', () async {
-    await ModulesService.activate('Santé');
-    expect(ModulesService.getStatus('Santé'), 'actif');
+    await ModulesService.activate('sante');
+    expect(ModulesService.getStatus('sante'), 'actif');
   });
 
   test('markPremium updates status', () async {
-    await ModulesService.markPremium('Éducation');
-    expect(ModulesService.getStatus('Éducation'), 'premium');
+    await ModulesService.markPremium('education');
+    expect(ModulesService.getStatus('education'), 'premium');
   });
 
   test('resetAllStatuses resets to disponible', () async {
-    await ModulesService.activate('Dressage');
+    await ModulesService.activate('dressage');
     await ModulesService.resetAllStatuses();
-    expect(ModulesService.getStatus('Dressage'), 'disponible');
+    expect(ModulesService.getStatus('dressage'), 'disponible');
   });
 
   test('getAllModulesStatus returns all modules', () async {
@@ -51,8 +51,8 @@ void main() {
 
   test('getAllStatuses and setActive', () async {
     final service = ModulesService();
-    await service.setActive('Santé');
+    await service.setActive('sante');
     final statuses = await service.getAllStatuses();
-    expect(statuses['Santé'], 'actif');
+    expect(statuses['sante'], 'actif');
   });
 }

--- a/test/noyau/unit/modules_summary_service_test.dart
+++ b/test/noyau/unit/modules_summary_service_test.dart
@@ -39,9 +39,9 @@ void main() {
     tempDir = await Directory.systemTemp.createTemp();
     Hive.init(tempDir.path);
     await LocalStorageService.init();
-    await LocalStorageService.set('module_status_Santé', 'actif');
-    await LocalStorageService.set('module_status_Éducation', 'actif');
-    await LocalStorageService.set('module_status_Dressage', 'actif');
+    await LocalStorageService.set('module_status_sante', 'actif');
+    await LocalStorageService.set('module_status_education', 'actif');
+    await LocalStorageService.set('module_status_dressage', 'actif');
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
## Summary
- expose `ModulesService.modules` and `ModulesService.allModules`
- remove unused instance `getModulesByCategory`
- update tests for module IDs

## Testing
- `flutter analyze` *(fails: Dart SDK version solving failed)*
- `flutter test` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_684f2844da3c832081259765edd04e2b