### PR TITLE
Update queue name in docs

### DIFF
--- a/docs/9__planification_photos.md
+++ b/docs/9__planification_photos.md
@@ -116,7 +116,7 @@ Sauvegarde cloud uniquement si activée ou premium (aucun coût imposé)
 
 - `camera_service.dart` gère la prise de vue et stocke dans `photo_model.dart`.
 - `ocr_photo_service.dart` extrait les textes pour alimenter l’IA locale.
-- Les photos passent par `photo_upload_queue.dart` pour une synchronisation différée avec le cloud et l’IA collective.
+- Les photos passent par `offline_photo_queue.dart` pour une synchronisation différée avec le cloud et l’IA collective.
 
 🧭 Vision long terme
 

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -111,7 +111,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 ### **Juin 2025 — Gestion photo & file offline**
 - [06/2025] Ajout du `camera_service.dart` pour la capture et le pré-traitement des images.
 - [06/2025] Création du modèle `photo_model.dart` (métadonnées, stockage Hive).
-- [06/2025] Mise en place de `offline_photo_queue.dart` (ex `photo_upload_queue.dart`) pour la synchronisation différée des clichés et pré-analyse IA.
+- [06/2025] Mise en place de `offline_photo_queue.dart` pour la synchronisation différée des clichés et pré-analyse IA.
 - [06/2025] Ajout de `offline_gps_queue.dart` pour enregistrer les traces GPS hors ligne et analyse IA.
 - [06/2025] Tests unitaires : `offline_photo_queue_test.dart`, `offline_gps_queue_test.dart`.
 - [06/2025] Tests unitaires : `camera_service_test.dart`, `photo_model_test.dart`.


### PR DESCRIPTION
## Summary
- replace old queue reference in photo planning doc
- drop outdated queue name from noyau_suivi

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685301ec6d9c83209e0b2bbbbe3deab5