### PR TITLE
Fix speech recognition service path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Missions / professionnels
 
 Chaque module embarque sa propre IA et son propre système de données.
 
-**Services transverses du noyau** : messagerie (`lib/modules/messagerie/services/messaging_service.dart`), partage (`lib/modules/noyau/services/local_sharing_service.dart`), commande vocale (`lib/modules/voice/speech_recognition_service.dart`), notifications (`lib/modules/noyau/services/notification_service.dart`), exports (`lib/modules/noyau/services/share_history_service.dart`), métriques IA (`lib/services/ia/ia_metrics_collector.dart`).
+**Services transverses du noyau** : messagerie (`lib/modules/messagerie/services/messaging_service.dart`), partage (`lib/modules/noyau/services/local_sharing_service.dart`), commande vocale (`lib/modules/noyau/services/speech_recognition_service.dart`), notifications (`lib/modules/noyau/services/notification_service.dart`), exports (`lib/modules/noyau/services/share_history_service.dart`), métriques IA (`lib/services/ia/ia_metrics_collector.dart`).
 
 🔒 Sécurité et confidentialité
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -63,7 +63,7 @@ Tous les textes des modules doivent passer par `AppLocalizations.of(context)` et
 ### Services transverses du noyau
 - Messagerie : `lib/modules/messagerie/services/messaging_service.dart`
 - Partage local/cloud : `lib/modules/noyau/services/local_sharing_service.dart`, `cloud_sharing_service.dart`
-- Voix : `lib/modules/voice/speech_recognition_service.dart`
+- Voix : `lib/modules/noyau/services/speech_recognition_service.dart`
 - Notifications : `lib/modules/noyau/services/notification_service.dart`
 - Exports : `lib/modules/noyau/services/share_history_service.dart`
 - File offline : `lib/modules/noyau/services/offline_sync_queue.dart`

--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -224,7 +224,7 @@ AniSphère dispose d'un service de partage local (Bluetooth, Wi‑Fi Direct, NFC
 Le noyau met à disposition plusieurs services communs accessibles par tous les modules :
 - **Messagerie interne** : `lib/modules/messagerie/services/messaging_service.dart` et sa file d'attente `offline_message_queue.dart`.
 - **Partage local et cloud** : `lib/modules/noyau/services/local_sharing_service.dart` et `cloud_sharing_service.dart`, avec suivi via `share_history_service.dart`.
-- **Commande vocale** : `lib/modules/voice/speech_recognition_service.dart` et `voice_command_analyzer.dart` pour déclencher rapidement des actions.
+- **Commande vocale** : `lib/modules/noyau/services/speech_recognition_service.dart` et `voice_command_analyzer.dart` pour déclencher rapidement des actions.
 - **Notifications intelligentes** : `lib/modules/noyau/services/notification_service.dart` connectée à l'IA maîtresse.
 - **Exports et historiques** : `lib/modules/noyau/noyau_module.dart` ainsi que `share_history_service.dart` pour générer des PDF ou archives.
 - **File de synchronisation offline** : `lib/modules/noyau/services/offline_sync_queue.dart`.


### PR DESCRIPTION
## Summary
- fix outdated service path references in docs

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd8e6a40832091e4477c2ac7d286