### PR TITLE
Standardize text colors in core screens

### DIFF
--- a/lib/modules/noyau/screens/animal_profile_screen.dart
+++ b/lib/modules/noyau/screens/animal_profile_screen.dart
@@ -70,12 +70,12 @@ class AnimalProfileScreen extends StatelessWidget {
           const SizedBox(height: 24),
           const Text(
             "Historique (à venir)",
-            style: TextStyle(fontWeight: FontWeight.bold, color: Colors.grey),
+            style: TextStyle(fontWeight: FontWeight.bold, color: Colors.black),
           ),
           const SizedBox(height: 4),
           const Text(
             "Cette section affichera bientôt les événements santé, entraînements, alertes IA, etc.",
-            style: TextStyle(fontSize: 12, color: Colors.grey),
+            style: TextStyle(fontSize: 12, color: Colors.black),
           ),
         ],
       ),

--- a/lib/modules/noyau/screens/animal_screen.dart
+++ b/lib/modules/noyau/screens/animal_screen.dart
@@ -95,7 +95,7 @@ class AnimalScreen extends StatelessWidget {
                 const SizedBox(height: 30),
                 const Divider(),
                 const Text("Modules IA à venir...",
-                    style: TextStyle(color: Colors.grey)),
+                    style: TextStyle(color: Colors.black)),
               ],
             ),
           ),
@@ -114,7 +114,7 @@ class AnimalScreen extends StatelessWidget {
             "$label : ",
             style: const TextStyle(
               fontWeight: FontWeight.bold,
-              color: Color(0xFF183153),
+              color: Colors.black,
             ),
           ),
           Expanded(child: Text(value)),

--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -124,7 +124,7 @@ class _HomeScreenState extends State<HomeScreen> {
                             style:
                                 Theme.of(context).textTheme.titleLarge?.copyWith(
                                       fontWeight: FontWeight.bold,
-                                      color: const Color(0xFF183153),
+                                      color: Colors.black,
                                     ),
                           ),
                         ),

--- a/lib/modules/noyau/screens/login_screen.dart
+++ b/lib/modules/noyau/screens/login_screen.dart
@@ -159,7 +159,7 @@ class LoginScreenState extends State<LoginScreen> {
             ),
             const SizedBox(height: 10),
             if (_errorMessage != null)
-              Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+              Text(_errorMessage!, style: const TextStyle(color: Colors.black)),
             const SizedBox(height: 20),
             _isLoading
                 ? const CircularProgressIndicator()

--- a/lib/modules/noyau/screens/register_screen.dart
+++ b/lib/modules/noyau/screens/register_screen.dart
@@ -90,7 +90,7 @@ class RegisterScreenState extends State<RegisterScreen> {
             if (_errorMessage != null)
               Text(
                 _errorMessage!,
-                style: const TextStyle(color: Colors.red),
+                style: const TextStyle(color: Colors.black),
               ),
             const SizedBox(height: 20),
             _isLoading

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -105,7 +105,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ListView(
         padding: const EdgeInsets.all(24),
         children: [
-          const Text("Préférences générales", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF183153))),
+          const Text("Préférences générales", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black)),
           const SizedBox(height: 8),
           SwitchListTile(
             title: const Text("Mode sombre"),
@@ -119,7 +119,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             trailing: const LanguageSelectorWidget(),
           ),
           const Divider(),
-          const Text("Intelligence Artificielle", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF183153))),
+          const Text("Intelligence Artificielle", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black)),
           const SizedBox(height: 8),
           SwitchListTile(
             title: const Text("Suggestions IA"),
@@ -167,7 +167,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
           const Divider(),
-          const Text("Sauvegarde & restauration", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Color(0xFF183153))),
+          const Text("Sauvegarde & restauration", style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black)),
           const SizedBox(height: 8),
           ListTile(
             leading: const Icon(Icons.backup, color: Color(0xFF183153)),

--- a/lib/modules/noyau/screens/share_screen.dart
+++ b/lib/modules/noyau/screens/share_screen.dart
@@ -64,7 +64,7 @@ class _ShareScreenState extends State<ShareScreen> {
               padding: EdgeInsets.symmetric(vertical: 8),
               child: Text(
                 'Partage cloud réservé aux comptes premium',
-                style: TextStyle(color: Colors.red),
+                style: TextStyle(color: Colors.black),
               ),
             ),
             ElevatedButton(

--- a/lib/modules/noyau/screens/user_profile_screen.dart
+++ b/lib/modules/noyau/screens/user_profile_screen.dart
@@ -148,7 +148,7 @@ class UserProfileScreen extends StatelessWidget {
         style: const TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.bold,
-          color: Color(0xFF183153),
+          color: Colors.black,
         ),
       ),
     );
@@ -164,7 +164,7 @@ class UserProfileScreen extends StatelessWidget {
             "$label : ",
             style: const TextStyle(
               fontWeight: FontWeight.bold,
-              color: Color(0xFF183153),
+              color: Colors.black,
             ),
           ),
           Expanded(


### PR DESCRIPTION
## Summary
- switch text color to `Colors.black` for settings titles
- keep `Colors.black` for home header text
- use `Colors.black` for profile and animal info rows
- change error text to black on login/register/share screens

## Testing
- `flutter test --coverage` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853161ea64c8320a39ea4800fee573e