### PR TITLE
Add IA category endpoints and sync

### DIFF
--- a/functions/ia.js
+++ b/functions/ia.js
@@ -1,0 +1,39 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const express = require('express');
+
+const router = express();
+router.use(express.json());
+
+function createBatchHandler(collection) {
+  return async (req, res) => {
+    const {category} = req.params;
+    const items = Array.isArray(req.body.items) ? req.body.items : [req.body];
+    const batch = admin.firestore().batch();
+    items.forEach((item) => {
+      const ref = admin
+        .firestore()
+        .collection('ia_categories')
+        .doc(category)
+        .collection(collection)
+        .doc();
+      batch.set(ref, {
+        ...item,
+        receivedAt: new Date().toISOString(),
+      });
+    });
+    await batch.commit();
+    functions.logger.info(
+      `Received ${items.length} ${collection} for ${category}`
+    );
+    res.status(200).json({status: 'ok', received: items.length});
+  };
+}
+
+const uploadHandler = createBatchHandler('uploads');
+const feedbackHandler = createBatchHandler('feedbacks');
+
+router.post('/ia_categories/:category/uploads', uploadHandler);
+router.post('/ia_categories/:category/feedbacks', feedbackHandler);
+
+module.exports = {router, uploadHandler, feedbackHandler};

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,3 +28,4 @@ exports.storeSensitiveUserData = functions.https.onCall(async (data, context) =>
 exports.dailyCleanup = require('./scheduler').dailyCleanup;
 exports.dailyRelaunch = require('./scheduler').dailyRelaunch;
 exports.processSupportQueue = require('./supportQueue').processSupportQueue;
+exports.iaApi = functions.https.onRequest(require('./ia').router);

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,8 @@
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "node --test"
   },
   "engines": {
     "node": "20"

--- a/functions/test/ia.test.js
+++ b/functions/test/ia.test.js
@@ -1,0 +1,39 @@
+const assert = require('node:assert');
+const {test} = require('node:test');
+
+let setCalls;
+const fakeBatch = {
+  set: (r, d) => setCalls.push(d),
+  commit: async () => {},
+};
+const fakeDb = {
+  batch: () => fakeBatch,
+  collection: () => ({
+    doc: () => ({
+      collection: () => ({
+        doc: () => ({}),
+      }),
+    }),
+  }),
+};
+const fakeAdmin = { firestore: () => fakeDb };
+require.cache[require.resolve('firebase-admin')] = {exports: fakeAdmin};
+const {uploadHandler, feedbackHandler} = require('../ia');
+
+test('uploadHandler stores batch items', async () => {
+  setCalls = [];
+  const req = {params: {category: 'test'}, body: {items: [{a:1},{b:2}]} };
+  const res = {status: () => res, json: (d) => {res.body = d;}};
+  await uploadHandler(req, res);
+  assert.equal(setCalls.length, 2);
+  assert.deepEqual(res.body, {status: 'ok', received: 2});
+});
+
+test('feedbackHandler works with single object', async () => {
+  setCalls = [];
+  const req = {params: {category: 'test'}, body: {foo: 'bar'} };
+  const res = {status: () => res, json: (d) => {res.body = d;}};
+  await feedbackHandler(req, res);
+  assert.equal(setCalls.length, 1);
+  assert.deepEqual(res.body, {status: 'ok', received: 1});
+});

--- a/lib/modules/noyau/logic/ia_master.dart
+++ b/lib/modules/noyau/logic/ia_master.dart
@@ -118,6 +118,24 @@ class IAMaster {
     }
   }
 
+  /// 🔁 Envoie de données brutes pour une catégorie IA
+  Future<void> pushCategoryData(String category, Map<String, dynamic> data) async {
+    try {
+      await _cloudSyncService.pushCategoryData(category, data);
+      await IALogger.log(
+        message: 'CATEGORY_$category',
+        channel: IAChannel.sync,
+      );
+    } catch (e) {
+      await OfflineSyncQueue.addTask(SyncTask(
+        type: 'category:$category',
+        data: data,
+        timestamp: DateTime.now(),
+      ));
+      debugPrint('⚠️ pushCategoryData offline for $category');
+    }
+  }
+
   /// 📸 Analyse locale d'une photo puis envoi ou mise en attente.
   Future<void> analyzeAndPushPhoto(File file) async {
     final analysis = await IAPhotoAnalyzer().analyze(file);

--- a/lib/modules/noyau/services/cloud_sync_service.dart
+++ b/lib/modules/noyau/services/cloud_sync_service.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 
 import '../models/animal_model.dart';
 import '../models/user_model.dart';
@@ -21,8 +22,12 @@ import '../services/offline_gps_queue.dart';
 import '../services/storage_optimizer.dart';
 class CloudSyncService {
   final FirebaseService _firebaseService;
-  CloudSyncService({FirebaseService? firebaseService})
-      : _firebaseService = firebaseService ?? FirebaseService();
+  final http.Client httpClient;
+  static const String _functionsBaseUrl =
+      'https://REGION-PROJECT.cloudfunctions.net/iaApi';
+  CloudSyncService({FirebaseService? firebaseService, http.Client? client})
+      : _firebaseService = firebaseService ?? FirebaseService(),
+        httpClient = client ?? http.Client();
   /// 🔁 Envoie les données d’un animal pour apprentissage IA
   Future<void> pushAnimalData(AnimalModel animal) async {
     try {
@@ -45,6 +50,30 @@ class CloudSyncService {
       await OfflineSyncQueue.addTask(
         SyncTask(type: "user", data: user.toJson(), timestamp: DateTime.now()),
       );
+    }
+  }
+
+  /// 🔁 Envoie un batch pour une catégorie IA vers la fonction cloud
+  Future<void> pushCategoryData(String category, Map<String, dynamic> data) async {
+    try {
+      final uri = Uri.parse('$_functionsBaseUrl/ia_categories/$category/uploads');
+      final res = await httpClient.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'items': [data]}),
+      );
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        debugPrint('☁️ Données IA $category envoyées.');
+        return;
+      }
+      throw HttpException('status ${res.statusCode}');
+    } catch (e) {
+      debugPrint('❌ [CloudSync] Erreur pushCategoryData : $e');
+      await OfflineSyncQueue.addTask(SyncTask(
+        type: 'category:$category',
+        data: data,
+        timestamp: DateTime.now(),
+      ));
     }
   }
   /// 🔁 Envoie de données spécifiques à un module (format libre)
@@ -240,6 +269,9 @@ class CloudSyncService {
             final convoId = task.type.split(":").last;
             await _firebaseService
                 .sendModuleData('messaging/$convoId', task.data ?? {});
+          } else if (task.type.startsWith('category:')) {
+            final cat = task.type.split(':').last;
+            await pushCategoryData(cat, task.data ?? {});
           }
       }
     });


### PR DESCRIPTION
## Summary
- implement Express router for `/ia_categories/:category/uploads` and `/feedbacks`
- expose new router via Cloud Functions
- enable Node tests for IA API handlers
- integrate category uploads in `CloudSyncService` and `IAMaster`
- add offline queue logic for category uploads

## Testing
- `npm --prefix functions test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ab9cbd348320aee754bff72c1cce