### PR TITLE
Resolve analyze warnings

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -15,7 +15,7 @@ final ThemeData appTheme = ThemeData(
     backgroundColor: backgroundGray,
     foregroundColor: Colors.black,
     elevation: 0,
-    iconTheme: const IconThemeData(color: Colors.black),
+    iconTheme: IconThemeData(color: Colors.black),
   ),
   splashColor: accentYellow,
   highlightColor: accentYellow,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,6 +89,7 @@ dev_dependencies:
   hive_test: ^1.0.0
   fake_cloud_firestore: ^3.1.0
   connectivity_plus_platform_interface: ^2.0.1
+  path_provider_platform_interface: ^2.1.2
 
 dependency_overrides:
   grpc: 3.2.4

--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   test('predict uses interpreter', () async {
     final mock = MockInterpreter();
-    when(mock.run(any<Object?>(), any<Object?>())).thenAnswer((invocation) {
+    when(() => mock.run(any<Object?>(), any<Object?>())).thenAnswer((invocation) {
       final output = invocation.positionalArguments[1] as List;
       (output.first as List)[0] = 3.14;
     });
@@ -45,6 +45,6 @@ void main() {
     final result = await loader.predict([1.0]);
 
     expect(result, [3.14]);
-    verify(mock.run(any<Object?>(), any<Object?>())).called(1);
+    verify(() => mock.run(any<Object?>(), any<Object?>())).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- remove redundant const from theme
- add path_provider_platform_interface to dev deps
- fix ia_model_loader tests for null-safety compliance

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68531abca12883208639564988a13d26