### PR TITLE
Add root l10n with translations

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations

--- a/l10n/app_ar.arb
+++ b/l10n/app_ar.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "بيت",
+  "settings_language": "لغة",
+  "confirm": "يتأكد",
+  "cancel": "يلغي",
+  "change_language_success": "تغيرت اللغة بنجاح"
+}

--- a/l10n/app_de.arb
+++ b/l10n/app_de.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Heim",
+  "settings_language": "Sprache",
+  "confirm": "Bestätigen",
+  "cancel": "Stornieren",
+  "change_language_success": "Die Sprache änderte sich erfolgreich"
+}

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Home",
+  "settings_language": "Language",
+  "confirm": "Confirm",
+  "cancel": "Cancel",
+  "change_language_success": "Language changed successfully"
+}

--- a/l10n/app_es.arb
+++ b/l10n/app_es.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Hogar",
+  "settings_language": "Idioma",
+  "confirm": "Confirmar",
+  "cancel": "Cancelar",
+  "change_language_success": "El lenguaje cambió con éxito"
+}

--- a/l10n/app_fr.arb
+++ b/l10n/app_fr.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Maison",
+  "settings_language": "Langue",
+  "confirm": "Confirmer",
+  "cancel": "Annuler",
+  "change_language_success": "La langue a changé avec succès"
+}

--- a/l10n/app_it.arb
+++ b/l10n/app_it.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Casa",
+  "settings_language": "Lingua",
+  "confirm": "Confermare",
+  "cancel": "Cancellare",
+  "change_language_success": "La lingua è cambiata con successo"
+}

--- a/l10n/app_ja.arb
+++ b/l10n/app_ja.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "家",
+  "settings_language": "言語",
+  "confirm": "確認する",
+  "cancel": "キャンセル",
+  "change_language_success": "言語は成功しました"
+}

--- a/l10n/app_pt.arb
+++ b/l10n/app_pt.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Lar",
+  "settings_language": "Linguagem",
+  "confirm": "Confirmar",
+  "cancel": "Cancelar",
+  "change_language_success": "A linguagem mudou com sucesso"
+}

--- a/l10n/app_ru.arb
+++ b/l10n/app_ru.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "Дом",
+  "settings_language": "Язык",
+  "confirm": "Подтверждать",
+  "cancel": "Отмена",
+  "change_language_success": "Язык успешно изменился"
+}

--- a/l10n/app_zh.arb
+++ b/l10n/app_zh.arb
@@ -1,0 +1,7 @@
+{
+  "home_title": "家",
+  "settings_language": "语言",
+  "confirm": "确认",
+  "cancel": "取消",
+  "change_language_success": "语言成功改变了"
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,0 @@
-{
-  "appTitle": "AniSphère",
-  "mainScreenTitle": "AniSphère"
-}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,4 +1,0 @@
-{
-  "appTitle": "AniSphère",
-  "mainScreenTitle": "AniSphère"
-}


### PR DESCRIPTION
## Summary
- remove obsolete `lib/l10n` folder
- add `l10n.yaml` to configure localization generation
- provide ARB files for 10 locales under `l10n/`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b99a501083208c42ba9934683f25