### PR TITLE
Update script usage instructions

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -26,9 +26,9 @@ git pull origin main
 
 echo ""
 echo "📚 📊 Mise à jour des suivis AniSphère..."
-dart scripts/update_test_tracker.dart
-dart scripts/update_suivi_taches.dart
-dart scripts/update_noyau_suivi.dart
+flutter pub run scripts/update_test_tracker.dart
+flutter pub run scripts/update_suivi_taches.dart
+flutter pub run scripts/update_noyau_suivi.dart
 echo "✅ Suivis Markdown mis à jour."
 
 echo ""

--- a/docs/test_architecture.md
+++ b/docs/test_architecture.md
@@ -32,7 +32,7 @@ test/
 | (à venir) dressage | `test/dressage/` |
 | (à venir) communaute | `test/communaute/` |
 
-Lorsqu’un nouveau module est créé, on lance `dart run scripts/generate_test_module.dart <nom>` pour générer automatiquement la hiérarchie.
+Lorsqu’un nouveau module est créé, on lance `flutter pub run scripts/generate_test_module.dart <nom>` pour générer automatiquement la hiérarchie. Un équivalent pur Dart est possible en utilisant `package:firebase_dart`.
 
 ## 3. Fichiers clés
 
@@ -54,7 +54,7 @@ Lorsqu’un nouveau module est créé, on lance `dart run scripts/generate_test_
    ```bash
    flutter test --coverage
    ```
-5. Exécuter `dart scripts/update_test_tracker.dart` pour mettre à jour le suivi local.
+5. Exécuter `flutter pub run scripts/update_test_tracker.dart` pour mettre à jour le suivi local.
 
 ## 5. Intégration GitHub
 

--- a/scripts/generate_test_module.dart
+++ b/scripts/generate_test_module.dart
@@ -1,9 +1,13 @@
+// 🛠 Génère la structure de test pour un module.
+// À exécuter avec : `flutter pub run scripts/generate_test_module.dart <nom>`
+// (Pour un environnement pur Dart, utilisez `package:firebase_dart` puis
+//  lancez : `dart run scripts/generate_test_module.dart <nom>`.)
 import 'dart:io';
 
 void main(List<String> args) {
   if (args.isEmpty) {
     stderr.writeln('❌ Merci de fournir un nom de module :');
-    stderr.writeln('   Exemple : dart run scripts/generate_test_module.dart sante');
+    stderr.writeln('   Exemple : flutter pub run scripts/generate_test_module.dart sante');
     exit(1);
   }
 


### PR DESCRIPTION
## Summary
- note `flutter pub run` requirement for scripts
- offer Dart alternative with `package:firebase_dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505080b30883208a08ad634eea096f