### PR TITLE
Use unified i18n provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ import 'package:anisphere/modules/noyau/services/offline_photo_queue.dart'
 import 'package:anisphere/modules/noyau/models/share_history_model.dart';
 import 'package:anisphere/modules/noyau/providers/feedback_options_provider.dart';
 import 'package:anisphere/modules/noyau/providers/payment_provider.dart';
-import 'package:anisphere/modules/noyau/providers/i18n_provider.dart';
+import 'package:anisphere/modules/noyau/i18n/i18n_provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() async {
@@ -114,7 +114,7 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => I18nProvider()),
+        ChangeNotifierProvider(create: (_) => I18nProvider()..load()),
         ChangeNotifierProvider(
           create: (_) => UserProvider(userService, authService),
         ),


### PR DESCRIPTION
## Summary
- use i18n provider from `lib/modules/noyau/i18n`
- load saved locale on provider creation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b9ab9cf083208063c52479100ce6