### PR TITLE
Add ignore for unused field in pro_validation_service

### DIFF
--- a/lib/modules/noyau/services/pro_validation_service.dart
+++ b/lib/modules/noyau/services/pro_validation_service.dart
@@ -9,6 +9,7 @@ import 'user_service.dart';
 import 'firebase_service.dart';
 
 class ProValidationService {
+  // ignore: unused_field
   final UserService _userService;
   final FirebaseService _firebaseService;
   final fns.HttpsCallable? _storeSensitiveUserData;


### PR DESCRIPTION
## Summary
- avoid linter warnings in `ProValidationService` by ignoring unused `_userService`

## Testing
- `flutter test test/noyau/unit/pro_validation_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854123640848320af8b946f703034a4