### PR TITLE
Update Node.js version for functions

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -17,6 +17,12 @@ Le développement d'AniSphère s'appuie sur **Flutter&nbsp;3.32.x** et **Dart&nb
 Les scripts de CI (GitHub Actions) utilisent cette version pour lancer
 les tests et la compilation. Veillez à utiliser la même version en local
 pour éviter toute incompatibilité.
+
+📌 Version Node.js requise
+
+Les fonctions Firebase reposent sur **Node.js 20**. Installez cette version ou
+une version compatible avant d'exécuter ou de développer les Cloud Functions en
+local.
 ℹ️ Notes d’utilisation du module Partage pour les contributeurs
 - Testez toujours le partage local hors connexion avant de valider une mise à jour.
 - Les fonctions cloud nécessitent un compte Premium de test ; utilisez `lib/core/sharing` pour simuler la synchro.

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- set Firebase functions engine to Node.js 20
- document the Node.js version requirement in the dev readme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8f031348320805b70286dcd17dd