### PR TITLE
Add path dependency and update docs

### DIFF
--- a/docs/6__technos_par_module.md
+++ b/docs/6__technos_par_module.md
@@ -25,6 +25,7 @@ TFLite : IA locale pour OCR et détection embarquée.
 OpenCV (via native plugin) : Analyse d’image, tri IA, reconnaissance.
 
 flutter_secure_storage : Stockage local chiffré de données sensibles.
+path : Gestion des chemins et manipulations de fichiers.
 
 shared_preferences : Gestion des préférences utilisateur (thème, vues, tutoriels) et stockage local de la langue choisie.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   # Base / stockage local
   provider: ^6.1.2
   path_provider: ^2.1.5
+  path: ^1.8.3
   flutter_secure_storage: ^10.0.0-beta.4
   connectivity_plus: ^6.1.3
   hive: ^2.2.3


### PR DESCRIPTION
## Summary
- add `path` package to pubspec
- mention `path` package in technical documentation

## Testing
- `flutter pub get` *(fails: /opt/flutter/bin/internal/shared.sh: No such file or directory)*
- `flutter test` *(fails: /opt/flutter/bin/internal/shared.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852f64aaa74832085029a313899bc9e