### PR TITLE
Add onTap and badge to ModuleCard

### DIFF
--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -5,12 +5,16 @@ class ModuleCard extends StatelessWidget {
   final ModuleModel module;
   final String status;
   final VoidCallback? onActivate;
+  final Widget? badge;
+  final VoidCallback? onTap;
 
   const ModuleCard({
     super.key,
     required this.module,
     required this.status,
     this.onActivate,
+    this.badge,
+    this.onTap,
   });
 
   @override
@@ -22,56 +26,70 @@ class ModuleCard extends StatelessWidget {
       _ => Colors.grey,
     };
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 16),
-      color: Colors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    module.name,
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Color(0xFF183153),
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 16),
+        color: Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        elevation: 2,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            module.name,
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: Color(0xFF183153),
+                            ),
+                          ),
+                        ),
+                        if (badge != null) ...[
+                          const SizedBox(width: 8),
+                          badge!,
+                        ],
+                      ],
                     ),
                   ),
-                ),
-                Chip(
-                  label: Text(
-                    status,
-                    style: const TextStyle(color: Colors.white),
+                  Chip(
+                    label: Text(
+                      status,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                    backgroundColor: chipColor,
                   ),
-                  backgroundColor: chipColor,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              module.description,
-              style: const TextStyle(color: Colors.black),
-            ),
-            const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton(
-                onPressed: (status == 'disponible') ? onActivate : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF183153),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: Colors.grey.shade300,
-                ),
-                child: Text(status == 'disponible' ? 'Activer' : 'Découvrir'),
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 8),
+              Text(
+                module.description,
+                style: const TextStyle(color: Colors.black),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton(
+                  onPressed: (status == 'disponible') ? onActivate : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF183153),
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: Colors.grey.shade300,
+                  ),
+                  child: Text(status == 'disponible' ? 'Activer' : 'Découvrir'),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- allow ModuleCard to accept a custom badge and tap callback
- update ModulesScreen to display badges and open IdentityScreen when tapping the Identité module

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856595753188320b95810f0c731d9e1