### PR TITLE
Fix identity_screen trailing comment

### DIFF
--- a/lib/modules/identite/screens/identity_screen.dart
+++ b/lib/modules/identite/screens/identity_screen.dart
@@ -84,14 +84,10 @@ class _IdentityScreenState extends State<IdentityScreen> {
               decoration: const InputDecoration(labelText: 'Statut'),
             ),
             const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _save,
-              child: const Text('Sauvegarder'),
-            ),
+            ElevatedButton(onPressed: _save, child: const Text('Sauvegarder')),
           ],
         ),
       ),
     );
   }
 }
-//       title: const Text("AniSphère - Identité de l’animal"),


### PR DESCRIPTION
## Summary
- remove stray comment at the end of `identity_screen.dart`
- run `flutter test` for `identity_screen_test.dart`

## Testing
- `flutter pub get`
- `flutter test test/identite/widget/identity_screen_test.dart` *(fails: PlatformException(channel-error, Unable to establish connection on channel))*

------
https://chatgpt.com/codex/tasks/task_e_68531bb9f77c8320a01f6dccce656421