### PR TITLE
Add Paywall screen with basic plans

### DIFF
--- a/lib/modules/noyau/models/payment_plan.dart
+++ b/lib/modules/noyau/models/payment_plan.dart
@@ -1,0 +1,15 @@
+library;
+
+class PaymentPlan {
+  final String id;
+  final String name;
+  final double price;
+  final String description;
+
+  const PaymentPlan({
+    required this.id,
+    required this.name,
+    required this.price,
+    required this.description,
+  });
+}

--- a/lib/modules/noyau/providers/payment_provider.dart
+++ b/lib/modules/noyau/providers/payment_provider.dart
@@ -1,0 +1,33 @@
+library;
+
+import 'package:flutter/foundation.dart';
+import '../models/payment_plan.dart';
+import '../services/payment_service.dart';
+
+class PaymentProvider extends ChangeNotifier {
+  final PaymentService _service;
+  final List<PaymentPlan> _plans = const [
+    PaymentPlan(
+      id: 'premium',
+      name: 'Premium Individuel',
+      price: 3.99,
+      description:
+          'Fonctionnalités cloud, exports stylisés, IA renforcée',
+    ),
+    PaymentPlan(
+      id: 'pro',
+      name: 'Pro / Éducateur',
+      price: 9.99,
+      description: 'Interface multi-profils, IA éducative avancée',
+    ),
+  ];
+
+  PaymentProvider({PaymentService? service})
+      : _service = service ?? PaymentService();
+
+  List<PaymentPlan> get plans => List.unmodifiable(_plans);
+
+  Future<void> purchase(PaymentPlan plan) async {
+    await _service.purchaseItem(plan);
+  }
+}

--- a/lib/modules/noyau/screens/paywall_screen.dart
+++ b/lib/modules/noyau/screens/paywall_screen.dart
@@ -1,0 +1,42 @@
+// Copilot Prompt : Écran Paywall/IAP pour AniSphère.
+// Affiche les plans depuis PaymentProvider et achète via PaymentService.purchaseItem.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/payment_provider.dart';
+import '../models/payment_plan.dart';
+
+class PaywallScreen extends StatelessWidget {
+  const PaywallScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<PaymentProvider>(context);
+    final plans = provider.plans;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Passer Premium'),
+      ),
+      body: ListView.builder(
+        itemCount: plans.length,
+        itemBuilder: (context, index) {
+          final plan = plans[index];
+          return Card(
+            margin: const EdgeInsets.all(12),
+            child: ListTile(
+              title: Text(plan.name),
+              subtitle: Text('${plan.price.toStringAsFixed(2)} €/mois'),
+              trailing: ElevatedButton(
+                onPressed: () => provider.purchase(plan),
+                child: const Text('Choisir'),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/modules/noyau/services/payment_service.dart
+++ b/lib/modules/noyau/services/payment_service.dart
@@ -1,0 +1,11 @@
+library;
+
+import 'package:flutter/foundation.dart';
+import '../models/payment_plan.dart';
+
+class PaymentService {
+  Future<void> purchaseItem(PaymentPlan plan) async {
+    debugPrint('\u{1F4B3} purchaseItem: ${plan.id}');
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+}

--- a/test/noyau/widget/paywall_screen_test.dart
+++ b/test/noyau/widget/paywall_screen_test.dart
@@ -1,0 +1,54 @@
+// Copilot Prompt : Test automatique généré pour paywall_screen.dart (widget)
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:anisphere/modules/noyau/screens/paywall_screen.dart';
+import 'package:anisphere/modules/noyau/providers/payment_provider.dart';
+import 'package:anisphere/modules/noyau/services/payment_service.dart';
+import 'package:anisphere/modules/noyau/models/payment_plan.dart';
+
+import '../../test_config.dart';
+
+class _TestPaymentService extends PaymentService {
+  bool called = false;
+  @override
+  Future<void> purchaseItem(PaymentPlan plan) async {
+    called = true;
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  testWidgets('renders plans list', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => PaymentProvider(),
+        child: const MaterialApp(home: PaywallScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Premium Individuel'), findsOneWidget);
+    expect(find.text('Pro / Éducateur'), findsOneWidget);
+  });
+
+  testWidgets('purchase button calls service', (tester) async {
+    final service = _TestPaymentService();
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => PaymentProvider(service: service),
+        child: const MaterialApp(home: PaywallScreen()),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Choisir').first);
+    await tester.pump();
+
+    expect(service.called, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add a `PaymentPlan` model
- add `PaymentProvider` and `PaymentService`
- implement `PaywallScreen` showing plans and purchase buttons
- add widget tests for paywall screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/noyau/widget/paywall_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2f2d848c83209c5111ab2a134b02