### PR TITLE
Fix naming of IAPScreen

### DIFF
--- a/lib/modules/noyau/screens/paywall_screen.dart
+++ b/lib/modules/noyau/screens/paywall_screen.dart
@@ -1,4 +1,4 @@
-// Deprecated screen kept for backward compatibility. Redirects to [IapScreen].
+// Deprecated screen kept for backward compatibility. Redirects to [IAPScreen].
 library;
 
 import 'package:flutter/material.dart';
@@ -10,6 +10,6 @@ class PaywallScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const IapScreen();
+    return const IAPScreen();
   }
 }

--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -70,7 +70,7 @@ class _ShareScreenState extends State<ShareScreen> {
             ),
             ElevatedButton(
               onPressed: () {
-                NavigationService.push(const IapScreen());
+                NavigationService.push(const IAPScreen());
               },
               child: const Text('Passer Premium'),
             ),

--- a/test/noyau/widget/iap_screen_test.dart
+++ b/test/noyau/widget/iap_screen_test.dart
@@ -30,7 +30,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider(
         create: (_) => provider,
-        child: const MaterialApp(home: IapScreen()),
+        child: const MaterialApp(home: IAPScreen()),
       ),
     );
     await tester.pump();
@@ -48,7 +48,7 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider(
         create: (_) => provider,
-        child: const MaterialApp(home: IapScreen()),
+        child: const MaterialApp(home: IAPScreen()),
       ),
     );
     await tester.pump();


### PR DESCRIPTION
## Summary
- rename all occurrences of `IapScreen` to `IAPScreen`
- update paywall screen, share screen, and tests

## Testing
- `flutter analyze` *(fails: flutter not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685009bed1008320806a0725786e6a9a