### PR TITLE
Update docs for i18n integration

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -12,6 +12,9 @@ Servir de passerelle entre le code, l’IA et les fichiers de suivi (test, roadm
 
 Il est mis à jour automatiquement à chaque évolution majeure du projet.
 AniSphère est maintenant multilingue grâce au système de traduction centralisé du noyau.
+* Tous les textes doivent être appelés via `AppLocalizations.of(context)` pour permettre la traduction automatique.
+* Les fichiers `.arb` sont regroupés dans `lib/l10n/` et générés ou traduits via script.
+* Le service central `lib/modules/noyau/i18n/` gère la langue globale pour tous les modules.
 📌 Version Flutter/Dart requise
 
 Le développement d'AniSphère s'appuie sur **Flutter&nbsp;3.32.x** et **Dart&nbsp;3.4+**.
@@ -45,6 +48,7 @@ Chaque module dispose de son propre dossier dans lib/modules/[nom_du_module]
 Le noyau est toujours accessible depuis les modules, mais les modules ne doivent jamais l’altérer
 
 Tous les tests sont regroupés dans /test et suivent la même hiérarchie que lib/
+Tous les textes des modules doivent passer par `AppLocalizations.of(context)` et les services utilisent `I18nService` pour la langue active. Aucune ressource `.arb` ne doit être créée dans les modules.
 
 ### Services transverses du noyau
 - Messagerie : `lib/modules/messagerie/services/messaging_service.dart`

--- a/docs/0__instructions.md
+++ b/docs/0__instructions.md
@@ -40,6 +40,9 @@ Tous les textes, choix et graphismes doivent être accessibles et lisibles
 
 L’application est multilingue et toutes les traductions sont centralisées dans le noyau
 L’interface prend en charge **10 langues** grâce au fichier `i18n_service.dart` et aux ressources `.arb`
+Tous les textes doivent passer par `AppLocalizations.of(context)` pour permettre la traduction automatique selon la langue choisie.
+Les fichiers `.arb` se trouvent dans `lib/l10n/` et sont générés automatiquement ou traduits via script.
+Le système multilingue est centralisé dans `lib/modules/noyau/i18n/`.
 
 🧠 Architecture IA
 

--- a/docs/2__roadmap.md
+++ b/docs/2__roadmap.md
@@ -25,6 +25,7 @@ Statut :
 ✅ Gestion compte utilisateur : OK
 ✅ Architecture des modules : OK
 🔄 En cours : synchronisation automatique animaux (local + cloud)
+✅ Multilingue activé (i18n) — fichiers `.arb` gérés, langue utilisateur sélectionnable dans les paramètres
 
 🧠 Phase 2 — IA maîtresse & automatisations
 

--- a/docs/6__technos_par_module.md
+++ b/docs/6__technos_par_module.md
@@ -26,13 +26,12 @@ OpenCV (via native plugin) : Analyse d’image, tri IA, reconnaissance.
 
 flutter_secure_storage : Stockage local chiffré de données sensibles.
 
-shared_preferences : Gestion des préférences utilisateur (thème, vues, tutoriels).
+shared_preferences : Gestion des préférences utilisateur (thème, vues, tutoriels) et stockage local de la langue choisie.
 
 firebase_crashlytics : Suivi des erreurs en production.
 
-Intl : Traductions et formats localisés.
-
-flutter_localizations : Localisations officielles Flutter.
+intl, flutter_localizations : Gestion du multilingue Flutter.
+Tous les modules utilisent `AppLocalizations` pour les textes, aucun système i18n n'est redéclaré.
 
 🩺 Module Santé
 

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -210,6 +210,15 @@ AniSphère introduit une authentification biométrique (empreinte digitale ou re
 | lib/modules/noyau/models/security_settings_model.dart | Stockage local des choix de sécurité et de consentement |
 | lib/modules/noyau/screens/security_settings_screen.dart | Interface pour modifier ou révoquer son consentement |
 
+### ✅ Multilingue (i18n)
+- 📁 `lib/modules/noyau/i18n/`
+- Fichiers : `i18n_service.dart`, `i18n_provider.dart`, `app_localizations.dart`
+- 📁 Traductions : `lib/l10n/app_xx.arb` (fr, en, es, it, de, pt, ar, zh, ru, ja…)
+- Fonction : Gère automatiquement la langue globale de l'application
+- Intégration : `MaterialApp(locale: ...)`, `AppLocalizations.of(context)`
+- Modules : Tous les modules utilisent automatiquement ce système sans duplication
+- Exports PDF & QR utilisent la langue active via `i18n_service`
+
 ---
 
 ## 🗂️ Annexes & liens


### PR DESCRIPTION
## Summary
- document centralized i18n setup in docs
- detail i18n usage rules in instructions and dev guide
- list i18n dependencies and usage in technos overview
- mark i18n complete on the roadmap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ecfc0f588320aed85912c5a9690e