### PR TITLE
Add IA log structure docs

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -34,6 +34,7 @@ local.
 - Pour l'appel des fonctions cloud, consultez `docs/firebase_function_examples.md`.
 - Téléchargez `GoogleService-Info.plist` depuis la console Firebase et placez ce fichier dans `ios/Runner/`. Un gabarit est disponible sous `ios/Runner/GoogleService-Info.plist.example`. Comme ce fichier contient des identifiants sensibles, il doit rester local et ne pas être commité.
 - Suivez [docs/firestore_setup.md](docs/firestore_setup.md) pour préparer manuellement les collections Firestore et lancer le script de vérification.
+- Consultez [docs/4__gestion_des_collections.md](docs/4__gestion_des_collections.md#collection-logs_ia) pour le format détaillé des logs IA.
 
 🗂️ Chapitre 2 — Structure du projet Flutter
 

--- a/docs/4__gestion_des_collections.md
+++ b/docs/4__gestion_des_collections.md
@@ -141,6 +141,38 @@ medias (images, vidéos, tri automatique IA)
 
 historique (actions IA ou utilisateur)
 
+📊 Collection logs_ia
+
+🔹 Objectif
+
+Centraliser tous les logs IA envoyés par l'application pour analyse ou apprentissage.
+
+🔹 Structure
+
+logs_ia (collection)
+ └── [logId] (document)
+     ├── module: string
+     ├── type: string
+     ├── userId: string
+     ├── animalId: string
+     ├── data: map (optionnelle)
+     ├── metadata: map (optionnelle)
+     └── timestamp: timestamp
+
+Exemple de document :
+
+```json
+{
+  "module": "education",
+  "type": "exercise_completed",
+  "userId": "u123",
+  "animalId": "a456",
+  "data": {"exerciseId": "sit", "score": 95},
+  "metadata": {"appVersion": "1.2.0"},
+  "timestamp": "2025-06-12T16:45:00Z"
+}
+```
+
 📌 Recommandations Firebase
 
 Minimiser les lectures avec whereEqualTo, limit, startAfter...


### PR DESCRIPTION
## Summary
- document the `logs_ia` collection with all fields and a JSON example
- explain where contributors can read this information in README_DEV

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1d3e3b48320a8123eb6289feee8