### PR TITLE
Add summary of home screen widgets

### DIFF
--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -38,6 +38,8 @@ Export PDF brut
 
 Interface guidée au lancement
 
+`home_screen.dart` sert de tableau de bord. Il récupère la liste des modules actifs pour afficher leurs widgets de résumé. Chaque module expose un `SummaryCard` dans `lib/modules/<module>/widgets/`. Les utilisateurs peuvent réordonner ces cartes et l’ordre est sauvegardé localement via Hive.
+
 🧩 Modules indépendants et connectés
 
 Chaque module est développé comme un composant autonome :


### PR DESCRIPTION
## Summary
- document how `home_screen.dart` loads active module `SummaryCard`s

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685007857ce08320a8be1526890b62cc