### PR TITLE
Add Stripe checkout fallback

### DIFF
--- a/lib/modules/noyau/services/stripe_checkout_service.dart
+++ b/lib/modules/noyau/services/stripe_checkout_service.dart
@@ -1,0 +1,34 @@
+library;
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../models/payment_plan.dart';
+import 'navigation_service.dart';
+
+/// Service minimal ouvrant la page Stripe Checkout dans une WebView.
+/// Utilisé comme solution de repli lorsque `in_app_purchase` n'est pas disponible.
+class StripeCheckoutService {
+  const StripeCheckoutService();
+
+  Future<void> openCheckout(PaymentPlan plan) async {
+    final url = 'https://example.com/checkout/${plan.id}';
+    await NavigationService.push(_StripeCheckoutPage(url: url));
+  }
+}
+
+class _StripeCheckoutPage extends StatelessWidget {
+  final String url;
+  const _StripeCheckoutPage({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse(url));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Paiement sécurisé')),
+      body: WebViewWidget(controller: controller),
+    );
+  }
+}

--- a/test/noyau/unit/payment_service_test.dart
+++ b/test/noyau/unit/payment_service_test.dart
@@ -7,7 +7,26 @@ import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/models/payment_plan.dart';
 import 'package:anisphere/modules/noyau/services/payment_service.dart';
 import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
+import 'package:anisphere/modules/noyau/services/stripe_checkout_service.dart';
 import 'package:anisphere/modules/noyau/logic/ia_logger.dart';
+
+class FakeStripeCheckoutService extends StripeCheckoutService {
+  bool called = false;
+
+  @override
+  Future<void> openCheckout(PaymentPlan plan) async {
+    called = true;
+  }
+}
+
+class TestPaymentService extends PaymentService {
+  final FakeStripeCheckoutService stripe;
+
+  TestPaymentService(this.stripe) : super(stripeService: stripe);
+
+  @override
+  bool get isIapSupported => false;
+}
 
 void main() {
   late Directory tempDir;
@@ -45,6 +64,20 @@ void main() {
     expect(await service.getActiveSubscriptions(), ['premium']);
     final logs = IALogger.getLogs();
     expect(logs.any((l) => l.contains('IAP_PURCHASED')), isTrue);
+  });
+
+  test('uses StripeCheckoutService when IAP unsupported', () async {
+    final stripe = FakeStripeCheckoutService();
+    final service = TestPaymentService(stripe);
+
+    await service.purchaseItem(const PaymentPlan(
+      id: 'test',
+      name: 'Test',
+      price: 0,
+      description: 'd',
+    ));
+
+    expect(stripe.called, isTrue);
   });
 
   test('dispose closes stream controller', () async {


### PR DESCRIPTION
## Summary
- implement `StripeCheckoutService` using a WebView
- fallback to this service from `PaymentService` when `in_app_purchase` isn't available
- expand unit tests for `PaymentService`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68500375c0f083208ab74138ed569079