### PR TITLE
Add video privacy notes

### DIFF
--- a/docs/7__ia.md
+++ b/docs/7__ia.md
@@ -136,6 +136,10 @@ Maîtrise totale des coûts IA cloud : apprentissage déclenché uniquement manu
 
 Le service `AnonymizationService` prépare les modèles avant leur synchronisation. Il retire ou hache les identifiants personnels (IDs, email, téléphone) pour qu'aucune information sensible ne soit stockée dans le cloud ou dans les files offline.
 
+### Gestion des vidéos
+
+Les vidéos envoyées pour analyse sont traitées **uniquement** en local. Elles sont supprimées juste après le calcul des prédictions. Seuls les résultats IA anonymisés sont ensuite stockés dans `logs_ia/` pour affiner les modèles. Aucune vidéo n'est conservée dans Firebase.
+
  
  
 

--- a/lib/modules/noyau/services/video_analysis_service.dart
+++ b/lib/modules/noyau/services/video_analysis_service.dart
@@ -1,0 +1,11 @@
+// Copilot Prompt : VideoAnalysisService analyses pet training videos locally.
+// Videos are deleted right after processing and never uploaded to Firebase.
+// Only anonymized AI results are sent to logs_ia/ for improvement.
+
+class VideoAnalysisService {
+  Future<Map<String, dynamic>> analyzeVideo(String path) async {
+    // TODO: implement call to TFLite model.
+    // After processing, delete the video file from local storage.
+    return {'score': 0};
+  }
+}

--- a/lib/modules/noyau/services/video_logs_collector.dart
+++ b/lib/modules/noyau/services/video_logs_collector.dart
@@ -1,0 +1,8 @@
+// Copilot Prompt : VideoLogsCollector sends anonymized results of video analysis to logs_ia/.
+// Videos themselves are never persisted in Firebase or any cloud storage.
+
+class VideoLogsCollector {
+  Future<void> uploadResult(Map<String, dynamic> result) async {
+    // TODO: implement Firestore upload to logs_ia/.
+  }
+}


### PR DESCRIPTION
## Summary
- create `VideoAnalysisService` and `VideoLogsCollector`
- document that uploaded videos are deleted after analysis
- stress deletion policy in the IA docs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541419f39c8320a654285df87395c7