### PR TITLE
Add Firebase function usage guide

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -21,6 +21,7 @@ pour éviter toute incompatibilité.
 - Testez toujours le partage local hors connexion avant de valider une mise à jour.
 - Les fonctions cloud nécessitent un compte Premium de test ; utilisez `lib/core/sharing` pour simuler la synchro.
 - Documentez les évolutions dans `docs/3__suivi_taches.md` et `docs/0__instructions.md`.
+- Pour l'appel des fonctions cloud, consultez `docs/firebase_function_examples.md`.
 - Téléchargez `GoogleService-Info.plist` depuis la console Firebase et placez ce fichier dans `ios/Runner/`. Un gabarit est disponible sous `ios/Runner/GoogleService-Info.plist.example`. Comme ce fichier contient des identifiants sensibles, il doit rester local et ne pas être commité.
 
 🗂️ Chapitre 2 — Structure du projet Flutter

--- a/docs/firebase_function_examples.md
+++ b/docs/firebase_function_examples.md
@@ -1,0 +1,49 @@
+📡 firebase_function_examples.md — Exemples d'appel aux fonctions cloud
+
+Ce document explique comment appeler les Cloud Functions d'AniSphère depuis Flutter ou n'importe quelle requête HTTP.
+
+## storeSensitiveUserData
+
+Cette fonction enregistre des informations sensibles sur l'utilisateur dans la collection `cloud_users`.
+
+### Avec Flutter
+
+```dart
+final storeSensitiveUserData = FirebaseFunctions.instance
+    .httpsCallable('storeSensitiveUserData');
+final result = await storeSensitiveUserData.call({
+  'nom': 'Dupont',
+  'prenom': 'Alice',
+  'email': 'alice@example.com',
+  'telephone': '+33123456789',
+  'adresse': '1 rue de la Paix',
+  'consentementIA': true,
+  'premium': false,
+});
+print(result.data); // { status: "success", message: "Données utilisateur stockées." }
+```
+
+### Via une requête REST
+
+La même fonction peut être appelée avec `fetch` ou `curl`. Remplacez `<region>` par la région de déploiement et `<projectId>` par l'identifiant Firebase.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <ID_TOKEN>" \
+  -H "Content-Type: application/json" \
+  https://<region>-<projectId>.cloudfunctions.net/storeSensitiveUserData \
+  -d '{
+    "data": {
+      "nom": "Dupont",
+      "prenom": "Alice",
+      "email": "alice@example.com",
+      "telephone": "+33123456789",
+      "adresse": "1 rue de la Paix",
+      "consentementIA": true,
+      "premium": false
+    }
+  }'
+```
+
+L'`ID_TOKEN` provient d'un utilisateur authentifié. En développement local, lancez `firebase login` puis `firebase functions:shell` pour tester rapidement.
+


### PR DESCRIPTION
## Summary
- document usage of `storeSensitiveUserData` cloud function
- link to the new examples from `README_DEV.md`

## Testing
- `flutter test --coverage` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8f4c87083209985a1d156219d9a