### PR TITLE
Implement modular IA metrics logging

### DIFF
--- a/lib/modules/identite/services/identity_service.dart
+++ b/lib/modules/identite/services/identity_service.dart
@@ -4,6 +4,7 @@
 library;
 import 'package:hive/hive.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
 import '../models/identity_model.dart';
 
 /// Service IdentityService pour AniSphère.
@@ -31,6 +32,7 @@ class IdentityService {
     required String animalId,
     required String field,
     required String newValue,
+    required String userId,
   }) async {
     final identity = localBox.get(animalId);
     if (identity == null) return;
@@ -56,6 +58,12 @@ class IdentityService {
     );
 
     await saveIdentityLocally(updatedModel);
+    await IAMetricsCollector.logIdentityEvent(
+      type: 'update_field',
+      animalId: animalId,
+      userId: userId,
+      data: {'field': field, 'newValue': newValue},
+    );
   }
 
   Future<void> syncToFirestore(IdentityModel model) async {

--- a/lib/modules/noyau/logic/ia_metrics_collector.dart
+++ b/lib/modules/noyau/logic/ia_metrics_collector.dart
@@ -9,34 +9,114 @@ part 'ia_metrics_collector.g.dart';
 @HiveType(typeId: 101)
 class IAMetric {
   @HiveField(0)
-  final String name;
+  final String module;
 
   @HiveField(1)
-  final dynamic value;
+  final String type;
 
   @HiveField(2)
+  final String animalId;
+
+  @HiveField(3)
+  final String userId;
+
+  @HiveField(4)
+  final Map<String, dynamic>? data;
+
+  @HiveField(5)
+  final Map<String, dynamic>? metadata;
+
+  @HiveField(6)
   final DateTime timestamp;
 
   IAMetric({
-    required this.name,
-    required this.value,
-    required this.timestamp,
-  });
+    required this.module,
+    required this.type,
+    required this.animalId,
+    required this.userId,
+    this.data,
+    this.metadata,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
 }
 
 class IAMetricsCollector {
   static const String _boxName = "ia_metrics";
 
-  /// 📥 Ajoute une métrique à la base locale
-  static Future<void> addMetric(String name, dynamic value) async {
+  /// 📥 Ajoute un événement de module à la base locale
+  static Future<void> _logModuleEvent({
+    required String module,
+    required String type,
+    required String animalId,
+    required String userId,
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? metadata,
+  }) async {
     final box = await Hive.openBox<IAMetric>(_boxName);
     final metric = IAMetric(
-      name: name,
-      value: value,
-      timestamp: DateTime.now(),
+      module: module,
+      type: type,
+      animalId: animalId,
+      userId: userId,
+      data: data,
+      metadata: metadata,
     );
     await box.add(metric);
-    debugPrint("📊 IAMetric enregistrée : $name = $value");
+    debugPrint("📊 IAMetric enregistrée : $module/$type for $animalId");
+  }
+
+  /// 🎓 Log d'un événement lié au module Éducation
+  static Future<void> logEducationEvent({
+    required String type,
+    required String animalId,
+    required String userId,
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? metadata,
+  }) async {
+    await _logModuleEvent(
+      module: 'education',
+      type: type,
+      animalId: animalId,
+      userId: userId,
+      data: data,
+      metadata: metadata,
+    );
+  }
+
+  /// 🐕‍🦺 Log d'un événement lié au module Dressage
+  static Future<void> logDressageEvent({
+    required String type,
+    required String animalId,
+    required String userId,
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? metadata,
+  }) async {
+    await _logModuleEvent(
+      module: 'dressage',
+      type: type,
+      animalId: animalId,
+      userId: userId,
+      data: data,
+      metadata: metadata,
+    );
+  }
+
+  /// 🏷️ Log d'un événement lié au module Identité
+  static Future<void> logIdentityEvent({
+    required String type,
+    required String animalId,
+    required String userId,
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? metadata,
+  }) async {
+    await _logModuleEvent(
+      module: 'identite',
+      type: type,
+      animalId: animalId,
+      userId: userId,
+      data: data,
+      metadata: metadata,
+    );
   }
 
   /// 📤 Récupère toutes les métriques collectées

--- a/lib/modules/noyau/logic/ia_metrics_collector.g.dart
+++ b/lib/modules/noyau/logic/ia_metrics_collector.g.dart
@@ -17,21 +17,33 @@ class IAMetricAdapter extends TypeAdapter<IAMetric> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return IAMetric(
-      name: fields[0] as String,
-      value: fields[1] as dynamic,
-      timestamp: fields[2] as DateTime,
+      module: fields[0] as String,
+      type: fields[1] as String,
+      animalId: fields[2] as String,
+      userId: fields[3] as String,
+      data: (fields[4] as Map?)?.cast<String, dynamic>(),
+      metadata: (fields[5] as Map?)?.cast<String, dynamic>(),
+      timestamp: fields[6] as DateTime,
     );
   }
 
   @override
   void write(BinaryWriter writer, IAMetric obj) {
     writer
-      ..writeByte(3)
+      ..writeByte(7)
       ..writeByte(0)
-      ..write(obj.name)
+      ..write(obj.module)
       ..writeByte(1)
-      ..write(obj.value)
+      ..write(obj.type)
       ..writeByte(2)
+      ..write(obj.animalId)
+      ..writeByte(3)
+      ..write(obj.userId)
+      ..writeByte(4)
+      ..write(obj.data)
+      ..writeByte(5)
+      ..write(obj.metadata)
+      ..writeByte(6)
       ..write(obj.timestamp);
   }
 

--- a/test/identite/unit/mock_services.mocks.dart
+++ b/test/identite/unit/mock_services.mocks.dart
@@ -97,6 +97,7 @@ class MockIdentityService extends _i1.Mock implements _i4.IdentityService {
     required String? animalId,
     required String? field,
     required String? newValue,
+    required String? userId,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -106,6 +107,7 @@ class MockIdentityService extends _i1.Mock implements _i4.IdentityService {
             #animalId: animalId,
             #field: field,
             #newValue: newValue,
+            #userId: userId,
           },
         ),
         returnValue: _i6.Future<void>.value(),

--- a/test/noyau/unit/ia_metrics_collector_test.dart
+++ b/test/noyau/unit/ia_metrics_collector_test.dart
@@ -21,16 +21,29 @@ void main() {
     await tempDir.delete(recursive: true);
   });
 
-  test('addMetric stores metric and can be retrieved', () async {
-    await IAMetricsCollector.addMetric('score', 5);
+  test('logEducationEvent stores metric with module context', () async {
+    await IAMetricsCollector.logEducationEvent(
+      type: 'lesson_completed',
+      animalId: 'a1',
+      userId: 'u1',
+      data: {'score': 5},
+    );
     final metrics = await IAMetricsCollector.getAllMetrics();
     expect(metrics.length, 1);
-    expect(metrics.first.name, 'score');
-    expect(metrics.first.value, 5);
+    final metric = metrics.first;
+    expect(metric.module, 'education');
+    expect(metric.type, 'lesson_completed');
+    expect(metric.animalId, 'a1');
+    expect(metric.userId, 'u1');
+    expect(metric.data?['score'], 5);
   });
 
   test('clearMetrics removes stored metrics', () async {
-    await IAMetricsCollector.addMetric('temp', 1);
+    await IAMetricsCollector.logEducationEvent(
+      type: 'temp',
+      animalId: 'a1',
+      userId: 'u1',
+    );
     await IAMetricsCollector.clearMetrics();
     final metrics = await IAMetricsCollector.getAllMetrics();
     expect(metrics, isEmpty);


### PR DESCRIPTION
## Summary
- expand `IAMetric` model with module context
- add modular logging methods in `IAMetricsCollector`
- record identity updates as IA metrics
- update mock services and unit tests

## Testing
- `flutter test test/noyau/unit/ia_metrics_collector_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852b1d79214832081f449e737936339