### PR TITLE
Add Firestore setup guide

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -22,6 +22,7 @@ pour éviter toute incompatibilité.
 - Les fonctions cloud nécessitent un compte Premium de test ; utilisez `lib/core/sharing` pour simuler la synchro.
 - Documentez les évolutions dans `docs/3__suivi_taches.md` et `docs/0__instructions.md`.
 - Téléchargez `GoogleService-Info.plist` depuis la console Firebase et placez ce fichier dans `ios/Runner/`. Un gabarit est disponible sous `ios/Runner/GoogleService-Info.plist.example`. Comme ce fichier contient des identifiants sensibles, il doit rester local et ne pas être commité.
+- Suivez [docs/firestore_setup.md](docs/firestore_setup.md) pour préparer manuellement les collections Firestore et lancer le script de vérification.
 
 🗂️ Chapitre 2 — Structure du projet Flutter
 

--- a/docs/firestore_setup.md
+++ b/docs/firestore_setup.md
@@ -1,0 +1,46 @@
+# 🚀 Configuration initiale de Firestore
+
+Ce guide résume les étapes manuelles à effectuer dans la console Firebase avant le premier lancement d'AniSphère. Il complète la structure détaillée dans [docs/4__gestion_des_collections.md](docs/4__gestion_des_collections.md).
+
+## Collections à créer manuellement
+
+1. **`ia_categories/`**
+   - `sante/uploads`
+   - `sante/models`
+   - `sante/feedbacks`
+   - `education/uploads`
+   - `education/models`
+   - `education/feedbacks`
+   - `dressage/uploads`
+   - `dressage/models`
+   - `dressage/feedbacks`
+   - `communaute/uploads`
+   - `communaute/models`
+   - `communaute/feedbacks`
+2. **`logs_ia/`**
+   - `sante`
+   - `education`
+   - `dressage`
+   - `communaute`
+3. **`consents/`**
+   - document `global` avec les champs :
+     - `current_version` (number)
+     - `last_update` (timestamp)
+     - `description` (string)
+     - `required` (bool)
+4. **`superadmin/`**
+   - document `flags` contenant :
+     - `start_training_sante` (bool)
+     - `start_training_education` (bool)
+     - `start_training_dressage` (bool)
+     - `start_training_communaute` (bool)
+
+## Vérification et scripts d'initialisation
+
+Après avoir créé ces collections, exécutez :
+
+```bash
+flutter pub run scripts/firestore_verification.dart
+```
+
+Le script vérifie la présence des documents et affiche les éléments manquants. Corrigez la configuration si nécessaire puis relancez-le.

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -299,7 +299,7 @@ Responsable : Superadmin
 
 ## 📌 Où suivre l'avancement de cette configuration ?
 
-➞ Mise à jour **manuelle** dans ce document : `firestore_structure_initiale.md`
+➞ Mise à jour **manuelle** dans ce document : [docs/firestore_setup.md](docs/firestore_setup.md)
 ➞ Synthèse globale à reporter dans : `docs/noyau_suivi.md` (section "Préparation Firestore IA") et `3__suivi_taches.md` (section noyau)
 
 ---


### PR DESCRIPTION
## Summary
- add `docs/firestore_setup.md` with instructions about manual collections and verification script
- link new guide from `README_DEV.md`
- update reference in `docs/noyau_suivi.md`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a8f8a4848320941d02c44ee18052