### PR TITLE
Add widget test for null user

### DIFF
--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -8,11 +8,58 @@ import 'package:anisphere/modules/noyau/providers/ia_context_provider.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/screens/main_screen.dart';
+import 'package:anisphere/modules/noyau/screens/splash_screen.dart';
+import 'package:anisphere/main.dart';
+import 'package:anisphere/modules/noyau/providers/theme_provider.dart';
+import 'package:anisphere/modules/noyau/i18n/i18n_provider.dart';
 
 import '../../test_config.dart';
 
 class _TestUserProvider extends UserProvider {
   _TestUserProvider() : super(UserService(skipHiveInit: true), AuthService());
+}
+
+class _NullUserProvider extends UserProvider {
+  _NullUserProvider() : super(UserService(skipHiveInit: true), AuthService());
+
+  @override
+  Future<void> loadUser() async {}
+}
+
+class _FakeI18nProvider with ChangeNotifier implements I18nProvider {
+  Locale _locale = const Locale('en');
+
+  @override
+  Locale get locale => _locale;
+
+  @override
+  Future<void> load() async {}
+
+  @override
+  Future<void> setLocale(Locale locale) async {
+    _locale = locale;
+    notifyListeners();
+  }
+}
+
+class _FakeThemeProvider with ChangeNotifier implements ThemeProvider {
+  bool _isDarkMode = false;
+
+  @override
+  bool get isDarkMode => _isDarkMode;
+
+  @override
+  ThemeMode get themeMode =>
+      _isDarkMode ? ThemeMode.dark : ThemeMode.light;
+
+  @override
+  Future<void> load() async {}
+
+  @override
+  Future<void> setDarkMode(bool value) async {
+    _isDarkMode = value;
+    notifyListeners();
+  }
 }
 
 void main() {
@@ -48,6 +95,24 @@ void main() {
 
     final menuIcon = tester.widget<Icon>(find.widgetWithIcon(PopupMenuButton<String>, Icons.more_vert));
     expect(menuIcon.color, const Color(0xFF183153));
+  });
+
+  testWidgets('shows SplashScreen when user is null', (tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<I18nProvider>(create: (_) => _FakeI18nProvider()),
+          ChangeNotifierProvider<ThemeProvider>(create: (_) => _FakeThemeProvider()),
+          ChangeNotifierProvider<UserProvider>(create: (_) => _NullUserProvider()),
+        ],
+        child: const MyApp(),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.byType(MainScreen), findsNothing);
+    expect(find.byType(SplashScreen), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- extend `main_screen_test.dart` with stub providers
- expect `SplashScreen` instead of `MainScreen` when `UserProvider` has no user

## Testing
- `flutter --version` *(fails: command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530485b26083209f345235fc822514