### PR TITLE
Fix mock run closure

### DIFF
--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -39,7 +39,7 @@ void main() {
       (invocation) {
         final output = invocation.positionalArguments[1] as List;
         (output.first as List)[0] = 3.14;
-        return null;
+        return;
       },
     );
     final loader = IaInterpreterLoader(


### PR DESCRIPTION
## Summary
- return nothing in ia_model_loader_test mock closure

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test test/noyau/unit/ia_local/ia_model_loader_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68545dd9660483208c56e9c241e3e0bb