### PR TITLE
Validate purchase receipts

### DIFF
--- a/test/noyau/widget/paywall_screen_test.dart
+++ b/test/noyau/widget/paywall_screen_test.dart
@@ -12,8 +12,9 @@ import '../../test_config.dart';
 
 class _TestPaymentService extends PaymentService {
   bool called = false;
+
   @override
-  Future<void> purchaseItem(PaymentPlan plan) async {
+  Future<void> purchaseItem(PaymentPlan plan, {String? receipt}) async {
     called = true;
   }
 }


### PR DESCRIPTION
## Summary
- validate receipts in `PaymentService.purchaseItem`
- update paywall test helper for new optional receipt parameter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685003695be483208b45bbbcad44b046