### PR TITLE
Add hint for future IAP dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # in_app_purchase: ^x.x.x  # uncomment when implementing IAP
   # UI
   cupertino_icons: ^1.0.8
   flutter_local_notifications: ^19.2.1


### PR DESCRIPTION
## Summary
- add a comment in `pubspec.yaml` about the future `in_app_purchase` dependency

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500378ba448320a4976b0129aca2f1