### PR TITLE
Update ProValidationService to use cloud functions

### DIFF
--- a/lib/modules/noyau/services/pro_validation_service.dart
+++ b/lib/modules/noyau/services/pro_validation_service.dart
@@ -1,17 +1,16 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_functions_interop/firebase_functions_interop.dart' as fns;
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
 import '../models/user_profile_model.dart';
-import '../models/user_model.dart';
 import 'user_service.dart';
 import 'firebase_service.dart';
 
 class ProValidationService {
   final UserService _userService;
   final FirebaseService _firebaseService;
-  final fns.HttpsCallable? _storeSensitiveUserData;
+  final FirebaseFunctions _functions = FirebaseFunctions.instance;
+  final HttpsCallable? _storeSensitiveUserData;
 
   static const String _profileBox = 'user_profile_data';
   Box<UserProfileModel>? _box;
@@ -19,11 +18,13 @@ class ProValidationService {
   ProValidationService({
     UserService? userService,
     FirebaseService? firebaseService,
-    fns.HttpsCallable? storeSensitiveUserData,
+    HttpsCallable? storeSensitiveUserData,
     Box<UserProfileModel>? testBox,
   })  : _userService = userService ?? UserService(),
         _firebaseService = firebaseService ?? FirebaseService(),
-        _storeSensitiveUserData = storeSensitiveUserData {
+        _storeSensitiveUserData =
+            storeSensitiveUserData ??
+            _functions.httpsCallable('storeSensitiveUserData') {
     if (testBox != null) {
       _box = testBox;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_core: ^3.14.0
   firebase_auth: ^5.6.0
   cloud_firestore: ^5.6.9
+  cloud_functions: ^5.5.2
   firebase_storage: ^12.4.7
   firebase_messaging: ^15.2.7
   firebase_remote_config: ^5.4.5


### PR DESCRIPTION
## Summary
- switch to the `cloud_functions` package for ProValidationService
- instantiate FirebaseFunctions in the service
- initialize `_storeSensitiveUserData` with a callable when absent
- add `cloud_functions` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541233a4b083208296eaa066d5e4df