### PR TITLE
Add genealogy module docs and stubs

### DIFF
--- a/docs/10__architecture.md
+++ b/docs/10__architecture.md
@@ -68,6 +68,7 @@ Fugue (photo d’identification, alerte automatique, page publique)
 
 * **noyau/** : coeur de l'application (auth, IA, services globaux, synchronisation, UI commune)
 * **identite/** : module identité animal (OCR, badge, éleveur, QR, documents)
+* **genealogie/** : module arbre généalogique et pedigree
 * à venir : **sante**, **education**, **dressage**, **communaute**, etc.
 
 ### lib/modules/noyau
@@ -99,7 +100,7 @@ L'appel principal se fait dans **main.dart > MainScreen**, avec le Provider **IA
 
 La gestion des fichiers de modèles est détaillée dans la section **Gestion des modèles IA locaux** de [7__ia.md](7__ia.md).
 
-## 📦 Modules externes (identite/, à venir : sante/, education/...)
+## 📦 Modules externes (identite/, genealogie/, à venir : sante/, education/...)
 
 Chaque module suit la même architecture que noyau/ :
 

--- a/docs/5__ux.md
+++ b/docs/5__ux.md
@@ -97,6 +97,9 @@ Retour haptique léger + animation fluide pour toute action significative.
 
 Accès rapide à tout moment à la fiche de l’animal sélectionné.
 
+Depuis cette fiche, un bouton **Généalogie** ouvre l’arbre familial complet.
+Un lien **Profil public** permet de partager la lignée en lecture seule.
+
 Glisser-déposer intelligent dans les listes (objectifs, rappels, tâches).
 
 Barre de recherche universelle (animaux, modules, historique, contenus).

--- a/docs/6__technos_par_module.md
+++ b/docs/6__technos_par_module.md
@@ -92,6 +92,16 @@ flutter_map_marker_cluster : Regroupement d’utilisateurs sur carte
 
 firebase_messaging + local_notifications : Notification combinée locale et cloud
 
+🌳 Module Généalogie
+
+graphview : Affichage interactif de l’arbre familial
+
+csv / gedcom : Import et export de pedigrees
+
+Hive : Stockage local des ascendances
+
+share_plus : Partage des profils publics
+
 🌐 Site compagnon (module intégré)
 
 Flutter Web : Interface web miroir

--- a/docs/suivi_identite.md
+++ b/docs/suivi_identite.md
@@ -21,6 +21,14 @@ Ce document suit le développement du module Identité animale pour AniSphère. 
 - [ ] Tests unitaires (modèle, service, IA photo)
 - [ ] Tests widget (fiche identité, édition, QR)
 - [ ] Tests d’intégration (ajout + lecture + partage QR)
+- - -
+- **Généalogie**
+- [ ] Dossier `lib/modules/genealogie/` créé
+- [ ] Modèle `genealogy_model.dart` défini
+- [ ] Service `genealogy_service.dart` initialisé
+- [ ] Écran `genealogy_screen.dart` créé
+- [ ] Export de l’arbre généalogique (PDF/PNG)
+- [ ] Partage public du pedigree (QR / lien)
 
 ### Technologies utilisées
 - Flutter, Hive, Firebase, qr_flutter
@@ -129,5 +137,23 @@ Assurer à chaque animal une fiche unique, fiable, partageable et intelligente, 
 - Utilise le vrai `AnimalModel` pour afficher les données
 - Redirige vers `IdentityScreen` via `IdentityService` Hive
 - UX fluide, couleurs branding appliquées, navigation fonctionnelle
+- Date : 2025-05-20
+
+### ⏳ genealogy_model.dart
+- 📁 `lib/modules/genealogie/models/genealogy_model.dart`
+- Modèle minimal d'arbre généalogique (`GenealogyNode`)
+- Stockage Hive préparé pour les liens parent/enfant
+- Date : 2025-05-20
+
+### ⏳ genealogy_service.dart
+- 📁 `lib/modules/genealogie/services/genealogy_service.dart`
+- Sauvegarde locale des noeuds et récupération rapide
+- Synchronisation différée prévue
+- Date : 2025-05-20
+
+### ⏳ genealogy_screen.dart
+- 📁 `lib/modules/genealogie/screens/genealogy_screen.dart`
+- Écran simple listant l'arbre (placeholder)
+- Accès depuis la fiche identité via un bouton
 - Date : 2025-05-20
 

--- a/lib/modules/genealogie/logic/genealogy_helper.dart
+++ b/lib/modules/genealogie/logic/genealogy_helper.dart
@@ -1,0 +1,3 @@
+class GenealogyHelper {
+  String formatNode(String name) => 'Node: \$name';
+}

--- a/lib/modules/genealogie/models/genealogy_model.dart
+++ b/lib/modules/genealogie/models/genealogy_model.dart
@@ -1,0 +1,23 @@
+class GenealogyNode {
+  final String animalId;
+  final String? parentId;
+  final String? photoUrl;
+
+  GenealogyNode({required this.animalId, this.parentId, this.photoUrl});
+
+  factory GenealogyNode.fromMap(Map<String, dynamic> map) {
+    return GenealogyNode(
+      animalId: map['animalId'] as String,
+      parentId: map['parentId'] as String?,
+      photoUrl: map['photoUrl'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'animalId': animalId,
+      'parentId': parentId,
+      'photoUrl': photoUrl,
+    };
+  }
+}

--- a/lib/modules/genealogie/screens/genealogy_screen.dart
+++ b/lib/modules/genealogie/screens/genealogy_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class GenealogyScreen extends StatelessWidget {
+  const GenealogyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Généalogie')),
+      body: const Center(
+        child: Text('Arbre généalogique en préparation'),
+      ),
+    );
+  }
+}

--- a/lib/modules/genealogie/services/genealogy_service.dart
+++ b/lib/modules/genealogie/services/genealogy_service.dart
@@ -1,0 +1,15 @@
+import 'package:hive/hive.dart';
+
+import '../models/genealogy_model.dart';
+
+class GenealogyService {
+  final Box<GenealogyNode> nodeBox;
+
+  GenealogyService(this.nodeBox);
+
+  Future<void> saveNode(GenealogyNode node) async {
+    await nodeBox.put(node.animalId, node);
+  }
+
+  GenealogyNode? getNode(String animalId) => nodeBox.get(animalId);
+}


### PR DESCRIPTION
## Summary
- document genealogy tasks in `suivi_identite.md`
- explain genealogy module in architecture and technologies docs
- give UX instructions about genealogy screen and profile
- stub genealogy module files

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685441b0a6fc83209e7bf322811787d5