### PR TITLE
Fix analyzer warnings

### DIFF
--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -124,3 +124,4 @@ suivi_[module].md → suivi fin par module
 - ✅ Mise à jour automatique des tâches le 2025-06-19
 
 - ✅ Mise à jour automatique des tâches le 2025-06-18
+- ✅ Mise à jour automatique des tâches le 2025-06-20

--- a/lib/modules/identite/services/identity_service.dart
+++ b/lib/modules/identite/services/identity_service.dart
@@ -3,7 +3,7 @@
 // des fiches d’identité animale (QR, statut, photo, badge IA).
 import 'package:hive/hive.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:anisphere/modules/noyau/logic/ia_metrics_collector.dart';
+import 'package:anisphere/services/ia/ia_metrics_collector.dart';
 import '../models/identity_model.dart';
 
 /// Service IdentityService pour AniSphère.

--- a/lib/modules/noyau/logic/ia_channel.dart
+++ b/lib/modules/noyau/logic/ia_channel.dart
@@ -1,4 +1,4 @@
-/// 🎯 Canaux de logs IA AniSphère (tri par type de message)
+// 🎯 Canaux de logs IA AniSphère (tri par type de message)
 
 enum IAChannel {
   system,

--- a/lib/modules/noyau/logic/ia_logger.dart
+++ b/lib/modules/noyau/logic/ia_logger.dart
@@ -1,6 +1,6 @@
-/// 🧠 IALogger — Journal IA local pour AniSphère
-/// Permet de tracer les événements IA localement dans Hive
-/// Compatible avec la stratégie IA cloud et le nettoyage automatique
+// 🧠 IALogger — Journal IA local pour AniSphère
+// Permet de tracer les événements IA localement dans Hive
+// Compatible avec la stratégie IA cloud et le nettoyage automatique
 import 'package:flutter/foundation.dart';
 
 import '../services/local_storage_service.dart';

--- a/lib/modules/noyau/logic/ia_rules.dart
+++ b/lib/modules/noyau/logic/ia_rules.dart
@@ -1,6 +1,6 @@
-/// 📐 IARules — Règles métiers IA pour AniSphère
-/// Contient les règles d’analyse comportementale, UX et alertes IA
-/// Appelé par IARuleEngine, IAMaster et les modules IA
+// 📐 IARules — Règles métiers IA pour AniSphère
+// Contient les règles d’analyse comportementale, UX et alertes IA
+// Appelé par IARuleEngine, IAMaster et les modules IA
 
 
 import '../models/animal_model.dart';

--- a/lib/modules/noyau/models/module_model.dart
+++ b/lib/modules/noyau/models/module_model.dart
@@ -27,6 +27,7 @@ class ModuleModel {
       description: map['description'] as String,
       icon: map['icon'] as String? ?? '',
       premium: premium,
+      // ignore: deprecated_member_use_from_same_package
       isPremium: premium,
     );
   }

--- a/lib/modules/noyau/providers/ia_context_provider.dart
+++ b/lib/modules/noyau/providers/ia_context_provider.dart
@@ -1,7 +1,7 @@
-/// 🧠 IAContextProvider — AniSphère
-/// Fournit dynamiquement un IAContext à toute l’application.
-/// Se base sur l’utilisateur, les animaux, la connectivité, la date de sync.
-/// Prompt Copilot : "IAContextProvider builds and updates the IAContext for use across AniSphère"
+// 🧠 IAContextProvider — AniSphère
+// Fournit dynamiquement un IAContext à toute l’application.
+// Se base sur l’utilisateur, les animaux, la connectivité, la date de sync.
+// Prompt Copilot : "IAContextProvider builds and updates the IAContext for use across AniSphère"
 
 
 import 'package:flutter/foundation.dart';

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -1,4 +1,4 @@
-/// Écran complet des paramètres AniSphère avec sauvegarde
+// Écran complet des paramètres AniSphère avec sauvegarde
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/modules/noyau/services/app_initializer.dart
+++ b/lib/modules/noyau/services/app_initializer.dart
@@ -1,6 +1,6 @@
-/// Service d'initialisation AniSphère (Firebase + Hive).
-/// Gère le démarrage sécurisé et multiplateforme, avec support tests, Web et logs.
-/// Initialisation des boîtes locales et de Firebase selon la plateforme.
+// Service d'initialisation AniSphère (Firebase + Hive).
+// Gère le démarrage sécurisé et multiplateforme, avec support tests, Web et logs.
+// Initialisation des boîtes locales et de Firebase selon la plateforme.
 
 import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/lib/modules/noyau/services/auth_service.dart
