### PR TITLE
Update ModuleModel with premium support

### DIFF
--- a/lib/modules/noyau/models/module_model.dart
+++ b/lib/modules/noyau/models/module_model.dart
@@ -3,23 +3,31 @@ class ModuleModel {
   final String name;
   final String category;
   final String description;
+  final String icon;
+  final bool premium;
+  @Deprecated('Use premium')
   final bool isPremium;
 
-  ModuleModel({
+  const ModuleModel({
     required this.id,
     required this.name,
     required this.category,
     required this.description,
-    this.isPremium = false,
+    this.icon = '',
+    this.premium = false,
+    @Deprecated('Use premium') this.isPremium = false,
   });
 
   factory ModuleModel.fromMap(Map<String, dynamic> map) {
+    final premium = map['premium'] as bool? ?? map['isPremium'] as bool? ?? false;
     return ModuleModel(
       id: map['id'] as String,
       name: map['name'] as String,
       category: map['category'] as String,
       description: map['description'] as String,
-      isPremium: map['isPremium'] as bool? ?? false,
+      icon: map['icon'] as String? ?? '',
+      premium: premium,
+      isPremium: premium,
     );
   }
 
@@ -29,7 +37,8 @@ class ModuleModel {
       'name': name,
       'category': category,
       'description': description,
-      'isPremium': isPremium,
+      'icon': icon,
+      'premium': premium,
     };
   }
 }

--- a/test/noyau/unit/module_model_test.dart
+++ b/test/noyau/unit/module_model_test.dart
@@ -8,7 +8,8 @@ void main() {
       name: 'Santé',
       category: 'Bien-être',
       description: 'Suivi santé',
-      isPremium: false,
+      icon: '🩺',
+      premium: true,
     );
 
     test('toMap returns expected map', () {
@@ -17,7 +18,8 @@ void main() {
         'name': 'Santé',
         'category': 'Bien-être',
         'description': 'Suivi santé',
-        'isPremium': false,
+        'icon': '🩺',
+        'premium': true,
       });
     });
 
@@ -27,7 +29,8 @@ void main() {
       expect(restored.name, module.name);
       expect(restored.category, module.category);
       expect(restored.description, module.description);
-      expect(restored.isPremium, module.isPremium);
+      expect(restored.icon, module.icon);
+      expect(restored.premium, module.premium);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `icon` and `premium` fields to `ModuleModel`
- deprecate `isPremium` and update serialization
- adjust module model unit test

## Testing
- `dart format lib/modules/noyau/models/module_model.dart test/noyau/unit/module_model_test.dart` *(failed: `dart` not found)*
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f283f7ffc8320a2eada9ee1f90f7f