### PR TITLE
docs: note currentUser crash fix

### DIFF
--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -107,6 +107,7 @@ Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolu
 ### **Juin 2025 — Préparation de la messagerie**
 - [06/2025] Définition de la collection `messages` (conversations, messages).
 - [06/2025] Création du dossier module `messagerie` et des premiers tests vides. *(Ce module sera intégré au noyau mi-juin 2025 — voir plus bas)*
+- [06/2025] Correction du crash au démarrage lorsque `currentUser` était `null`.
 
 ### **Juin 2025 — Gestion photo & file offline**
 - [06/2025] Ajout du `camera_service.dart` pour la capture et le pré-traitement des images.


### PR DESCRIPTION
## Summary
- document crash fix when `currentUser` was null at app start

## Testing
- `flutter test` *(fails: command not found)*
- `flutter pub run scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853048a40a883209f230d851d9c96d1