### PR TITLE
Fix argument matchers in ia_model_loader_test

### DIFF
--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   test('predict uses interpreter', () async {
     final mock = MockInterpreter();
-    when(mock.run(any, any)).thenAnswer((invocation) {
+    when(mock.run(any<Object?>(), any<Object?>())).thenAnswer((invocation) {
       final output = invocation.positionalArguments[1] as List;
       (output.first as List)[0] = 3.14;
     });
@@ -45,6 +45,6 @@ void main() {
     final result = await loader.predict([1.0]);
 
     expect(result, [3.14]);
-    verify(mock.run(any, any)).called(1);
+    verify(mock.run(any<Object?>(), any<Object?>())).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- fix mockito argument matcher types in ia_model_loader_test

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f64d88888320afff7bc761802c00