### PR TITLE
Guard Firebase init in tests

### DIFF
--- a/test/test_config.dart
+++ b/test/test_config.dart
@@ -3,5 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 
 Future<void> initTestEnv() async {
   TestWidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp();
+  }
 }


### PR DESCRIPTION
## Summary
- guard Firebase.init in `initTestEnv`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546338191c832085d087323c4bd589