### PR TITLE
Implement IAP validator service

### DIFF
--- a/lib/modules/noyau/services/iap_validator.dart
+++ b/lib/modules/noyau/services/iap_validator.dart
@@ -1,0 +1,40 @@
+// Copilot Prompt : Service de validation d'achats in-app pour AniSphère.
+// Vérifie les jetons localement et marque les déblocages suspects.
+// Utilise LocalStorageService pour verrouiller si la validation échoue.
+library;
+
+import 'package:flutter/foundation.dart';
+
+import 'local_storage_service.dart';
+
+class IapValidator {
+  static const _validKey = 'iap_valid_tokens';
+  static const _suspiciousKey = 'iap_suspicious_tokens';
+  static const _lockKey = 'iap_locked';
+
+  /// Vérifie un reçu d'achat localement.
+  /// Retourne `true` si le reçu est reconnu comme valide.
+  Future<bool> validate(String receipt) async {
+    final stored = LocalStorageService.get(_validKey, defaultValue: <String>[]);
+    final tokens = stored is List ? stored.cast<String>() : <String>[];
+    final isValid = tokens.contains(receipt);
+    if (!isValid) {
+      await _markSuspicious(receipt);
+      await LocalStorageService.set(_lockKey, true);
+      debugPrint('❌ Reçu invalide : $receipt');
+    } else {
+      await LocalStorageService.set(_lockKey, false);
+      debugPrint('✅ Reçu valide : $receipt');
+    }
+    return isValid;
+  }
+
+  Future<void> _markSuspicious(String receipt) async {
+    final stored = LocalStorageService.get(_suspiciousKey, defaultValue: <String>[]);
+    final list = stored is List ? List<String>.from(stored) : <String>[];
+    if (!list.contains(receipt)) {
+      list.add(receipt);
+      await LocalStorageService.set(_suspiciousKey, list);
+    }
+  }
+}

--- a/test/noyau/unit/iap_validator_test.dart
+++ b/test/noyau/unit/iap_validator_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/services/iap_validator.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('iap_validator placeholder', () {
+    final validator = IapValidator();
+    expect(validator, isA<IapValidator>());
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple local IAP validator service
- record suspicious tokens in local storage
- lock local unlocks when validation fails
- provide placeholder unit test for the validator

## Testing
- `flutter test test/noyau/unit/iap_validator_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffaaee21883209a660220d5850af0