+++ b/lib/modules/noyau/services/auth_service.dart
@@ -1,6 +1,6 @@
-/// Service d'authentification pour AniSphère.
-/// Gère email/password, Google, Apple, création, reset, logout.
-/// Intègre Firebase Auth et Firebase Firestore (via UserService).
+// Service d'authentification pour AniSphère.
+// Gère email/password, Google, Apple, création, reset, logout.
+// Intègre Firebase Auth et Firebase Firestore (via UserService).
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';

--- a/lib/modules/noyau/services/cloud_sync_service.dart
+++ b/lib/modules/noyau/services/cloud_sync_service.dart
@@ -1,7 +1,7 @@
-/// ☁️ CloudSyncService — AniSphère
-/// Service central de synchronisation cloud (Firebase ou autre backend)
-/// Toutes les données modules & noyau passent ici pour apprentissage IA cloud
-/// Utilisé par IAMaster, les modules, les IA locales
+// ☁️ CloudSyncService — AniSphère
+// Service central de synchronisation cloud (Firebase ou autre backend)
+// Toutes les données modules & noyau passent ici pour apprentissage IA cloud
+// Utilisé par IAMaster, les modules, les IA locales
 
 import 'dart:convert';
 import 'dart:io';

--- a/lib/modules/noyau/services/maintenance_service.dart
+++ b/lib/modules/noyau/services/maintenance_service.dart
@@ -1,7 +1,7 @@
-/// Service de maintenance automatique pour le noyau AniSphère.
-/// Gère le nettoyage des logs, la purge Hive, la réinitialisation IA.
-/// Appelé périodiquement par le noyau ou à chaque lancement si besoin.
-/// Peut déclencher une sync IA ou une relance utilisateur.
+// Service de maintenance automatique pour le noyau AniSphère.
+// Gère le nettoyage des logs, la purge Hive, la réinitialisation IA.
+// Appelé périodiquement par le noyau ou à chaque lancement si besoin.
+// Peut déclencher une sync IA ou une relance utilisateur.
 
 
 import 'package:flutter/foundation.dart';

--- a/lib/modules/noyau/services/modules_summary_service.dart
+++ b/lib/modules/noyau/services/modules_summary_service.dart
@@ -1,7 +1,7 @@
-/// 🧠 modules_summary_service.dart — AniSphère
-/// Génère dynamiquement des résumés IA pour les modules actifs.
-/// Utilisé sur l’écran d’accueil IA pour afficher une vue synthétique.
-/// Dépend de IAContext, AnimalService et ModulesService.
+// 🧠 modules_summary_service.dart — AniSphère
+// Génère dynamiquement des résumés IA pour les modules actifs.
+// Utilisé sur l’écran d’accueil IA pour afficher une vue synthétique.
+// Dépend de IAContext, AnimalService et ModulesService.
 
 
 import 'package:anisphere/modules/noyau/services/modules_service.dart';

--- a/scripts/fix_imports_noyau.dart
+++ b/scripts/fix_imports_noyau.dart
@@ -1,5 +1,5 @@
-/// 🛠 Script Dart pour corriger tous les imports du noyau après réorganisation
-/// À exécuter avec : dart scripts/fix_imports_noyau.dart
+// 🛠 Script Dart pour corriger tous les imports du noyau après réorganisation
+// À exécuter avec : dart scripts/fix_imports_noyau.dart
 
 import 'dart:io';
 

--- a/test/noyau/unit/behavior_analysis_service_test.dart
+++ b/test/noyau/unit/behavior_analysis_service_test.dart
@@ -17,7 +17,7 @@ class FakeStepCount implements StepCount {
   FakeStepCount(this.steps, this.timeStamp);
 
   @override
-  String toString() => 'Steps taken: ' + steps.toString() + ' at ' + timeStamp.toIso8601String();
+  String toString() => 'Steps taken: $steps at ${timeStamp.toIso8601String()}';
 }
 
 


### PR DESCRIPTION
## Summary
- fix import path for `IAMetricsCollector`
- avoid deprecated `isPremium` warning
- switch library doc comments to regular comments
- update test to use interpolation
- log latest task update

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b478cddc83208f93e1b83c95cfcc