### PR TITLE
Adjust module status logic

### DIFF
--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -54,8 +54,11 @@ class ModulesService {
 
   /// 🔄 Récupère le statut d’un module : actif, premium, disponible
   static String getStatus(String moduleId) {
-    return LocalStorageService.get("module_status_$moduleId",
-        defaultValue: "disponible");
+    final defaultValue = moduleId == 'identite' ? 'actif' : 'disponible';
+    return LocalStorageService.get(
+      "module_status_$moduleId",
+      defaultValue: defaultValue,
+    );
   }
 
   /// ✅ Active un module (accessible immédiatement)

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -33,6 +33,10 @@ void main() {
     expect(ModulesService.getStatus('sante'), 'actif');
   });
 
+  test('getStatus identite default is actif', () {
+    expect(ModulesService.getStatus('identite'), 'actif');
+  });
+
   test('markPremium updates status', () async {
     await ModulesService.markPremium('education');
     expect(ModulesService.getStatus('education'), 'premium');


### PR DESCRIPTION
## Summary
- set default status to `actif` for the `identite` module
- add a unit test for the new behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856594f088c8320ab8794fe20ede52c