### PR TITLE
Improve camera and banner tests

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -31,6 +31,7 @@
 | test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
 | test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | ✅ |
+| test/noyau/unit/camera_service_test.dart | unit | package:anisphere/modules/noyau/services/camera_service.dart | ✅ |
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | ✅ |
 | test/noyau/unit/consent_service_test.dart | unit | package:anisphere/modules/noyau/services/consent_service.dart | ✅ |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | ✅ |

--- a/lib/modules/noyau/services/camera_service.dart
+++ b/lib/modules/noyau/services/camera_service.dart
@@ -7,7 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
 class CameraService {
-  final ImagePicker _picker = ImagePicker();
+  final ImagePicker _picker;
+
+  CameraService({ImagePicker? picker}) : _picker = picker ?? ImagePicker();
 
   /// Vérifie et demande la permission d'accès à la caméra si nécessaire.
   Future<bool> _ensurePermission() async {

--- a/test/noyau/unit/camera_service_test.dart
+++ b/test/noyau/unit/camera_service_test.dart
@@ -1,12 +1,38 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mockito/mockito.dart';
+import 'package:anisphere/modules/noyau/services/camera_service.dart';
 import '../../test_config.dart';
+
+class MockImagePicker extends Mock implements ImagePicker {}
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-  test('camera_service placeholder', () {
-    expect(true, isTrue);
+  test('takePicture returns photo when permission granted', () async {
+    final picker = MockImagePicker();
+    final file = XFile('test.jpg');
+    when(picker.pickImage(source: ImageSource.camera))
+        .thenAnswer((_) async => file);
+
+    final service = CameraService(picker: picker);
+    final result = await service.takePicture();
+
+    expect(result, file);
+    verify(picker.pickImage(source: ImageSource.camera)).called(2);
+  });
+
+  test('takePicture returns null when permission denied', () async {
+    final picker = MockImagePicker();
+    when(picker.pickImage(source: ImageSource.camera))
+        .thenThrow(Exception('denied'));
+
+    final service = CameraService(picker: picker);
+    final result = await service.takePicture();
+
+    expect(result, isNull);
+    verify(picker.pickImage(source: ImageSource.camera)).called(1);
   });
 }

--- a/test/noyau/widget/ia_banner_test.dart
+++ b/test/noyau/widget/ia_banner_test.dart
@@ -1,13 +1,33 @@
 // Copilot Prompt : Test automatique généré pour ia_banner.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/widgets/ia_banner.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('ia_banner fonctionne (test auto)', () {
-    // TODO : compléter le test pour ia_banner.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  testWidgets('displays message and icon with styles', (tester) async {
+    const message = 'Hello';
+    const icon = Icons.warning;
+    const background = Colors.green;
+
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: IABanner(
+          message: message,
+          icon: icon,
+          background: background,
+        ),
+      ),
+    ));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.byIcon(icon), findsOneWidget);
+
+    final container = tester.widget<Container>(find.byType(Container));
+    final decoration = container.decoration as BoxDecoration?;
+    expect(decoration?.color, background);
   });
 }

--- a/test/noyau/widget/notification_icon_test.dart
+++ b/test/noyau/widget/notification_icon_test.dart
@@ -1,13 +1,37 @@
 // Copilot Prompt : Test automatique généré pour notification_icon.dart (widget)
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:anisphere/modules/noyau/widgets/notification_icon.dart';
 import '../../test_config.dart';
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  test('notification_icon fonctionne (test auto)', () {
-    // TODO : compléter le test pour notification_icon.dart
-    expect(true, isTrue); // À remplacer par un vrai test
+  testWidgets('shows badge when unread notifications exist', (tester) async {
+    int taps = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: NotificationIcon(
+        unreadCount: 3,
+        onTap: () => taps++,
+      ),
+    ));
+
+    expect(find.text('3'), findsOneWidget);
+    expect(taps, 0);
+    await tester.tap(find.byType(IconButton));
+    expect(taps, 1);
+  });
+
+  testWidgets('hides badge when there are no notifications', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: NotificationIcon(
+        unreadCount: 0,
+        onTap: () {},
+      ),
+    ));
+
+    expect(find.text('0'), findsNothing);
+    expect(find.byType(Container), findsNothing);
   });
 }

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -31,6 +31,7 @@
 | test/noyau/unit/notification_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_service.dart | ✅ |
 | test/noyau/unit/notification_feedback_service_test.dart | unit | package:anisphere/modules/noyau/services/notification_feedback_service.dart | ✅ |
 | test/noyau/unit/backup_service_test.dart | unit | package:anisphere/modules/noyau/services/backup_service.dart | ✅ |
+| test/noyau/unit/camera_service_test.dart | unit | package:anisphere/modules/noyau/services/camera_service.dart | ✅ |
 | test/noyau/unit/local_storage_service_test.dart | unit | package:anisphere/modules/noyau/services/local_storage_service.dart | ✅ |
 | test/noyau/unit/consent_service_test.dart | unit | package:anisphere/modules/noyau/services/consent_service.dart | ✅ |
 | test/noyau/unit/animal_service_test.dart | unit | package:anisphere/modules/noyau/services/animal_service.dart | ✅ |


### PR DESCRIPTION
## Summary
- allow dependency injection for `CameraService`
- add unit tests for `CameraService`
- add widget tests for `IABanner` and `NotificationIcon`
- track `camera_service_test.dart` in test tracker

## Testing
- `flutter test test/noyau/unit/camera_service_test.dart test/noyau/widget/ia_banner_test.dart test/noyau/widget/notification_icon_test.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd8f92a083208f4d3b8c792c6e66