### PR TITLE
Ensure MaterialApp always returned in MyApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -161,9 +161,7 @@ class _MyAppState extends State<MyApp> {
         context.watch<I18nProvider?>()?.locale ?? const Locale('en');
     final mode =
         context.watch<ThemeProvider?>()?.themeMode ?? ThemeMode.light; // TODO: ajouter test
-    if (user == null) {
-      return const SplashScreen();
-    }
+    final home = user == null ? const SplashScreen() : const MainScreen();
     return MaterialApp(
       navigatorKey: NavigationService.navigatorKey,
       title: AppLocalizations.of(context)?.appTitle ?? 'AniSphère',
@@ -174,7 +172,7 @@ class _MyAppState extends State<MyApp> {
       theme: appTheme,
       darkTheme: darkTheme,
       themeMode: mode,
-      home: const MainScreen(),
-    );
+      home: home,
+      );
   }
 }


### PR DESCRIPTION
## Summary
- always return `MaterialApp` from `MyApp.build`
- set `home` to `SplashScreen` when there is no user

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854633689c48320844308090bbda400