### PR TITLE
Update theme colors, adjust tests

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -112,6 +112,7 @@
 | test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
 | test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |
 | test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_interpreter_loader.dart | ✅ |
+| test/noyau/widget/theme_colors_test.dart | widget | package:anisphere/theme.dart | ✅ |
 | test/identite/unit/genealogy_model_test.dart | unit | package:anisphere/modules/identite/models/genealogy_model.dart | ✅ |
 | test/identite/unit/genealogy_ocr_service_test.dart | unit | package:anisphere/modules/identite/services/genealogy_ocr_service.dart | ✅ |
 | test/identite/unit/genealogy_pdf_ocr_service_test.dart | unit | package:anisphere/modules/identite/services/genealogy_pdf_ocr_service.dart | ✅ |

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 // TODO: ajouter test
 
 const Color primaryBlue = Color(0xFF183153);
-const Color backgroundGray = Color(0xFFF5F5F5); // ✅ gris clair Samsung Health
+const Color backgroundGray = Color(0xFFF2F2F2); // ✅ gris clair Samsung Health
 
 const Color accentYellow = Color(0xFFFBC02D);
 
@@ -64,7 +64,7 @@ final ThemeData darkTheme = ThemeData.dark().copyWith(
   ),
   bottomNavigationBarTheme: const BottomNavigationBarThemeData(
     backgroundColor: Color(0xFF1E1E1E),
-    selectedItemColor: accentYellow,
+    selectedItemColor: primaryBlue,
     unselectedItemColor: Colors.grey,
     showUnselectedLabels: true,
     type: BottomNavigationBarType.fixed,

--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -81,7 +81,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final appBar = tester.widget<AppBar>(find.byType(AppBar));
-    expect(appBar.backgroundColor, const Color(0xFFF5F5F5));
+    expect(appBar.backgroundColor, const Color(0xFFF2F2F2));
     expect(appBar.foregroundColor, const Color(0xFF183153));
     expect(appBar.elevation, 0);
 

--- a/test/noyau/widget/theme_colors_test.dart
+++ b/test/noyau/widget/theme_colors_test.dart
@@ -1,0 +1,47 @@
+// Test for theme colors
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:anisphere/theme.dart';
+
+void main() {
+  testWidgets('light theme uses new background and nav colors', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme,
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            items: const [
+              BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+              BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final theme = Theme.of(tester.element(find.byType(BottomNavigationBar)));
+    expect(theme.scaffoldBackgroundColor, const Color(0xFFF2F2F2));
+    expect(theme.bottomNavigationBarTheme.selectedItemColor, primaryBlue);
+  });
+
+  testWidgets('dark theme uses primaryBlue nav color', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: darkTheme,
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            items: const [
+              BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+              BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final theme = Theme.of(tester.element(find.byType(BottomNavigationBar)));
+    expect(theme.bottomNavigationBarTheme.selectedItemColor, primaryBlue);
+  });
+}


### PR DESCRIPTION
## Summary
- tweak theme background color
- unify bottom navigation bar selected item color
- update main screen color expectation
- add widget tests for theme colors
- track new test in docs

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856616e53ec8320a43308121985bae7