### PR TITLE
Add identity module localization

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Numéro de puce"
   ,"status_label": "Statut"
   ,"save_button": "Enregistrer"
+  ,"identityModuleTitle": "Identité"
+  ,"identityModuleDescription": "Gérer l'identité de l'animal"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -281,6 +281,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Save'**
   String get save_button;
+
+  /// No description provided for @identityModuleTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Identity'**
+  String get identityModuleTitle;
+
+  /// No description provided for @identityModuleDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage your animal\'s identity'**
+  String get identityModuleDescription;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -92,4 +92,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -92,4 +92,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -92,4 +92,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -92,4 +92,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -92,4 +92,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get save_button => 'Enregistrer';
+
+  @override
+  String get identityModuleTitle => 'Identité';
+
+  @override
+  String get identityModuleDescription => "Gérer l'identité de l'animal";
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -92,4 +92,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -91,4 +91,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -92,4 +92,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -92,4 +92,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -91,4 +91,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get save_button => 'Save';
+
+  @override
+  String get identityModuleTitle => 'Identity';
+
+  @override
+  String get identityModuleDescription => 'Manage your animal\'s identity';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -27,4 +27,6 @@
   ,"microchip_label": "Microchip number"
   ,"status_label": "Status"
   ,"save_button": "Save"
+  ,"identityModuleTitle": "Identity"
+  ,"identityModuleDescription": "Manage your animal's identity"
 }

--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 
 import '../services/modules_summary_service.dart';
 import '../services/animal_service.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import '../providers/ia_context_provider.dart';
 import '../providers/user_provider.dart';
 import '../services/pro_validation_service.dart';
@@ -75,6 +76,7 @@ class _HomeScreenState extends State<HomeScreen> {
       final summaryService = ModulesSummaryService(
         animalService: AnimalService(),
         context: iaContext,
+        l10n: AppLocalizations.of(context)!,
       );
 
       final result = await summaryService.generateSummaries();

--- a/lib/modules/noyau/services/modules_summary_service.dart
+++ b/lib/modules/noyau/services/modules_summary_service.dart
@@ -7,6 +7,7 @@
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
 import 'package:anisphere/modules/noyau/services/animal_service.dart';
 import 'package:anisphere/modules/noyau/logic/ia_context.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 
 class ModuleSummary {
   final String moduleName;
@@ -25,10 +26,12 @@ class ModuleSummary {
 class ModulesSummaryService {
   final AnimalService animalService;
   final IAContext context;
+  final AppLocalizations l10n;
 
   ModulesSummaryService({
     required this.animalService,
     required this.context,
+    required this.l10n,
   });
 
   /// 📦 Récupère les résumés IA pour les modules actifs.
@@ -78,6 +81,19 @@ class ModulesSummaryService {
                     : "Aucun animal enregistré pour le dressage",
                 icon: "🎯",
                 isPremium: true,
+              ),
+            );
+            break;
+
+          case "Identité":
+            summaries.add(
+              ModuleSummary(
+                moduleName: l10n.identityModuleTitle,
+                summary: context.animalCount == 0
+                    ? l10n.identityModuleDescription
+                    : "${context.animalCount} identités enregistrées",
+                icon: "🆔",
+                isPremium: false,
               ),
             );
             break;

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import '../models/module_model.dart';
 
 class ModuleCard extends StatelessWidget {
@@ -22,6 +23,14 @@ class ModuleCard extends StatelessWidget {
       _ => Colors.grey,
     };
 
+    final l10n = AppLocalizations.of(context)!;
+    final title = module.id == 'identite'
+        ? l10n.identityModuleTitle
+        : module.name;
+    final description = module.id == 'identite'
+        ? l10n.identityModuleDescription
+        : module.description;
+
     return Card(
       margin: const EdgeInsets.only(bottom: 16),
       color: Colors.white,
@@ -36,7 +45,7 @@ class ModuleCard extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    module.name,
+                    title,
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
@@ -55,7 +64,7 @@ class ModuleCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Text(
-              module.description,
+              description,
               style: const TextStyle(color: Colors.black),
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- add identity module title/description keys in all ARB files
- regenerate localization files manually with new getters
- reference localization for identity module in ModuleCard
- add l10n to module summaries on HomeScreen
- update ModulesSummaryService for identity support

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685659555d4c83209cd379744621475e