### PR TITLE
Add base i18n module

### DIFF
--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "en",
+  "home_title": "Home",
+  "settings_language": "Language",
+  "confirm": "Confirm"
+}

--- a/l10n/app_fr.arb
+++ b/l10n/app_fr.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "fr",
+  "home_title": "Accueil",
+  "settings_language": "Langue",
+  "confirm": "Confirmer"
+}

--- a/lib/modules/noyau/i18n/app_localizations.dart
+++ b/lib/modules/noyau/i18n/app_localizations.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart' as l10n;
+
+class AppLocalizations {
+  static l10n.AppLocalizations of(BuildContext context) {
+    return l10n.AppLocalizations.of(context)!;
+  }
+
+  static const LocalizationsDelegate<l10n.AppLocalizations> delegate =
+      l10n.AppLocalizations.delegate;
+}

--- a/lib/modules/noyau/i18n/i18n_provider.dart
+++ b/lib/modules/noyau/i18n/i18n_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'i18n_service.dart';
+
+class I18nProvider extends ChangeNotifier {
+  Locale _locale = I18nService.getCurrentLocale();
+
+  Locale get locale => _locale;
+
+  Future<void> load() async {
+    _locale = I18nService.getCurrentLocale();
+    notifyListeners();
+  }
+
+  Future<void> setLocale(Locale locale) async {
+    _locale = locale;
+    await I18nService.setLocale(locale);
+    notifyListeners();
+  }
+}

--- a/lib/modules/noyau/i18n/i18n_service.dart
+++ b/lib/modules/noyau/i18n/i18n_service.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../services/local_storage_service.dart';
+
+class I18nService {
+  static const _key = 'locale';
+
+  static Locale getCurrentLocale() {
+    final code = LocalStorageService.get(_key, defaultValue: 'en') as String;
+    return Locale(code);
+  }
+
+  static Future<void> setLocale(Locale locale) async {
+    await LocalStorageService.set(_key, locale.languageCode);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -643,6 +643,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_blue_plus:
     dependency: "direct main"
     description:
@@ -1174,7 +1179,7 @@ packages:
     source: hosted
     version: "0.4.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.20.2
 
   # in_app_purchase: ^x.x.x  # uncomment when implementing IAP
   # UI
@@ -93,6 +96,7 @@ dependency_overrides:
   googleapis_auth: 1.6.0
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/logo/anisphere_logo.png


### PR DESCRIPTION
## Summary
- add i18n service/provider and app localization wrapper
- add English and French translation files
- enable l10n generation and dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b41d10a88320920192366458fab1