### PR TITLE
Add multilingual info in docs

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -11,6 +11,7 @@ Centraliser les bonnes pratiques, automatisations, et outils
 Servir de passerelle entre le code, l’IA et les fichiers de suivi (test, roadmap, modules)
 
 Il est mis à jour automatiquement à chaque évolution majeure du projet.
+AniSphère est maintenant multilingue grâce au système de traduction centralisé du noyau.
 📌 Version Flutter/Dart requise
 
 Le développement d'AniSphère s'appuie sur **Flutter&nbsp;3.32.x** et **Dart&nbsp;3.4+**.

--- a/docs/0__instructions.md
+++ b/docs/0__instructions.md
@@ -38,6 +38,8 @@ L’interface est claire, animée, inspirée de Samsung Health
 
 Tous les textes, choix et graphismes doivent être accessibles et lisibles
 
+L’application est multilingue et toutes les traductions sont centralisées dans le noyau
+
 🧠 Architecture IA
 
 L’IA est découpée en 2 niveaux :

--- a/docs/2__roadmap.md
+++ b/docs/2__roadmap.md
@@ -117,6 +117,7 @@ Ajout rapide d’un animal via action rapide (slide up)
 Statut :
 
 🔲 À développer à partir des composants de base
+✅ internationalisation activée
 
 🌍 Phase 6 — Site compagnon & synchronisation
 

--- a/docs/6__technos_par_module.md
+++ b/docs/6__technos_par_module.md
@@ -30,6 +30,10 @@ shared_preferences : Gestion des préférences utilisateur (thème, vues, tutori
 
 firebase_crashlytics : Suivi des erreurs en production.
 
+Intl : Traductions et formats localisés.
+
+flutter_localizations : Localisations officielles Flutter.
+
 🩺 Module Santé
 
 Tesseract / TFLite : OCR carnet santé (ordonnances, vaccins).

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -324,3 +324,4 @@ Responsable : Superadmin
 - 🧩 Mise à jour de `ia_logger.dart` pour tracer les paiements, tests à jour le 2025-06-15
 
 - 🧩 Synchronisation automatique du noyau le 2025-06-18
+- 🆕 Multilingue : i18n_service, i18n_provider, fichiers .arb


### PR DESCRIPTION
## Summary
- document multilingual support in README_DEV
- highlight translation centralisation in dev instructions
- track i18n activation in roadmap
- list intl packages for core tech stack
- note i18n bullet in development log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b5dfdba88320972e5aa561fdbd30