### PR TITLE
Add Firestore verification script

### DIFF
--- a/scripts/firestore_verification.dart
+++ b/scripts/firestore_verification.dart
@@ -1,0 +1,29 @@
+// @dart=3.4
+// 🔍 Script de vérification de la connexion Firestore
+// Exécution : dart run scripts/firestore_verification.dart
+
+import 'dart:io';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../lib/firebase_options.dart';
+
+Future<void> main() async {
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+
+    final snapshot = await FirebaseFirestore.instance
+        .collection('verification')
+        .limit(1)
+        .get();
+
+    stdout.writeln(
+      '✅ Firestore accessible : ${snapshot.docs.length} document(s) trouvés',
+    );
+  } catch (e) {
+    stderr.writeln('❌ Échec de la vérification Firestore : $e');
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Firestore verification script that avoids `print` by using stdout and stderr

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685051ef502083209f55c00a2b53fb74