### PR TITLE
Fix missing ModuleModel import

### DIFF
--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -6,6 +6,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
 import 'package:anisphere/modules/noyau/widgets/module_card.dart';
+import 'package:anisphere/modules/noyau/models/module_model.dart';
 
 class ModulesScreen extends StatefulWidget {
   const ModulesScreen({super.key});


### PR DESCRIPTION
## Summary
- add `ModuleModel` import in `ModulesScreen`

## Testing
- `flutter doctor -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2b9870448320ad035b6fad03ccb9