### PR TITLE
Fix test generics for tflite mock

### DIFF
--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -35,16 +35,22 @@ void main() {
 
   test('predict uses interpreter', () async {
     final mock = MockInterpreter();
-    when(() => mock.run(any<Object?>(), any<Object?>())).thenAnswer((invocation) {
-      final output = invocation.positionalArguments[1] as List;
-      (output.first as List)[0] = 3.14;
-    });
-    final loader = IaInterpreterLoader(modelPath: 'models/dummy.tflite', creator: (_) async => mock);
+    when(() => mock.run(any<List<Object?>>(), any<List<Object?>>())).thenAnswer(
+      (invocation) {
+        final output = invocation.positionalArguments[1] as List;
+        (output.first as List)[0] = 3.14;
+        return null;
+      },
+    );
+    final loader = IaInterpreterLoader(
+      modelPath: 'models/dummy.tflite',
+      creator: (_) async => mock,
+    );
     await loader.load();
 
     final result = await loader.predict([1.0]);
 
     expect(result, [3.14]);
-    verify(() => mock.run(any<Object?>(), any<Object?>())).called(1);
+    verify(() => mock.run(any<List<Object?>>(), any<List<Object?>>())).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- fix generic types in ia_model_loader_test so analyzer doesn't report null dereference

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854041f9124832090266a512df0639c