### PR TITLE
Add editable user info screen

### DIFF
--- a/lib/modules/noyau/models/user_model.dart
+++ b/lib/modules/noyau/models/user_model.dart
@@ -67,6 +67,12 @@ class UserModel {
   @HiveField(18)
   final String? langue;
 
+  @HiveField(19)
+  final String address;
+
+  @HiveField(20)
+  final DateTime? birthDate;
+
   const UserModel({
     required this.id,
     required this.name,
@@ -87,6 +93,8 @@ class UserModel {
     this.iaTrained = false,
     this.syncedAt,
     this.langue,
+    this.address = '',
+    this.birthDate,
   });
 
   Map<String, dynamic> toJson() => {
@@ -109,6 +117,8 @@ class UserModel {
         'iaTrained': iaTrained,
         'syncedAt': syncedAt?.toIso8601String(),
         'langue': langue,
+        'address': address,
+        'birthDate': birthDate?.toIso8601String(),
       };
 
   factory UserModel.fromJson(Map<String, dynamic> json) {
@@ -136,6 +146,10 @@ class UserModel {
           ? DateTime.tryParse(json['syncedAt'])
           : null,
       langue: json['langue'],
+      address: json['address'] ?? '',
+      birthDate: json['birthDate'] != null
+          ? DateTime.tryParse(json['birthDate'])
+          : null,
     );
   }
 
@@ -159,6 +173,8 @@ class UserModel {
     bool? iaTrained,
     DateTime? syncedAt,
     String? langue,
+    String? address,
+    DateTime? birthDate,
   }) {
     return UserModel(
       id: id ?? this.id,
@@ -180,6 +196,8 @@ class UserModel {
       iaTrained: iaTrained ?? this.iaTrained,
       syncedAt: syncedAt ?? this.syncedAt,
       langue: langue ?? this.langue,
+      address: address ?? this.address,
+      birthDate: birthDate ?? this.birthDate,
     );
   }
 }

--- a/lib/modules/noyau/models/user_model.g.dart
+++ b/lib/modules/noyau/models/user_model.g.dart
@@ -36,13 +36,15 @@ class UserModelAdapter extends TypeAdapter<UserModel> {
       iaTrained: fields[16] as bool,
       syncedAt: fields[17] as DateTime?,
       langue: fields[18] as String?,
+      address: fields[19] as String,
+      birthDate: fields[20] as DateTime?,
     );
   }
 
   @override
   void write(BinaryWriter writer, UserModel obj) {
     writer
-      ..writeByte(19)
+      ..writeByte(21)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -80,7 +82,11 @@ class UserModelAdapter extends TypeAdapter<UserModel> {
       ..writeByte(17)
       ..write(obj.syncedAt)
       ..writeByte(18)
-      ..write(obj.langue);
+      ..write(obj.langue)
+      ..writeByte(19)
+      ..write(obj.address)
+      ..writeByte(20)
+      ..write(obj.birthDate);
   }
 
   @override

--- a/lib/modules/noyau/models/user_profile_model.dart
+++ b/lib/modules/noyau/models/user_profile_model.dart
@@ -15,27 +15,21 @@ class UserProfileModel extends UserModel {
   final String firstName;
 
   @HiveField(21)
-  final String address;
-
-  @HiveField(22)
-  final DateTime? birthDate;
-
-  @HiveField(23)
   final String birthPlace;
 
-  @HiveField(24)
+  @HiveField(22)
   final String unit;
 
-  @HiveField(25)
+  @HiveField(23)
   final String company;
 
-  @HiveField(26)
+  @HiveField(24)
   final String group;
 
-  @HiveField(27)
+  @HiveField(25)
   final String nigend;
 
-  @HiveField(28)
+  @HiveField(26)
   final bool proValidated;
 
   const UserProfileModel({
@@ -60,8 +54,6 @@ class UserProfileModel extends UserModel {
     super.langue,
     this.lastName = '',
     this.firstName = '',
-    this.address = '',
-    this.birthDate,
     this.birthPlace = '',
     this.unit = '',
     this.company = '',
@@ -94,10 +86,6 @@ class UserProfileModel extends UserModel {
       langue: base.langue,
       lastName: json['lastName'] ?? '',
       firstName: json['firstName'] ?? '',
-      address: json['address'] ?? '',
-      birthDate: json['birthDate'] != null
-          ? DateTime.tryParse(json['birthDate'])
-          : null,
       birthPlace: json['birthPlace'] ?? '',
       unit: json['unit'] ?? '',
       company: json['company'] ?? '',
@@ -112,8 +100,6 @@ class UserProfileModel extends UserModel {
         ...super.toJson(),
         'lastName': lastName,
         'firstName': firstName,
-        'address': address,
-        'birthDate': birthDate?.toIso8601String(),
         'birthPlace': birthPlace,
         'unit': unit,
         'company': company,
@@ -127,8 +113,6 @@ class UserProfileModel extends UserModel {
   UserProfileModel copyWith({
     String? lastName,
     String? firstName,
-    String? address,
-    DateTime? birthDate,
     String? birthPlace,
     String? unit,
     String? company,
@@ -178,8 +162,6 @@ class UserProfileModel extends UserModel {
       langue: langue ?? this.langue,
       lastName: lastName ?? this.lastName,
       firstName: firstName ?? this.firstName,
-      address: address ?? this.address,
-      birthDate: birthDate ?? this.birthDate,
       birthPlace: birthPlace ?? this.birthPlace,
       unit: unit ?? this.unit,
       company: company ?? this.company,

--- a/lib/modules/noyau/models/user_profile_model.g.dart
+++ b/lib/modules/noyau/models/user_profile_model.g.dart
@@ -32,10 +32,10 @@ class UserProfileModelAdapter extends TypeAdapter<UserProfileModel> {
       iaTrained: fields[16] as bool,
       syncedAt: fields[17] as DateTime?,
       langue: fields[18] as String?,
-      lastName: fields[19] as String,
-      firstName: fields[20] as String,
-      address: fields[21] as String,
-      birthDate: fields[22] as DateTime?,
+      address: fields[19] as String,
+      birthDate: fields[20] as DateTime?,
+      lastName: fields[21] as String,
+      firstName: fields[22] as String,
       birthPlace: fields[23] as String,
       unit: fields[24] as String,
       company: fields[25] as String,
@@ -88,13 +88,13 @@ class UserProfileModelAdapter extends TypeAdapter<UserProfileModel> {
       ..writeByte(18)
       ..write(obj.langue)
       ..writeByte(19)
-      ..write(obj.lastName)
-      ..writeByte(20)
-      ..write(obj.firstName)
-      ..writeByte(21)
       ..write(obj.address)
-      ..writeByte(22)
+      ..writeByte(20)
       ..write(obj.birthDate)
+      ..writeByte(21)
+      ..write(obj.lastName)
+      ..writeByte(22)
+      ..write(obj.firstName)
       ..writeByte(23)
       ..write(obj.birthPlace)
       ..writeByte(24)

--- a/lib/modules/noyau/screens/user_edit_screen.dart
+++ b/lib/modules/noyau/screens/user_edit_screen.dart
@@ -1,0 +1,125 @@
+// Screen to edit user basic information.
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/user_provider.dart';
+
+class UserEditScreen extends StatefulWidget {
+  const UserEditScreen({super.key});
+
+  @override
+  State<UserEditScreen> createState() => _UserEditScreenState();
+}
+
+class _UserEditScreenState extends State<UserEditScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _addressController = TextEditingController();
+  final _professionController = TextEditingController();
+  DateTime? _birthDate;
+
+  @override
+  void initState() {
+    super.initState();
+    final user = Provider.of<UserProvider>(context, listen: false).user;
+    if (user != null) {
+      _nameController.text = user.name;
+      _phoneController.text = user.phone;
+      _addressController.text = user.address;
+      _professionController.text = user.profession;
+      _birthDate = user.birthDate;
+    }
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    final provider = Provider.of<UserProvider>(context, listen: false);
+    final user = provider.user;
+    if (user == null) return;
+
+    final updated = user.copyWith(
+      name: _nameController.text.trim(),
+      phone: _phoneController.text.trim(),
+      address: _addressController.text.trim(),
+      profession: _professionController.text.trim(),
+      birthDate: _birthDate,
+      updatedAt: DateTime.now(),
+    );
+    await provider.updateUser(updated);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = Provider.of<UserProvider>(context).user;
+    if (user == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Modifier mon compte')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Nom'),
+                validator: (v) => v == null || v.isEmpty ? 'Requis' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _phoneController,
+                decoration: const InputDecoration(labelText: 'Téléphone'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _addressController,
+                decoration: const InputDecoration(labelText: 'Adresse'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _professionController,
+                decoration: const InputDecoration(labelText: 'Profession'),
+              ),
+              const SizedBox(height: 12),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Date de naissance'),
+                subtitle: Text(
+                  _birthDate != null
+                      ? '${_birthDate!.day}/${_birthDate!.month}/${_birthDate!.year}'
+                      : 'Non renseignée',
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.calendar_today),
+                  onPressed: () async {
+                    final now = DateTime.now();
+                    final picked = await showDatePicker(
+                      context: context,
+                      initialDate: _birthDate ?? now,
+                      firstDate: DateTime(now.year - 100),
+                      lastDate: now,
+                    );
+                    if (picked != null) setState(() => _birthDate = picked);
+                  },
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text('Email: ${user.email}'),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _save,
+                child: const Text('Enregistrer'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/modules/noyau/screens/user_profile_screen.dart
+++ b/lib/modules/noyau/screens/user_profile_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'user_edit_screen.dart';
 
 class UserProfileScreen extends StatelessWidget {
   const UserProfileScreen({super.key});
@@ -116,6 +117,21 @@ class UserProfileScreen extends StatelessWidget {
           ),
 
           const SizedBox(height: 32),
+          Center(
+            child: ElevatedButton.icon(
+              icon: const Icon(Icons.edit),
+              label: const Text('Modifier mon compte'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const UserEditScreen(),
+                  ),
+                );
+              },
+            ),
+          ),
+
+          const SizedBox(height: 16),
           Center(
             child: ElevatedButton.icon(
               icon: const Icon(Icons.logout),

--- a/lib/modules/noyau/services/auth_service.dart
+++ b/lib/modules/noyau/services/auth_service.dart
@@ -173,6 +173,8 @@ class AuthService {
     String phone = "",
     String profilePicture = "",
     String profession = "",
+    String address = "",
+    DateTime? birthDate,
   }) {
     return UserModel(
       id: id,
@@ -181,6 +183,8 @@ class AuthService {
       phone: phone,
       profilePicture: profilePicture,
       profession: profession,
+      address: address,
+      birthDate: birthDate,
       ownedSpecies: {},
       ownedAnimals: [],
       preferences: {"theme": "light", "notifications": true},

--- a/lib/modules/noyau/services/user_service.dart
+++ b/lib/modules/noyau/services/user_service.dart
@@ -129,6 +129,8 @@ class UserService {
         activeModules: List<String>.from(
             fields['activeModules'] ?? currentUser.activeModules),
         langue: fields['langue'],
+        address: fields['address'],
+        birthDate: fields['birthDate'],
         updatedAt: DateTime.now(),
       );
       await updateUser(updatedUser);

--- a/test/noyau/unit/user_model_test.dart
+++ b/test/noyau/unit/user_model_test.dart
@@ -15,6 +15,8 @@ void main() {
       phone: '',
       profilePicture: '',
       profession: '',
+      address: 'addr',
+      birthDate: DateTime(2000),
       ownedSpecies: const {},
       ownedAnimals: const [],
       preferences: const {},
@@ -31,5 +33,7 @@ void main() {
     expect(copy.id, 'u1');
     expect(copy.email, 'e');
     expect(copy.langue, 'fr');
+    expect(copy.address, 'addr');
+    expect(copy.birthDate, DateTime(2000));
   });
 }

--- a/test/noyau/unit/user_service_test.dart
+++ b/test/noyau/unit/user_service_test.dart
@@ -41,4 +41,37 @@ void main() {
     await box.deleteFromDisk();
     await dir.delete(recursive: true);
   });
+
+  test('updateUserFields updates address and birthDate', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserModelAdapter());
+    final box = await Hive.openBox<UserModel>('users2');
+    final service =
+        UserService(testBox: box, firestore: FakeFirebaseFirestore(), skipHiveInit: true);
+    final user = UserModel(
+      id: 'u2',
+      name: 'n',
+      email: 'e',
+      phone: '',
+      profilePicture: '',
+      profession: '',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+    await service.saveUserLocally(user);
+    await service.updateUserFields({'address': 'new', 'birthDate': DateTime(2020)});
+    final fetched = service.getUserFromHive();
+    expect(fetched?.address, 'new');
+    expect(fetched?.birthDate, DateTime(2020));
+    await box.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
 }

--- a/test/noyau/widget/user_edit_screen_test.dart
+++ b/test/noyau/widget/user_edit_screen_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:anisphere/modules/noyau/screens/user_edit_screen.dart';
+import 'package:anisphere/modules/noyau/providers/user_provider.dart';
+import 'package:anisphere/modules/noyau/services/user_service.dart';
+import 'package:anisphere/modules/noyau/services/auth_service.dart';
+import 'package:anisphere/modules/noyau/models/user_model.dart';
+import '../../test_config.dart';
+
+class _FakeUserProvider extends UserProvider {
+  final UserModel? _user;
+  _FakeUserProvider(this._user)
+      : super(UserService(skipHiveInit: true), AuthService());
+
+  @override
+  UserModel? get user => _user;
+}
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  testWidgets('shows fields and save button', (tester) async {
+    final user = UserModel(
+      id: 'u1',
+      name: 'Test',
+      email: 't@test.com',
+      phone: '1',
+      profilePicture: '',
+      profession: 'dev',
+      address: 'a',
+      birthDate: DateTime(2000),
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<UserProvider>.value(
+        value: _FakeUserProvider(user),
+        child: const MaterialApp(home: UserEditScreen()),
+      ),
+    );
+
+    expect(find.text('Nom'), findsOneWidget);
+    expect(find.text('Enregistrer'), findsOneWidget);
+    expect(find.text('Email: t@test.com'), findsOneWidget);
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -72,6 +72,7 @@
 | test/noyau/widget/main_screen_test.dart | widget | package:anisphere/modules/noyau/screens/main_screen.dart | ✅ |
 | test/noyau/widget/animal_profile_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_profile_screen.dart | ✅ |
 | test/noyau/widget/user_profile_screen_test.dart | widget | package:anisphere/modules/noyau/screens/user_profile_screen.dart | ✅ |
+| test/noyau/widget/user_edit_screen_test.dart | widget | package:anisphere/modules/noyau/screens/user_edit_screen.dart | ✅ |
 | test/noyau/widget/animal_form_screen_test.dart | widget | package:anisphere/modules/noyau/screens/animal_form_screen.dart | ✅ |
 | test/noyau/widget/home_screen_test.dart | widget | package:anisphere/modules/noyau/screens/home_screen.dart | ✅ |
 | test/noyau/widget/splash_screen_test.dart | widget | package:anisphere/modules/noyau/screens/splash_screen.dart | ✅ |


### PR DESCRIPTION
## Summary
- extend `UserModel` with `address` and `birthDate`
- update Hive adapters and serialization for the new fields
- remove duplicates from `UserProfileModel`
- persist new fields in `UserService`
- allow editing account via new `UserEditScreen`
- link edit screen from profile screen
- test model, service and new screen

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68566171253883208a287f490b0f857e