### PR TITLE
Add language selector widget

### DIFF
--- a/lib/modules/noyau/i18n/language_selector_widget.dart
+++ b/lib/modules/noyau/i18n/language_selector_widget.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import '../providers/i18n_provider.dart';
+
+/// Dropdown widget allowing users to switch application language.
+class LanguageSelectorWidget extends StatelessWidget {
+  const LanguageSelectorWidget({super.key});
+
+  String _nativeName(Locale locale) {
+    switch (locale.languageCode) {
+      case 'fr':
+        return 'Français';
+      case 'en':
+        return 'English';
+      default:
+        return locale.languageCode;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<I18nProvider>();
+    return DropdownButton<Locale>(
+      value: provider.locale,
+      onChanged: (Locale? newLocale) {
+        if (newLocale != null) {
+          context.read<I18nProvider>().setLocale(newLocale);
+        }
+      },
+      items: AppLocalizations.supportedLocales
+          .map(
+            (locale) => DropdownMenuItem<Locale>(
+              value: locale,
+              child: Text(_nativeName(locale)),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -10,6 +10,7 @@ import '../providers/theme_provider.dart';
 import 'feedback_settings_screen.dart';
 import '../providers/payment_provider.dart';
 import 'iap_screen.dart';
+import '../i18n/language_selector_widget.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -111,6 +112,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text("Thème sombre automatique"),
             value: darkMode,
             onChanged: (val) => _updatePreference("dark_mode", val),
+          ),
+          ListTile(
+            leading: const Icon(Icons.language, color: Color(0xFF183153)),
+            title: const Text('Langue'),
+            trailing: const LanguageSelectorWidget(),
           ),
           const Divider(),
           const Text("Intelligence Artificielle", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF183153))),

--- a/test/noyau/widget/language_selector_widget_test.dart
+++ b/test/noyau/widget/language_selector_widget_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:anisphere/modules/noyau/i18n/language_selector_widget.dart';
+import 'package:anisphere/modules/noyau/providers/i18n_provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../../test_config.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  testWidgets('shows and changes language', (tester) async {
+    final provider = I18nProvider();
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: provider,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: LanguageSelectorWidget()),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('English'), findsOneWidget);
+
+    await tester.tap(find.byType(DropdownButton<Locale>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Français').last);
+    await tester.pumpAndSettle();
+
+    expect(provider.locale.languageCode, 'fr');
+  });
+}


### PR DESCRIPTION
## Summary
- add `LanguageSelectorWidget` with `DropdownButton<Locale>`
- integrate language selector into Settings screen
- test language switching

## Testing
- `dart format lib/modules/noyau/i18n/language_selector_widget.dart lib/modules/noyau/screens/settings_screen.dart test/noyau/widget/language_selector_widget_test.dart`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6852b99c7f7c83209b2814356b48cb2c