### PR TITLE
Rename IaModelLoader service

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -34,7 +34,8 @@ Placez tous les modèles `.tflite` ou `.pkl` dans `assets/models/` et ajoutez
 leurs chemins dans `pubspec.yaml` sous `flutter/assets`. Exécutez ensuite
 `flutter pub get` pour que Flutter prenne ces fichiers en compte. Lorsque
 `IaModelUpdater` télécharge un modèle au démarrage, ce dossier sert de chemin de
-secours.
+secours. `IaModelLoader` copie ensuite le fichier dans `ApplicationDocumentsDirectory`,
+et `IaInterpreterLoader` instancie l'interpréteur TFLite pour l'utiliser dans les services.
 ℹ️ Notes d’utilisation du module Partage pour les contributeurs
 - Testez toujours le partage local hors connexion avant de valider une mise à jour.
 - Les fonctions cloud nécessitent un compte Premium de test ; utilisez `lib/core/sharing` pour simuler la synchro.

--- a/docs/7__ia.md
+++ b/docs/7__ia.md
@@ -164,7 +164,7 @@ modules/[module]/logic/
 IA locale de chaque module (TFLite, rules, analyzers)
 - Ex. `BehaviorAnalysisService` pour interpréter les pas et la posture
 - Dossier `lib/modules/noyau/ia_local/` : prédicteurs génériques (`IaPredictor`),
-  chargement de modèles (`IaModelLoader`) et prédicteur éducation (`EducationIaPredictor`)
+  chargement de modèles (`IaModelLoader`, copie des fichiers) et prédicteur éducation (`EducationIaPredictor`)
 
 cloud/ (non versionné ici)  
 
@@ -173,20 +173,19 @@ Backend API IA cloud par catégorie (API REST, batch endpoints, ML pipeline)
 Stockage Firestore ou BigQuery par catégorie
 
 Scripts d’apprentissage, retrain, déploiement modèles
-<<<<<<< HEAD
 train_ia_pipeline.py : entraîne les modèles localement et exporte un fichier .tflite
 upload_model_to_functions.sh : envoie le package généré vers Firebase Functions
 
 Les modèles sont donc entraînés localement, puis le package est copié dans `functions/` pour être déployé via Firebase Functions.
-=======
->>>>>>> codex/add-subsection-sur-modèles-ia-locaux
 
 ### Gestion des modèles IA locaux
 
 Les modèles embarqués sont rangés dans `lib/modules/noyau/ia_local/`. Ce dossier
 contient une sous-arborescence par type de modèle (OCR, comportement, etc.).
 Chaque modèle est téléchargé puis stocké dans `ApplicationDocumentsDirectory` à
-travers le service `IaModelLoader`. L’utilitaire `IaModelUpdater` vérifie
+puis chargé dans l’application via le service `IaModelLoader`. Ce dernier se
+contente de copier le fichier localement, tandis que `IaInterpreterLoader`
+instancie l’interpréteur TFLite pour l’utiliser. L’utilitaire `IaModelUpdater` vérifie
 périodiquement Firebase Storage pour récupérer la dernière version disponible.
 Si la connexion échoue ou qu’aucun modèle n’est publié, l’application continue
 d’utiliser la version locale déjà enregistrée ou celle embarquée par défaut.

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -113,6 +113,6 @@
 | test/noyau/unit/i18n_service_test.dart | unit | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |
-| test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_model_loader.dart | ✅ |
+| test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_interpreter_loader.dart | ✅ |
 
 - ✅ Tests validés automatiquement le 2025-06-18

--- a/lib/modules/noyau/services/ia_interpreter_loader.dart
+++ b/lib/modules/noyau/services/ia_interpreter_loader.dart
@@ -1,12 +1,12 @@
 import 'package:tflite_flutter/tflite_flutter.dart';
 
-/// Utility class to load and run local TensorFlow Lite models.
-class IaModelLoader {
+/// Utility class to load and run local TensorFlow Lite interpreters.
+class IaInterpreterLoader {
   final String modelPath;
   final Future<Interpreter> Function(String path) _creator;
   Interpreter? _interpreter;
 
-  IaModelLoader({required this.modelPath, Future<Interpreter> Function(String path)? creator})
+  IaInterpreterLoader({required this.modelPath, Future<Interpreter> Function(String path)? creator})
       : _creator = creator ?? Interpreter.fromAsset;
 
   /// Loaded interpreter instance.

--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:anisphere/modules/noyau/services/ia_model_loader.dart';
+import 'package:anisphere/modules/noyau/services/ia_interpreter_loader.dart';
 import 'package:tflite_flutter/tflite_flutter.dart';
 
 import '../../../test_config.dart';
@@ -16,7 +16,7 @@ void main() {
   });
 
   test('load returns true with valid interpreter', () async {
-    final loader = IaModelLoader(modelPath: 'models/dummy.tflite', creator: _mockCreator);
+    final loader = IaInterpreterLoader(modelPath: 'models/dummy.tflite', creator: _mockCreator);
 
     final result = await loader.load();
 
@@ -25,7 +25,7 @@ void main() {
   });
 
   test('load returns false when model missing', () async {
-    final loader = IaModelLoader(modelPath: 'missing.tflite', creator: _throwingCreator);
+    final loader = IaInterpreterLoader(modelPath: 'missing.tflite', creator: _throwingCreator);
 
     final result = await loader.load();
 
@@ -39,7 +39,7 @@ void main() {
       final output = invocation.positionalArguments[1] as List;
       (output.first as List)[0] = 3.14;
     });
-    final loader = IaModelLoader(modelPath: 'models/dummy.tflite', creator: (_) async => mock);
+    final loader = IaInterpreterLoader(modelPath: 'models/dummy.tflite', creator: (_) async => mock);
     await loader.load();
 
     final result = await loader.predict([1.0]);

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -113,4 +113,4 @@
 | test/noyau/unit/i18n_service_test.dart | unit | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |
-| test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_model_loader.dart | ✅ |
+| test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_interpreter_loader.dart | ✅ |


### PR DESCRIPTION
## Summary
- rename `ia_model_loader.dart` to `ia_interpreter_loader.dart`
- update imports and docs
- clarify difference between IaModelLoader and IaInterpreterLoader

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f655eef48320a567db59755d145c