### PR TITLE
Fix Dressage module premium flag

### DIFF
--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -27,7 +27,7 @@ class ModulesService {
       name: 'Dressage',
       description: 'Entraînement avancé',
       category: 'Dressage',
-      isPremium: true,
+      premium: true,
     ),
     // 🔽 Ajouter ici les modules futurs
   ];


### PR DESCRIPTION
## Summary
- use the `premium` flag when defining the Dressage module

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffffed83c83208ed684cfc9b903eb