### PR TITLE
Implement subscription stream in payment provider

### DIFF
--- a/lib/modules/noyau/providers/payment_provider.dart
+++ b/lib/modules/noyau/providers/payment_provider.dart
@@ -35,8 +35,8 @@ class PaymentProvider extends ChangeNotifier {
   /// Returns `true` if the user currently has an active premium subscription.
   bool get isPremium => _isPremium;
 
-  /// Active subscription identifiers for the current user.
-  List<String> get subscriptions => List.unmodifiable(_subscriptions);
+  /// Flux des abonnements actifs pour l'utilisateur courant.
+  Stream<List<String>> get subscriptions => _service.subscriptionUpdates;
 
   /// Initializes the provider by loading current subscriptions and
   /// listening to updates from [PaymentService].

--- a/lib/modules/noyau/services/payment_service.dart
+++ b/lib/modules/noyau/services/payment_service.dart
@@ -41,15 +41,15 @@ class PaymentService {
     }
   }
 
-  /// Stream emitting active subscription identifiers when they change.
-  Stream<List<String>> get subscriptionUpdates => const Stream.empty();
-
-  /// Returns the list of currently active subscription identifiers.
-  Future<List<String>> getActiveSubscriptions() async => const [];
-
   /// Initiates the purchase flow for the given plan.
-  Future<void> purchaseItem(PaymentPlan plan) async {}
+  Future<void> purchaseItem(PaymentPlan plan) async {
+    _subscriptions.add(plan.id);
+    _controller.add(List.unmodifiable(_subscriptions));
+    await updateState(PurchaseState.purchased);
+  }
 
   /// Cleans up any resources held by the service.
-  void dispose() {}
+  void dispose() {
+    _controller.close();
+  }
 }

--- a/test/noyau/unit/payment_provider_test.dart
+++ b/test/noyau/unit/payment_provider_test.dart
@@ -39,11 +39,12 @@ void main() {
 
     expect(provider.isPremium, isFalse);
 
+    final first = provider.subscriptions.first;
     service.emit(['premium']);
-    await Future<void>.delayed(Duration.zero);
+    final subs = await first;
 
     expect(provider.isPremium, isTrue);
-    expect(provider.subscriptions, ['premium']);
+    expect(subs, ['premium']);
 
     provider.dispose();
   });


### PR DESCRIPTION
## Summary
- update `PaymentService` with a working subscription stream
- allow `PaymentProvider` to expose the stream and listen for updates
- adapt unit test for `PaymentProvider`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500360ccb48320ae6a460b10e325ef