### PR TITLE
Add subscription support to PaymentProvider

### DIFF
--- a/lib/modules/noyau/providers/payment_provider.dart
+++ b/lib/modules/noyau/providers/payment_provider.dart
@@ -1,11 +1,16 @@
 library;
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import '../models/payment_plan.dart';
 import '../services/payment_service.dart';
 
 class PaymentProvider extends ChangeNotifier {
   final PaymentService _service;
+  late final StreamSubscription<List<String>> _subscriptionSub;
+  List<String> _subscriptions = const [];
+  bool _isPremium = false;
   final List<PaymentPlan> _plans = const [
     PaymentPlan(
       id: 'premium',
@@ -27,7 +32,33 @@ class PaymentProvider extends ChangeNotifier {
 
   List<PaymentPlan> get plans => List.unmodifiable(_plans);
 
+  /// Returns `true` if the user currently has an active premium subscription.
+  bool get isPremium => _isPremium;
+
+  /// Active subscription identifiers for the current user.
+  List<String> get subscriptions => List.unmodifiable(_subscriptions);
+
+  /// Initializes the provider by loading current subscriptions and
+  /// listening to updates from [PaymentService].
+  Future<void> init() async {
+    _subscriptions = await _service.getActiveSubscriptions();
+    _isPremium = _subscriptions.contains('premium');
+    notifyListeners();
+    _subscriptionSub = _service.subscriptionUpdates.listen((subs) {
+      _subscriptions = subs;
+      _isPremium = _subscriptions.contains('premium');
+      notifyListeners();
+    });
+  }
+
   Future<void> purchase(PaymentPlan plan) async {
     await _service.purchaseItem(plan);
+  }
+
+  @override
+  void dispose() {
+    _subscriptionSub.cancel();
+    _service.dispose();
+    super.dispose();
   }
 }

--- a/lib/modules/noyau/services/payment_service.dart
+++ b/lib/modules/noyau/services/payment_service.dart
@@ -1,6 +1,7 @@
 library;
 
 import '../logic/ia_logger.dart';
+import '../models/payment_plan.dart';
 
 /// États possibles d'un achat in-app.
 enum PurchaseState { initial, purchased, expired, cancelled }
@@ -27,4 +28,16 @@ class PaymentService {
         break;
     }
   }
+
+  /// Stream emitting active subscription identifiers when they change.
+  Stream<List<String>> get subscriptionUpdates => const Stream.empty();
+
+  /// Returns the list of currently active subscription identifiers.
+  Future<List<String>> getActiveSubscriptions() async => const [];
+
+  /// Initiates the purchase flow for the given plan.
+  Future<void> purchaseItem(PaymentPlan plan) async {}
+
+  /// Cleans up any resources held by the service.
+  void dispose() {}
 }

--- a/test/noyau/unit/payment_provider_test.dart
+++ b/test/noyau/unit/payment_provider_test.dart
@@ -44,5 +44,7 @@ void main() {
 
     expect(provider.isPremium, isTrue);
     expect(provider.subscriptions, ['premium']);
+
+    provider.dispose();
   });
 }

--- a/test/noyau/widget/paywall_screen_test.dart
+++ b/test/noyau/widget/paywall_screen_test.dart
@@ -24,9 +24,11 @@ void main() {
   });
 
   testWidgets('renders plans list', (tester) async {
+    final provider = PaymentProvider();
+    await provider.init();
     await tester.pumpWidget(
       ChangeNotifierProvider(
-        create: (_) => PaymentProvider(),
+        create: (_) => provider,
         child: const MaterialApp(home: PaywallScreen()),
       ),
     );
@@ -34,13 +36,17 @@ void main() {
 
     expect(find.text('Premium Individuel'), findsOneWidget);
     expect(find.text('Pro / Éducateur'), findsOneWidget);
+
+    provider.dispose();
   });
 
   testWidgets('purchase button calls service', (tester) async {
     final service = _TestPaymentService();
+    final provider = PaymentProvider(service: service);
+    await provider.init();
     await tester.pumpWidget(
       ChangeNotifierProvider(
-        create: (_) => PaymentProvider(service: service),
+        create: (_) => provider,
         child: const MaterialApp(home: PaywallScreen()),
       ),
     );
@@ -50,5 +56,7 @@ void main() {
     await tester.pump();
 
     expect(service.called, isTrue);
+
+    provider.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- support active subscriptions in `PaymentProvider`
- add default APIs in `PaymentService`
- adjust unit and widget tests for new provider API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffffdd0248320b2f38e67b79eb74d