### PR TITLE
Add tesseract_ocr dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   mobile_scanner: ^7.0.1
   pdf: ^3.10.4
   printing: ^5.12.0
+  tesseract_ocr: ^0.5.0
 
   # IA locale / capteurs
   sensors_plus: ^6.1.1


### PR DESCRIPTION
## Summary
- include `tesseract_ocr` package
- keep existing `tesseract_ocr` import in GenealogyPdfOcrService

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545dd643b88320ac849fd565efbfa2