### PR TITLE
Update genealogy model fields

### DIFF
--- a/lib/modules/identite/models/genealogy_model.dart
+++ b/lib/modules/identite/models/genealogy_model.dart
@@ -9,10 +9,10 @@ class GenealogyModel {
   final String animalId;
 
   @HiveField(1)
-  final String? fatherId;
+  final String? fatherName;
 
   @HiveField(2)
-  final String? motherId;
+  final String? motherName;
 
   @HiveField(3)
   final String? affixe;
@@ -26,24 +26,29 @@ class GenealogyModel {
   @HiveField(6)
   final DateTime lastUpdate;
 
+  @HiveField(7)
+  final String? originCountry;
+
   const GenealogyModel({
     required this.animalId,
-    this.fatherId,
-    this.motherId,
+    this.fatherName,
+    this.motherName,
     this.affixe,
     this.litterNumber,
     this.lofName,
+    this.originCountry,
     DateTime? lastUpdate,
   }) : lastUpdate = lastUpdate ?? DateTime.now();
 
   factory GenealogyModel.fromMap(Map<String, dynamic> map) {
     return GenealogyModel(
       animalId: map['animalId'] ?? '',
-      fatherId: map['fatherId'],
-      motherId: map['motherId'],
+      fatherName: map['fatherName'] ?? map['fatherId'],
+      motherName: map['motherName'] ?? map['motherId'],
       affixe: map['affixe'],
       litterNumber: map['litterNumber'],
       lofName: map['lofName'],
+      originCountry: map['originCountry'],
       lastUpdate: map['lastUpdate'] is DateTime
           ? map['lastUpdate'] as DateTime
           : DateTime.tryParse(map['lastUpdate'] ?? '') ?? DateTime.now(),
@@ -53,11 +58,12 @@ class GenealogyModel {
   Map<String, dynamic> toMap() {
     return {
       'animalId': animalId,
-      'fatherId': fatherId,
-      'motherId': motherId,
+      'fatherName': fatherName,
+      'motherName': motherName,
       'affixe': affixe,
       'litterNumber': litterNumber,
       'lofName': lofName,
+      'originCountry': originCountry,
       'lastUpdate': lastUpdate.toIso8601String(),
     };
   }

--- a/lib/modules/identite/models/genealogy_model.g.dart
+++ b/lib/modules/identite/models/genealogy_model.g.dart
@@ -14,25 +14,26 @@ class GenealogyModelAdapter extends TypeAdapter<GenealogyModel> {
     };
     return GenealogyModel(
       animalId: fields[0] as String,
-      fatherId: fields[1] as String?,
-      motherId: fields[2] as String?,
+      fatherName: fields[1] as String?,
+      motherName: fields[2] as String?,
       affixe: fields[3] as String?,
       litterNumber: fields[4] as String?,
       lofName: fields[5] as String?,
       lastUpdate: fields[6] as DateTime?,
+      originCountry: fields[7] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, GenealogyModel obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.animalId)
       ..writeByte(1)
-      ..write(obj.fatherId)
+      ..write(obj.fatherName)
       ..writeByte(2)
-      ..write(obj.motherId)
+      ..write(obj.motherName)
       ..writeByte(3)
       ..write(obj.affixe)
       ..writeByte(4)
@@ -40,7 +41,9 @@ class GenealogyModelAdapter extends TypeAdapter<GenealogyModel> {
       ..writeByte(5)
       ..write(obj.lofName)
       ..writeByte(6)
-      ..write(obj.lastUpdate);
+      ..write(obj.lastUpdate)
+      ..writeByte(7)
+      ..write(obj.originCountry);
   }
 
   @override

--- a/lib/modules/identite/screens/genealogy_summary_card.dart
+++ b/lib/modules/identite/screens/genealogy_summary_card.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 
 class GenealogySummaryCard extends StatelessWidget {
   final String animalId;
-  final String? fatherId;
-  final String? motherId;
+  final String? fatherName;
+  final String? motherName;
   const GenealogySummaryCard({
     super.key,
     required this.animalId,
-    this.fatherId,
-    this.motherId,
+    this.fatherName,
+    this.motherName,
   });
 
   @override
@@ -16,7 +16,8 @@ class GenealogySummaryCard extends StatelessWidget {
     return Card(
       child: ListTile(
         title: Text('Genealogy of $animalId'),
-        subtitle: Text('Father: ${fatherId ?? '-'}, Mother: ${motherId ?? '-'}'),
+        subtitle:
+            Text('Father: ${fatherName ?? '-'}, Mother: ${motherName ?? '-'}'),
       ),
     );
   }

--- a/lib/modules/identite/services/genealogy_ocr_service.dart
+++ b/lib/modules/identite/services/genealogy_ocr_service.dart
@@ -15,13 +15,13 @@ class GenealogyOCRService {
   /// Visible for testing
   Map<String, String> parseText(String text) {
     final Map<String, String> data = {};
-    final father = RegExp(r'Father ID[:\s]*([\w-]+)', caseSensitive: false)
-        .firstMatch(text);
-    final mother = RegExp(r'Mother ID[:\s]*([\w-]+)', caseSensitive: false)
-        .firstMatch(text);
+    final father =
+        RegExp(r'Father[:\s]*([\w\s-]+)', caseSensitive: false).firstMatch(text);
+    final mother =
+        RegExp(r'Mother[:\s]*([\w\s-]+)', caseSensitive: false).firstMatch(text);
 
-    if (father != null) data['fatherId'] = father.group(1)!;
-    if (mother != null) data['motherId'] = mother.group(1)!;
+    if (father != null) data['fatherName'] = father.group(1)!.trim();
+    if (mother != null) data['motherName'] = mother.group(1)!.trim();
     return data;
   }
 

--- a/lib/modules/identite/services/genealogy_pdf_ocr_service.dart
+++ b/lib/modules/identite/services/genealogy_pdf_ocr_service.dart
@@ -10,10 +10,10 @@ class GenealogyPdfOcrService {
       final text = await TesseractOcr.extractText(pdfFile.path);
       final data = <String, String>{};
 
-      final fatherMatch = RegExp(r'P\u00e8?re[:\s]*([\w-]+)', caseSensitive: false)
-          .firstMatch(text);
-      final motherMatch = RegExp(r'M\u00e8?re[:\s]*([\w-]+)', caseSensitive: false)
-          .firstMatch(text);
+      final fatherMatch =
+          RegExp(r'P\u00e8?re[:\s]*([\w\s-]+)', caseSensitive: false).firstMatch(text);
+      final motherMatch =
+          RegExp(r'M\u00e8?re[:\s]*([\w\s-]+)', caseSensitive: false).firstMatch(text);
       final affixeMatch =
           RegExp(r'Affixe[:\s]*([\w-]+)', caseSensitive: false).firstMatch(text);
       final litterMatch = RegExp(r'Port\w*[:\s]*(\w+)', caseSensitive: false)
@@ -21,8 +21,8 @@ class GenealogyPdfOcrService {
       final lofMatch =
           RegExp(r'LOF[:\s]*([\w-]+)', caseSensitive: false).firstMatch(text);
 
-      if (fatherMatch != null) data['fatherId'] = fatherMatch.group(1)!;
-      if (motherMatch != null) data['motherId'] = motherMatch.group(1)!;
+      if (fatherMatch != null) data['fatherName'] = fatherMatch.group(1)!.trim();
+      if (motherMatch != null) data['motherName'] = motherMatch.group(1)!.trim();
       if (affixeMatch != null) data['affixe'] = affixeMatch.group(1)!;
       if (litterMatch != null) data['litterNumber'] = litterMatch.group(1)!;
       if (lofMatch != null) data['lofName'] = lofMatch.group(1)!;

--- a/lib/modules/identite/widgets/genealogy_summary_card.dart
+++ b/lib/modules/identite/widgets/genealogy_summary_card.dart
@@ -21,8 +21,8 @@ class GenealogySummaryCard extends StatelessWidget {
             Text(l10n.genealogy_title,
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
-            _row(l10n.father, genealogy.fatherId ?? '-'),
-            _row(l10n.mother, genealogy.motherId ?? '-'),
+            _row(l10n.father, genealogy.fatherName ?? '-'),
+            _row(l10n.mother, genealogy.motherName ?? '-'),
             if (genealogy.affixe != null)
               _row(l10n.breeder_affixe, genealogy.affixe!),
             if (genealogy.litterNumber != null)

--- a/test/identite/unit/genealogy_mapper_test.dart
+++ b/test/identite/unit/genealogy_mapper_test.dart
@@ -11,15 +11,15 @@ void main() {
     final mapper = GenealogyMapper();
     final map = {
       'animalId': 'ani2',
-      'fatherId': 'dad2',
-      'motherId': 'mom2',
+      'fatherName': 'dad2',
+      'motherName': 'mom2',
       'affixe': 'Aff2',
       'litterNumber': 'L2',
       'lofName': 'LOF2',
       'lastUpdate': DateTime(2024, 1, 2).toIso8601String(),
     };
     final model = mapper.fromMap(map);
-    expect(model.fatherId, 'dad2');
+    expect(model.fatherName, 'dad2');
     expect(model.affixe, 'Aff2');
     final back = mapper.toMap(model);
     expect(back, map);

--- a/test/identite/unit/genealogy_model_test.dart
+++ b/test/identite/unit/genealogy_model_test.dart
@@ -10,8 +10,8 @@ void main() {
   test('GenealogyModel toMap/fromMap round trip', () {
     final model = GenealogyModel(
       animalId: 'ani1',
-      fatherId: 'dad1',
-      motherId: 'mom1',
+      fatherName: 'dad1',
+      motherName: 'mom1',
       affixe: 'Affix',
       litterNumber: 'L1',
       lofName: 'LOF123',
@@ -20,8 +20,8 @@ void main() {
     final map = model.toMap();
     final from = GenealogyModel.fromMap(map);
     expect(from.animalId, equals('ani1'));
-    expect(from.fatherId, equals('dad1'));
-    expect(from.motherId, equals('mom1'));
+    expect(from.fatherName, equals('dad1'));
+    expect(from.motherName, equals('mom1'));
     expect(from.affixe, equals('Affix'));
     expect(from.litterNumber, equals('L1'));
     expect(from.lofName, equals('LOF123'));

--- a/test/identite/unit/genealogy_ocr_service_test.dart
+++ b/test/identite/unit/genealogy_ocr_service_test.dart
@@ -7,12 +7,12 @@ void main() {
     await initTestEnv();
   });
 
-  test('parseText extracts father and mother ids', () {
+  test('parseText extracts father and mother names', () {
     final service = GenealogyOCRService();
-    const sample = 'Father ID: F123\nSome text\nMother ID: M456';
+    const sample = 'Father: F123\nSome text\nMother: M456';
     final result = service.parseText(sample);
-    expect(result['fatherId'], 'F123');
-    expect(result['motherId'], 'M456');
+    expect(result['fatherName'], 'F123');
+    expect(result['motherName'], 'M456');
     service.dispose();
   });
 }

--- a/test/identite/widget/genealogy_summary_card_test.dart
+++ b/test/identite/widget/genealogy_summary_card_test.dart
@@ -3,9 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/identite/screens/genealogy_summary_card.dart';
 
 void main() {
-  testWidgets('GenealogySummaryCard displays parent ids', (WidgetTester tester) async {
+  testWidgets('GenealogySummaryCard displays parent names', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
-      home: GenealogySummaryCard(animalId: 'a1', fatherId: 'f1', motherId: 'm1'),
+      home: GenealogySummaryCard(animalId: 'a1', fatherName: 'f1', motherName: 'm1'),
     ));
 
     expect(find.text('Genealogy of a1'), findsOneWidget);


### PR DESCRIPTION
## Summary
- rename genealogy parent ID fields to `fatherName` and `motherName`
- add `originCountry` info
- update OCR services and widgets to use new fields
- adjust unit and widget tests

## Testing
- `flutter pub get` *(fails: No such file or directory)*
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: No such file or directory)*
- `dart test` *(fails: version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854545040348320bbfdda5fc4cd604c