### PR TITLE
Add basic scheduler functions and seed script

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -249,6 +249,8 @@ Voici une liste d’outils, scripts et automatismes à mettre en place progressi
 
 generate_test_module.dart → Génère les tests automatiquement (unit/widget/integration)
 
+seed_scheduler_config.dart → Crée la configuration de planification dans Firestore
+
 update_test_tracker.dart → Met à jour la checklist de couverture de tests (test_tracker.md)
 
 flutter_tests.yml → GitHub Actions : lance les tests à chaque push

--- a/functions/index.js
+++ b/functions/index.js
@@ -42,3 +42,8 @@ exports.storeSensitiveUserData = functions.https.onCall(async (data, context) =>
 
   return { status: "success", message: "Données utilisateur stockées." };
 });
+
+// Scheduled tasks and queue processors
+exports.dailyCleanup = require('./scheduler').dailyCleanup;
+exports.dailyRelaunch = require('./scheduler').dailyRelaunch;
+exports.processSupportQueue = require('./supportQueue').processSupportQueue;

--- a/functions/scheduler.js
+++ b/functions/scheduler.js
@@ -1,0 +1,34 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+// Scheduled function: purge old temp data daily
+exports.dailyCleanup = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const batch = admin.firestore().batch();
+    const query = admin
+      .firestore()
+      .collection('temp')
+      .where('createdAt', '<', cutoff);
+
+    const snapshots = await query.get();
+    snapshots.forEach((doc) => batch.delete(doc.ref));
+    await batch.commit();
+  });
+
+// Scheduled function: trigger push notification relaunch every morning
+exports.dailyRelaunch = functions.pubsub
+  .schedule('0 8 * * *')
+  .timeZone('Europe/Paris')
+  .onRun(async () => {
+    // TODO: offline queue integration for push relaunch
+    const message = {
+      notification: {
+        title: 'AniSphère',
+        body: 'Pensez à mettre à jour le suivi de vos animaux !',
+      },
+      topic: 'all',
+    };
+    await admin.messaging().send(message);
+  });

--- a/functions/supportQueue.js
+++ b/functions/supportQueue.js
@@ -1,0 +1,27 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+// Processes tasks from 'supportQueue' collection in batches
+exports.processSupportQueue = functions.pubsub
+  .schedule('every 5 minutes')
+  .onRun(async () => {
+    const batchSize = 10;
+    const snapshot = await admin
+      .firestore()
+      .collection('supportQueue')
+      .orderBy('createdAt')
+      .limit(batchSize)
+      .get();
+
+    if (snapshot.empty) return null;
+
+    const batch = admin.firestore().batch();
+    snapshot.docs.forEach((doc) => {
+      const data = doc.data();
+      // TODO: offline queue fallback when Firestore not reachable
+      batch.set(admin.firestore().collection('support').doc(), data);
+      batch.delete(doc.ref);
+    });
+    await batch.commit();
+    return null;
+  });

--- a/scripts/seed_scheduler_config.dart
+++ b/scripts/seed_scheduler_config.dart
@@ -1,0 +1,29 @@
+// @dart=3.4
+// Seed scheduler configuration in Firestore
+// Usage: dart run scripts/seed_scheduler_config.dart
+
+import 'dart:io';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../lib/firebase_options.dart';
+
+Future<void> main() async {
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+
+    final ref = FirebaseFirestore.instance.collection('config').doc('scheduler');
+    await ref.set({
+      'cleanupEnabled': true,
+      'relaunchTime': '08:00',
+      'updatedAt': DateTime.now().toIso8601String(),
+    }, SetOptions(merge: true));
+
+    stdout.writeln('✅ Scheduler configuration created.');
+  } catch (e) {
+    stderr.writeln('❌ Failed to seed scheduler config: $e');
+    exit(1);
+  }
+}

--- a/scripts/test_suivi_automatique.sh
+++ b/scripts/test_suivi_automatique.sh
@@ -13,6 +13,7 @@ fi
 
 # Liste des scripts à exécuter
 scripts=(
+  "scripts/seed_scheduler_config.dart"
   "scripts/update_test_tracker.dart"
   "scripts/update_suivi_taches.dart"
   "scripts/update_noyau_suivi.dart"


### PR DESCRIPTION
## Summary
- add scheduled Cloud Functions for cleanup and relaunch
- process Firestore queue batches
- include TODOs for offline queue integration
- seed Firestore scheduler config
- document new seed script

## Testing
- `bash scripts/test_suivi_automatique.sh` *(fails: Docker not installed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852a8f6901c832083194aa72b945e62