### PR TITLE
Add IAP logs

### DIFF
--- a/lib/modules/noyau/logic/ia_logger.dart
+++ b/lib/modules/noyau/logic/ia_logger.dart
@@ -8,6 +8,26 @@ import '../services/local_storage_service.dart';
 import 'ia_config.dart';
 import 'ia_channel.dart';
 
+/// Types d'événements enregistrés dans le journal IA.
+enum IALogEvent {
+  IAP_PURCHASED,
+  IAP_EXPIRED,
+  IAP_CANCELLED,
+}
+
+extension IALogEventName on IALogEvent {
+  String get name {
+    switch (this) {
+      case IALogEvent.IAP_PURCHASED:
+        return 'IAP_PURCHASED';
+      case IALogEvent.IAP_EXPIRED:
+        return 'IAP_EXPIRED';
+      case IALogEvent.IAP_CANCELLED:
+        return 'IAP_CANCELLED';
+    }
+  }
+}
+
 class IALogger {
   static const String _key = "ia_logs";
 
@@ -36,6 +56,30 @@ class IALogger {
   static Future<void> clearLogs() async {
     await LocalStorageService.set(_key, <String>[]);
     await log(message: "CLEAR_LOGS", channel: IAChannel.system);
+  }
+
+  /// 🎟️ Enregistre un achat in-app réussi
+  static Future<void> logIAPPurchased() async {
+    await log(
+      message: IALogEvent.IAP_PURCHASED.name,
+      channel: IAChannel.system,
+    );
+  }
+
+  /// ⏰ Enregistre l'expiration d'un achat in-app
+  static Future<void> logIAPExpired() async {
+    await log(
+      message: IALogEvent.IAP_EXPIRED.name,
+      channel: IAChannel.system,
+    );
+  }
+
+  /// ❌ Enregistre l'annulation d'un achat in-app
+  static Future<void> logIAPCancelled() async {
+    await log(
+      message: IALogEvent.IAP_CANCELLED.name,
+      channel: IAChannel.system,
+    );
   }
 
   /// 🧹 Si trop de logs, on garde uniquement les plus récents

--- a/lib/modules/noyau/services/payment_service.dart
+++ b/lib/modules/noyau/services/payment_service.dart
@@ -1,0 +1,30 @@
+library;
+
+import '../logic/ia_logger.dart';
+
+/// États possibles d'un achat in-app.
+enum PurchaseState { initial, purchased, expired, cancelled }
+
+/// Gère la mise à jour du statut d'achat et journalise les changements.
+class PaymentService {
+  PurchaseState _state = PurchaseState.initial;
+
+  PurchaseState get state => _state;
+
+  Future<void> updateState(PurchaseState newState) async {
+    _state = newState;
+    switch (newState) {
+      case PurchaseState.purchased:
+        await IALogger.logIAPPurchased();
+        break;
+      case PurchaseState.expired:
+        await IALogger.logIAPExpired();
+        break;
+      case PurchaseState.cancelled:
+        await IALogger.logIAPCancelled();
+        break;
+      case PurchaseState.initial:
+        break;
+    }
+  }
+}

--- a/test/noyau/unit/ia_logger_test.dart
+++ b/test/noyau/unit/ia_logger_test.dart
@@ -1,14 +1,43 @@
 // Copilot Prompt : Test automatique généré pour ia_logger.dart (unit)
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:io';
+
 import '../../test_config.dart';
+import 'package:hive/hive.dart';
 import 'package:anisphere/modules/noyau/logic/ia_logger.dart';
+import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
+import 'package:anisphere/modules/noyau/services/payment_service.dart';
 
 void main() {
+  late Directory tempDir;
+
   setUpAll(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await LocalStorageService.init();
+  });
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk('users');
+    await Hive.deleteBoxFromDisk('animals');
+    await Hive.deleteBoxFromDisk('settings');
+    await tempDir.delete(recursive: true);
   });
   test('getLogs returns empty list by default', () {
     final logs = IALogger.getLogs();
     expect(logs, isEmpty);
+  });
+
+  test('PaymentService triggers IAP logs', () async {
+    final service = PaymentService();
+    await service.updateState(PurchaseState.purchased);
+    await service.updateState(PurchaseState.expired);
+    await service.updateState(PurchaseState.cancelled);
+
+    final logs = IALogger.getLogs();
+    expect(logs.any((l) => l.contains('IAP_PURCHASED')), isTrue);
+    expect(logs.any((l) => l.contains('IAP_EXPIRED')), isTrue);
+    expect(logs.any((l) => l.contains('IAP_CANCELLED')), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add `IALogEvent` enum with new values
- expose helper methods in `IALogger`
- implement `PaymentService` to track purchase states
- update IA logger unit test for purchase events

## Testing
- `flutter format lib/modules/noyau/logic/ia_logger.dart lib/modules/noyau/services/payment_service.dart test/noyau/unit/ia_logger_test.dart` *(fails: command not found)*
- `flutter test test/noyau/unit/ia_logger_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2f33d3748320b4bef0e68fe1d193