### PR TITLE
Add Identité module to core service

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "هوية",
+  ,"module_identity_description": "إدارة هوية الحيوان والرقاقة والنسب"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Identität",
+  ,"module_identity_description": "Verwalten von Identität, Mikrochip und Genealogie des Tieres"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Identity",
+  ,"module_identity_description": "Manage animal identity, microchip and genealogy"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Identidad",
+  ,"module_identity_description": "Gestionar identidad del animal, microchip y genealogía"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identité"
   ,"microchip_label": "Numéro de puce"
   ,"status_label": "Statut"
-  ,"save_button": "Enregistrer"
+  ,"save_button": "Enregistrer",
+  ,"module_identity_name": "Identité",
+  ,"module_identity_description": "Gérer l'identité, la puce et la généalogie de l'animal"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Identità",
+  ,"module_identity_description": "Gestire identità animale, microchip e genealogia"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "アイデンティティ",
+  ,"module_identity_description": "動物の身元、マイクロチップ、血統を管理"
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -92,4 +92,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'هوية';
+
+  @override
+  String get module_identity_description => 'إدارة هوية الحيوان والرقاقة والنسب';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -92,4 +92,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Identität';
+
+  @override
+  String get module_identity_description => 'Verwalten von Identität, Mikrochip und Genealogie des Tieres';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -92,4 +92,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Identity';
+
+  @override
+  String get module_identity_description => 'Manage animal identity, microchip and genealogy';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -92,4 +92,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Identidad';
+
+  @override
+  String get module_identity_description => 'Gestionar identidad del animal, microchip y genealogía';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -92,4 +92,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get save_button => 'Enregistrer';
+
+  @override
+  String get module_identity_name => 'Identité';
+
+  @override
+  String get module_identity_description => "Gérer l'identité, la puce et la généalogie de l'animal";
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -92,4 +92,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Identità';
+
+  @override
+  String get module_identity_description => 'Gestire identità animale, microchip e genealogia';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -91,4 +91,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'アイデンティティ';
+
+  @override
+  String get module_identity_description => '動物の身元、マイクロチップ、血統を管理';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -92,4 +92,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Identidade';
+
+  @override
+  String get module_identity_description => 'Gerenciar identidade, microchip e genealogia do animal';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -92,4 +92,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => 'Идентификация';
+
+  @override
+  String get module_identity_description => 'Управление данными животного, микрочипом и родословной';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -91,4 +91,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get module_identity_name => '身份';
+
+  @override
+  String get module_identity_description => '管理动物身份、芯片和血统';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Identidade",
+  ,"module_identity_description": "Gerenciar identidade, microchip e genealogia do animal"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "Идентификация",
+  ,"module_identity_description": "Управление данными животного, микрочипом и родословной"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -26,5 +26,7 @@
   ,"identity_screen_title": "Identity"
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
-  ,"save_button": "Save"
+  ,"save_button": "Save",
+  ,"module_identity_name": "身份",
+  ,"module_identity_description": "管理动物身份、芯片和血统"
 }

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -6,9 +6,11 @@
 
 import 'package:anisphere/modules/noyau/services/local_storage_service.dart';
 import 'package:anisphere/modules/noyau/models/module_model.dart';
+import 'package:anisphere/modules/noyau/i18n/app_localizations.dart';
+import 'package:anisphere/modules/noyau/services/navigation_service.dart';
 
 class ModulesService {
-  static const List<ModuleModel> availableModules = [
+  static final List<ModuleModel> availableModules = [
     ModuleModel(
       id: 'sante',
       name: 'Santé',
@@ -27,6 +29,13 @@ class ModulesService {
       description: 'Entraînement avancé',
       category: 'Dressage',
       premium: true,
+    ),
+    ModuleModel(
+      id: 'identite',
+      name: AppLocalizations.of(NavigationService.context!)?.module_identity_name ?? 'Identité',
+      description: AppLocalizations.of(NavigationService.context!)?.module_identity_description ?? 'Gestion de l\'identité',
+      category: 'Communauté',
+      icon: '👤',
     ),
     // 🔽 Ajouter ici les modules futurs
   ];


### PR DESCRIPTION
## Summary
- localize new module details
- expose `module_identity_*` messages in l10n files
- register new `identite` module in `ModulesService`

## Testing
- `dart format lib/modules/noyau/services/modules_service.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856594d1b1483208acf7c860b9061d3