### PR TITLE
Fix i18n imports and update docs/tests

### DIFF
--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -125,3 +125,4 @@ suivi_[module].md → suivi fin par module
 
 - ✅ Mise à jour automatique des tâches le 2025-06-18
 - ✅ Mise à jour automatique des tâches le 2025-06-20
+- ✅ Mise à jour automatique des tâches le 2025-06-30 (correctifs i18n)

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -326,3 +326,4 @@ Responsable : Superadmin
 - 🧩 Synchronisation automatique du noyau le 2025-06-18
 - 🆕 Multilingue : i18n_service, i18n_provider, fichiers .arb
 - 🆕 Support complet de **10 langues** grâce à `i18n_service.dart` et aux fichiers `.arb` localisés
+- 🛠️ 2025-06-30 : Correction des imports i18n (`AppLocalizations`, `I18nProvider`) et mise à jour des tests associés

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -112,6 +112,6 @@
 | test/noyau/unit/behavior_analysis_service_test.dart | unit | package:anisphere/modules/noyau/services/behavior_analysis_service.dart | ✅ |
 | test/noyau/unit/i18n_service_test.dart | unit | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
-| test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/providers/i18n_provider.dart | ✅ |
+| test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |
 
 - ✅ Tests validés automatiquement le 2025-06-18

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ import 'package:anisphere/modules/noyau/models/share_history_model.dart';
 import 'package:anisphere/modules/noyau/providers/feedback_options_provider.dart';
 import 'package:anisphere/modules/noyau/providers/payment_provider.dart';
 import 'package:anisphere/modules/noyau/i18n/i18n_provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/modules/noyau/i18n/app_localizations.dart
+++ b/lib/modules/noyau/i18n/app_localizations.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart' as l10n;
+import 'package:anisphere/l10n/app_localizations.dart' as l10n;
 
 class AppLocalizations {
   static l10n.AppLocalizations of(BuildContext context) {

--- a/lib/modules/noyau/i18n/language_selector_widget.dart
+++ b/lib/modules/noyau/i18n/language_selector_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import '../providers/i18n_provider.dart';
+import 'i18n_provider.dart';
 
 /// Dropdown widget allowing users to switch application language.
 class LanguageSelectorWidget extends StatelessWidget {

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -1,7 +1,7 @@
 // Copilot Prompt : MainScreen avec navigation sécurisée et IAScheduler.
 // Comporte 4 onglets dynamiques.
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'home_screen.dart';
 import 'share_screen.dart';

--- a/test/noyau/unit/i18n_service_test.dart
+++ b/test/noyau/unit/i18n_service_test.dart
@@ -4,10 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
-import 'package:anisphere/modules/noyau/services/i18n_service.dart'
-    as hive_service;
-import 'package:anisphere/modules/noyau/i18n/i18n_service.dart'
-    as i18n_service;
+import 'package:anisphere/modules/noyau/i18n/i18n_service.dart';
 import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
 import '../../test_config.dart';
 
@@ -16,18 +13,11 @@ void main() {
     await initTestEnv();
   });
 
-  test('saveLocale stores the locale and loadLocale retrieves it', () async {
-    final dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    final box = await Hive.openBox('settings');
-    final service = hive_service.I18nService(testBox: box);
-
-    await service.saveLocale('fr');
-    expect(box.get('locale'), 'fr');
-    expect(service.loadLocale(), 'fr');
-
-    await box.deleteFromDisk();
-    await dir.delete(recursive: true);
+  test('setLocale stores the locale and getCurrentLocale retrieves it', () async {
+    await LocalStorageService.init();
+    await I18nService.setLocale(const Locale('fr'));
+    final locale = I18nService.getCurrentLocale();
+    expect(locale.languageCode, 'fr');
   });
 
   test('getCurrentLocale returns default when none saved', () async {
@@ -38,7 +28,7 @@ void main() {
     // Ensure no locale is stored
     await LocalStorageService.remove('locale');
 
-    final locale = i18n_service.I18nService.getCurrentLocale();
+    final locale = I18nService.getCurrentLocale();
     expect(locale.languageCode, 'en');
 
     await Hive.deleteBoxFromDisk('users');

--- a/test/noyau/widget/i18n_widget_test.dart
+++ b/test/noyau/widget/i18n_widget_test.dart
@@ -2,8 +2,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:anisphere/modules/noyau/i18n/i18n_service.dart';
-
 import '../../test_config.dart';
 
 class TestLocalizations {

--- a/test/noyau/widget/language_selector_widget_test.dart
+++ b/test/noyau/widget/language_selector_widget_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
-import 'package:anisphere/modules/noyau/providers/i18n_provider.dart';
+import 'package:anisphere/modules/noyau/i18n/i18n_provider.dart';
 import '../../test_config.dart';
 
 class _LanguageSelectorWidget extends StatelessWidget {

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -112,4 +112,4 @@
 | test/noyau/unit/behavior_analysis_service_test.dart | unit | package:anisphere/modules/noyau/services/behavior_analysis_service.dart | ✅ |
 | test/noyau/unit/i18n_service_test.dart | unit | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
-| test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/providers/i18n_provider.dart | ✅ |
+| test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |


### PR DESCRIPTION
## Summary
- fix imports of `AppLocalizations`
- correct `I18nProvider` path
- adjust i18n tests and remove unused imports
- update documentation trackers for new paths
- log i18n fix in project history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852bd8a9f308320b8e8830217dbdd1b