### PR TITLE
fix notification tile color

### DIFF
--- a/lib/modules/noyau/screens/notifications_screen.dart
+++ b/lib/modules/noyau/screens/notifications_screen.dart
@@ -4,6 +4,7 @@
 // Prévu pour une extension IA intelligente (filtrage, urgences…).
 
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class NotificationsScreen extends StatelessWidget {
   const NotificationsScreen({super.key});
@@ -45,7 +46,7 @@ class NotificationsScreen extends StatelessWidget {
               moduleName,
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
-                    color: Colors.deepPurple,
+                    color: primaryBlue,
                   ),
             ),
             children: moduleNotifications.map((notif) {


### PR DESCRIPTION
## Summary
- use the app's primary blue color for notification tiles

## Testing
- `flutter test test/noyau/widget/notifications_screen_test.dart` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531bb32cac832083b5a2e8500dbb4f