### PR TITLE
Add Firestore security and seed tools

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -254,6 +254,14 @@ update_test_tracker.dart → Met à jour la checklist de couverture de tests (te
 flutter_tests.yml → GitHub Actions : lance les tests à chaque push
 
 update_test_tracker.yml → GitHub Actions : met à jour la checklist à chaque push
+firestore_verification.dart → Vérifie la connexion Firestore
+seed_firestore.dart → Insère des données de démonstration (support, messages, subscriptions)
+
+### Exécution des scripts Firestore
+
+Assure-toi d'avoir configuré Firebase (`flutterfire configure`).
+Lance ensuite : `dart run scripts/seed_firestore.dart`
+
 
 🚀 Outils à ajouter (roadmap IA & Dev)
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,46 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // 🔹 Collection support
+    match /support/{feedbackId} {
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+      allow read, update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+
+    // 🔹 Collection messages
+    match /messages/{conversationId} {
+      allow create: if request.auth != null && request.auth.uid in request.resource.data.participants;
+      allow read, update, delete: if request.auth != null && request.auth.uid in resource.data.participants;
+
+      match /messages/{messageId} {
+        allow create: if request.auth != null && request.auth.uid == request.resource.data.senderId;
+        allow read: if request.auth != null &&
+          request.auth.uid in get(/databases/$(database)/documents/messages/$(conversationId)).data.participants;
+        allow update, delete: if request.auth != null && request.auth.uid == resource.data.senderId;
+      }
+    }
+
+    // 🔹 Collection subscriptions
+    match /subscriptions/{subscriptionId} {
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+      allow read, update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+
+    // 🔹 Compléments prévus
+    match /notifications/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /partages/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /medias/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /historique/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/scripts/seed_firestore.dart
+++ b/scripts/seed_firestore.dart
@@ -1,0 +1,60 @@
+// @dart=3.4
+// 🗄️ Script de remplissage Firestore pour les collections principales
+// Exécution : dart run scripts/seed_firestore.dart
+
+import 'dart:io';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../lib/firebase_options.dart';
+
+Future<void> main() async {
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+
+  final firestore = FirebaseFirestore.instance;
+
+  await _seedSupport(firestore);
+  await _seedMessages(firestore);
+  await _seedSubscriptions(firestore);
+
+  stdout.writeln('✅ Données de démonstration ajoutées.');
+}
+
+Future<void> _seedSupport(FirebaseFirestore firestore) async {
+  await firestore.collection('support').add({
+    'userId': 'demoUser',
+    'type': 'bug',
+    'message': 'Exemple de feedback.',
+    'status': 'brouillon',
+    'createdAt': Timestamp.now(),
+    'updatedAt': Timestamp.now(),
+  });
+}
+
+Future<void> _seedMessages(FirebaseFirestore firestore) async {
+  final conv = await firestore.collection('messages').add({
+    'participants': ['demoUser', 'admin'],
+    'lastMessage': 'Hello',
+    'updatedAt': Timestamp.now(),
+  });
+
+  await conv.collection('messages').add({
+    'senderId': 'demoUser',
+    'text': 'Hello',
+    'sentAt': Timestamp.now(),
+    'readBy': [],
+  });
+}
+
+Future<void> _seedSubscriptions(FirebaseFirestore firestore) async {
+  await firestore.collection('subscriptions').add({
+    'userId': 'demoUser',
+    'type': 'premium',
+    'startDate': Timestamp.now(),
+    'expiryDate': Timestamp.now(),
+    'status': 'active',
+    'lastSync': Timestamp.now(),
+  });
+}


### PR DESCRIPTION
## Summary
- define Firestore rules for support, messages and subscriptions collections
- add a Firestore seeding script with sample data
- document Firestore scripts in README_DEV

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8edacd483208f62cc1b1d147466