### PR TITLE
Update theme button splash behavior

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -17,9 +17,25 @@ final ThemeData appTheme = ThemeData(
     elevation: 0,
     iconTheme: IconThemeData(color: Colors.black),
   ),
-  splashColor: accentYellow,
-  highlightColor: accentYellow,
   splashFactory: NoSplash.splashFactory,
+  textButtonTheme: TextButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
+  ),
+  outlinedButtonTheme: OutlinedButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
+  ),
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
+  ),
   bottomNavigationBarTheme: BottomNavigationBarThemeData(
     backgroundColor: backgroundGray,
     selectedItemColor: primaryBlue,
@@ -40,8 +56,6 @@ final ThemeData appTheme = ThemeData(
 
 final ThemeData darkTheme = ThemeData.dark().copyWith(
   primaryColor: primaryBlue,
-  splashColor: accentYellow,
-  highlightColor: accentYellow,
   appBarTheme: const AppBarTheme(
     backgroundColor: backgroundGray,
     foregroundColor: Colors.black,
@@ -54,6 +68,24 @@ final ThemeData darkTheme = ThemeData.dark().copyWith(
     unselectedItemColor: Colors.grey,
     showUnselectedLabels: true,
     type: BottomNavigationBarType.fixed,
+  ),
+  textButtonTheme: TextButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
+  ),
+  outlinedButtonTheme: OutlinedButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
+  ),
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ButtonStyle(
+      overlayColor: MaterialStateProperty.all(Colors.transparent),
+      splashFactory: NoSplash.splashFactory,
+    ),
   ),
   textTheme: const TextTheme(
     bodyLarge: TextStyle(fontSize: 16, color: Colors.black),

--- a/test/noyau/widget/splash_screen_test.dart
+++ b/test/noyau/widget/splash_screen_test.dart
@@ -9,7 +9,7 @@ void main() {
   setUpAll(() async {
     await initTestEnv();
   });
-  testWidgets('main screen uses yellow ripple', (tester) async {
+  testWidgets('buttons use transparent overlay without splash', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: appTheme,
@@ -20,7 +20,18 @@ void main() {
     final materialApp = tester.widget<MaterialApp>(find.byType(MaterialApp));
     final theme = materialApp.theme!;
 
-    expect(theme.highlightColor, const Color(0xFFFBC02D));
-    expect(theme.splashColor, const Color(0xFFFBC02D));
+    final overlayColor = theme.textButtonTheme.style?.overlayColor?.resolve({});
+    expect(overlayColor, Colors.transparent);
+
+    expect(theme.splashColor, isNot(const Color(0xFFFBC02D)));
+    expect(theme.highlightColor, isNot(const Color(0xFFFBC02D)));
+
+    final elevatedOverlay =
+        theme.elevatedButtonTheme.style?.overlayColor?.resolve({});
+    expect(elevatedOverlay, Colors.transparent);
+
+    final outlinedOverlay =
+        theme.outlinedButtonTheme.style?.overlayColor?.resolve({});
+    expect(outlinedOverlay, Colors.transparent);
   });
 }


### PR DESCRIPTION
## Summary
- remove highlight and splash color settings
- add button theme overlay color with no splash
- update splash screen theme test

## Testing
- `flutter test test/noyau/widget/splash_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531bb686d08320baca900052218f24