### PR TITLE
Add isActive helper to modules service

### DIFF
--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -37,8 +37,10 @@ class _ModulesScreenState extends State<ModulesScreen> {
   }
 
   Future<void> _activate(String id) async {
-    await _modulesService.setActive(id);
-    _loadStatuses();
+    if (!ModulesService.isActive(id)) {
+      await _modulesService.setActive(id);
+      _loadStatuses();
+    }
   }
 
   @override

--- a/lib/modules/noyau/services/modules_service.dart
+++ b/lib/modules/noyau/services/modules_service.dart
@@ -58,6 +58,11 @@ class ModulesService {
         defaultValue: "disponible");
   }
 
+  /// 🔎 Retourne `true` si le module est actif
+  static bool isActive(String moduleId) {
+    return getStatus(moduleId) == "actif";
+  }
+
   /// ✅ Active un module (accessible immédiatement)
   static Future<void> activate(String moduleId) async {
     await LocalStorageService.set("module_status_$moduleId", "actif");

--- a/lib/modules/noyau/services/modules_summary_service.dart
+++ b/lib/modules/noyau/services/modules_summary_service.dart
@@ -41,7 +41,7 @@ class ModulesSummaryService {
     for (final module in ModulesService.modules) {
       final status = statuses[module.id] ?? "disponible";
 
-      if (status == "actif") {
+      if (ModulesService.isActive(module.id)) {
         switch (module.name) {
           case "Santé":
             summaries.add(

--- a/test/noyau/unit/modules_service_test.dart
+++ b/test/noyau/unit/modules_service_test.dart
@@ -33,6 +33,11 @@ void main() {
     expect(ModulesService.getStatus('sante'), 'actif');
   });
 
+  test('isActive returns true when module is actif', () async {
+    await ModulesService.activate('education');
+    expect(ModulesService.isActive('education'), isTrue);
+  });
+
   test('markPremium updates status', () async {
     await ModulesService.markPremium('education');
     expect(ModulesService.getStatus('education'), 'premium');


### PR DESCRIPTION
## Summary
- add `isActive` boolean helper in `ModulesService`
- use this helper in `ModulesSummaryService` and `ModulesScreen`
- test new helper

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565950cec08320b61b0f572237941e