### PR TITLE
Fix identite tests for name fields

### DIFF
--- a/test/identite/unit/genealogy_pdf_ocr_service_test.dart
+++ b/test/identite/unit/genealogy_pdf_ocr_service_test.dart
@@ -31,8 +31,8 @@ void main() {
   test('extractGenealogyData parses pdf OCR output', () async {
     final service = GenealogyPdfOcrService();
     final result = await service.extractGenealogyData(tempFile);
-    expect(result['fatherId'], 'F123');
-    expect(result['motherId'], 'M456');
+    expect(result['fatherName'], 'F123');
+    expect(result['motherName'], 'M456');
     expect(result['affixe'], 'AFF');
     expect(result['litterNumber'], 'L99');
     expect(log.any((c) => c.method == 'extractText'), isTrue);

--- a/test/identite/widget/genealogy_summary_card_test.dart
+++ b/test/identite/widget/genealogy_summary_card_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   testWidgets('GenealogySummaryCard displays parent ids', (WidgetTester tester) async {
-    final model = GenealogyModel(animalId: 'a1', fatherId: 'f1', motherId: 'm1');
+    final model = GenealogyModel(animalId: 'a1', fatherName: 'f1', motherName: 'm1');
     await tester.pumpWidget(MaterialApp(
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Summary
- update `GenealogySummaryCard` test to use fatherName/motherName
- check fatherName/motherName in `GenealogyPdfOcrService` test

## Testing
- `flutter test test/identite` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545dd786d48320a9f0b88cb436b26e