### PR TITLE
Localize genealogy screen

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "يرجى تحديث الهاتف أو العنوان أو المهنة."
   ,"profile_update_button": "تحديث"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Bitte aktualisieren Sie Telefon, Adresse oder Beruf."
   ,"profile_update_button": "Aktualisieren"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Please update your phone, address or profession."
   ,"profile_update_button": "Update"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Actualice su teléfono, dirección o profesión."
   ,"profile_update_button": "Actualizar"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Mettez à jour votre téléphone, adresse ou profession."
   ,"profile_update_button": "Mettre à jour"
   ,"genealogy_title": "Généalogie"
+  ,"genealogy_screen_text": "Écran de généalogie"
   ,"father": "Père"
   ,"mother": "Mère"
   ,"breeder_affixe": "Affixe"

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Aggiorna telefono, indirizzo o professione."
   ,"profile_update_button": "Aggiorna"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "電話、住所、職業を更新してください。"
   ,"profile_update_button": "更新"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -180,6 +180,12 @@ abstract class AppLocalizations {
   /// **'Genealogy'**
   String get genealogy_title;
 
+  /// No description provided for @genealogy_screen_text.
+  ///
+  /// In en, this message translates to:
+  /// **'Genealogy Screen'**
+  String get genealogy_screen_text;
+
   /// No description provided for @father.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -41,6 +41,8 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -41,6 +41,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -43,6 +43,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get genealogy_title => 'Genealogy';
 
   @override
+  String get genealogy_screen_text => 'Genealogy Screen';
+
+  @override
   String get father => 'Father';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -41,6 +41,8 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -41,6 +41,8 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Généalogie';
+@override
+  String get genealogy_screen_text => 'Écran de généalogie';
 
   @override
   String get father => 'Père';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -41,6 +41,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -40,6 +40,8 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -41,6 +41,8 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -41,6 +41,8 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -40,6 +40,8 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get genealogy_title => 'Genealogy';
+@override
+  String get genealogy_screen_text => 'Genealogy Screen';
 
   @override
   String get father => 'Father';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Atualize telefone, endereço ou profissão."
   ,"profile_update_button": "Atualizar"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "Обновите телефон, адрес или профессию."
   ,"profile_update_button": "Обновить"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -10,6 +10,7 @@
   ,"profile_incomplete_message": "请更新电话、地址或职业。"
   ,"profile_update_button": "更新"
   ,"genealogy_title": "Genealogy"
+  ,"genealogy_screen_text": "Genealogy Screen"
   ,"father": "Father"
   ,"mother": "Mother"
   ,"breeder_affixe": "Affix"

--- a/lib/modules/identite/screens/genealogy_screen.dart
+++ b/lib/modules/identite/screens/genealogy_screen.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 
 class GenealogyScreen extends StatelessWidget {
   const GenealogyScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: const Text('Genealogy')),
-      body: const Center(child: Text('Genealogy Screen')),
+      appBar: AppBar(title: Text(t.genealogy_title)),
+      body: Center(child: Text(t.genealogy_screen_text)),
     );
   }
 }

--- a/test/identite/widget/genealogy_screen_test.dart
+++ b/test/identite/widget/genealogy_screen_test.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
+import '../../test_config.dart';
 import 'package:anisphere/modules/identite/screens/genealogy_screen.dart';
 
 void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
   testWidgets('GenealogyScreen shows title', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: GenealogyScreen()));
-    expect(find.text('Genealogy'), findsOneWidget);
-    expect(find.text('Genealogy Screen'), findsOneWidget);
+    await tester.pumpWidget(MaterialApp(
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      locale: const Locale('fr'),
+      home: const GenealogyScreen(),
+    ));
+    await tester.pump();
+    expect(find.text('Généalogie'), findsOneWidget);
+    expect(find.text('Écran de généalogie'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `genealogy_screen_text` localization key for all languages
- use `AppLocalizations` in `GenealogyScreen`
- update generated localization files with new getter
- adjust widget test for French localization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545451f7cc832082d061e58e16758a