### PR TITLE
Add premium menu link

### DIFF
--- a/lib/modules/noyau/screens/iap_screen.dart
+++ b/lib/modules/noyau/screens/iap_screen.dart
@@ -1,0 +1,15 @@
+library;
+
+import 'package:flutter/material.dart';
+
+import 'paywall_screen.dart';
+
+/// Wrapper around [PaywallScreen] to expose it as IAPScreen.
+class IAPScreen extends StatelessWidget {
+  const IAPScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PaywallScreen();
+  }
+}

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -8,6 +8,8 @@ import '../services/backup_service.dart';
 import '../providers/user_provider.dart';
 import '../services/animal_service.dart';
 import 'feedback_settings_screen.dart';
+import '../providers/payment_provider.dart';
+import 'iap_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -130,6 +132,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 context,
                 MaterialPageRoute(
                     builder: (_) => const FeedbackSettingsScreen()),
+              );
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.workspace_premium, color: Color(0xFF183153)),
+            title: const Text('Passer Premium'),
+            subtitle: const Text('Débloquez toutes les fonctionnalités'),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: () {
+              final paymentProvider =
+                  Provider.of<PaymentProvider>(context, listen: false);
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ChangeNotifierProvider.value(
+                    value: paymentProvider,
+                    child: const IAPScreen(),
+                  ),
+                ),
               );
             },
           ),

--- a/test/noyau/widget/settings_screen_test.dart
+++ b/test/noyau/widget/settings_screen_test.dart
@@ -1,13 +1,34 @@
 // Copilot Prompt : Test automatique généré pour settings_screen.dart (widget)
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:anisphere/modules/noyau/screens/settings_screen.dart';
+import 'package:anisphere/modules/noyau/screens/iap_screen.dart';
+import 'package:anisphere/modules/noyau/providers/payment_provider.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('settings_screen fonctionne (test auto)', () {
-    // TODO : compléter le test pour settings_screen.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  testWidgets('premium tile navigates to IAPScreen', (tester) async {
+    final provider = PaymentProvider();
+    await provider.init();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: const MaterialApp(home: SettingsScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Passer Premium'), findsOneWidget);
+    await tester.tap(find.text('Passer Premium'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(IAPScreen), findsOneWidget);
+
+    provider.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- wrap Paywall screen as `IAPScreen`
- link to `IAPScreen` from Settings
- test navigation to new screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850037dedf48320b99a0c85aea3908e