### PR TITLE
Fix missing import

### DIFF
--- a/lib/modules/noyau/services/payment_service.dart
+++ b/lib/modules/noyau/services/payment_service.dart
@@ -7,6 +7,7 @@ import '../logic/ia_logger.dart';
 import '../logic/ia_channel.dart';
 import '../models/payment_plan.dart';
 import 'stripe_checkout_service.dart';
+import 'local_storage_service.dart';
 
 /// États possibles d'un achat in-app.
 enum PurchaseState { initial, purchased, expired, cancelled }


### PR DESCRIPTION
## Summary
- import LocalStorageService in `payment_service.dart`

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685009c3a3c883209810b4e7aecac29b