### PR TITLE
Add modules screen identity test

### DIFF
--- a/test/noyau/widget/modules_screen_test.dart
+++ b/test/noyau/widget/modules_screen_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:anisphere/modules/noyau/screens/modules_screen.dart';
+import 'package:anisphere/modules/noyau/services/modules_service.dart';
+import 'package:anisphere/modules/identite/screens/identity_screen.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 
 void main() {
@@ -18,5 +21,27 @@ void main() {
 
     final listViews = tester.widgetList<ListView>(find.byType(ListView));
     expect(listViews.any((lv) => lv.scrollDirection == Axis.horizontal), isTrue);
+  });
+
+  testWidgets('opens IdentityScreen when identite module tapped', (tester) async {
+    await ModulesService.activate('identite');
+    await tester.pumpWidget(
+      MaterialApp(
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        locale: const Locale('fr'),
+        home: const ModulesScreen(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Identité animale'), findsOneWidget);
+    expect(find.text('Gratuit'), findsOneWidget);
+
+    await tester.tap(find.text('Identité animale'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(IdentityScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- check that ModulesScreen shows identity module
- ensure tapping the card navigates to IdentityScreen

## Testing
- `flutter test test/noyau/widget/modules_screen_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856595842b48320a6955ffc0bb3ef61