### PR TITLE
Add basic internationalization provider

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,4 @@
+{
+  "appTitle": "AniSphère",
+  "mainScreenTitle": "AniSphère"
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,0 +1,4 @@
+{
+  "appTitle": "AniSphère",
+  "mainScreenTitle": "AniSphère"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,8 @@ import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
 import 'package:anisphere/modules/noyau/models/share_history_model.dart';
 import 'package:anisphere/modules/noyau/providers/feedback_options_provider.dart';
 import 'package:anisphere/modules/noyau/providers/payment_provider.dart';
+import 'package:anisphere/modules/noyau/providers/i18n_provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -112,6 +114,7 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => I18nProvider()),
         ChangeNotifierProvider(
           create: (_) => UserProvider(userService, authService),
         ),
@@ -152,7 +155,10 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       navigatorKey: NavigationService.navigatorKey,
-      title: 'AniSphère',
+      title: AppLocalizations.of(context)!.appTitle,
+      locale: context.watch<I18nProvider>().locale,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
       debugShowCheckedModeBanner: false,
       theme: appTheme,
       darkTheme: darkTheme,

--- a/lib/modules/noyau/providers/i18n_provider.dart
+++ b/lib/modules/noyau/providers/i18n_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Provides the current [Locale] of the app and allows switching it.
+class I18nProvider extends ChangeNotifier {
+  Locale _locale = const Locale('en');
+
+  /// Current app locale.
+  Locale get locale => _locale;
+
+  /// Change the locale and notify listeners.
+  void setLocale(Locale locale) {
+    if (_locale == locale) return;
+    _locale = locale;
+    notifyListeners();
+  }
+}

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -1,6 +1,7 @@
 // Copilot Prompt : MainScreen avec navigation sécurisée et IAScheduler.
 // Comporte 4 onglets dynamiques.
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'home_screen.dart';
 import 'share_screen.dart';
@@ -105,9 +106,9 @@ class MainScreenState extends State<MainScreen> {
         backgroundColor: const Color(0xFFF5F5F5),
         foregroundColor: const Color(0xFF183153),
         elevation: 0,
-        title: const Text(
-          'AniSphère',
-          style: TextStyle(
+        title: Text(
+          AppLocalizations.of(context)!.mainScreenTitle,
+          style: const TextStyle(
             fontWeight: FontWeight.w600,
             fontSize: 20,
             color: Color(0xFF183153),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_local_notifications: ^19.2.1
   webview_flutter: ^4.13.0
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.1
 
   # Base / stockage local
   provider: ^6.1.2
@@ -93,6 +96,7 @@ dependency_overrides:
   googleapis_auth: 1.6.0
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/logo/anisphere_logo.png


### PR DESCRIPTION
## Summary
- add I18nProvider and localization files
- wire I18nProvider in main.dart
- expose locale settings to `MaterialApp`
- localize main screen title
- enable localization generation in `pubspec.yaml`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852b41f529c8320a8d36ac9ea0df149