### PR TITLE
Update docs for i18n

### DIFF
--- a/docs/0__instructions.md
+++ b/docs/0__instructions.md
@@ -39,6 +39,7 @@ L’interface est claire, animée, inspirée de Samsung Health
 Tous les textes, choix et graphismes doivent être accessibles et lisibles
 
 L’application est multilingue et toutes les traductions sont centralisées dans le noyau
+L’interface prend en charge **10 langues** grâce au fichier `i18n_service.dart` et aux ressources `.arb`
 
 🧠 Architecture IA
 

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -325,3 +325,4 @@ Responsable : Superadmin
 
 - 🧩 Synchronisation automatique du noyau le 2025-06-18
 - 🆕 Multilingue : i18n_service, i18n_provider, fichiers .arb
+- 🆕 Support complet de **10 langues** grâce à `i18n_service.dart` et aux fichiers `.arb` localisés


### PR DESCRIPTION
## Summary
- document 10-language support in instructions
- note i18n `.arb` files in noyau suivi

## Testing
- `flutter test --coverage --dart-define=CI=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b9a087e8832098ac56182e255e32