### PR TITLE
Load animals before showing screen

### DIFF
--- a/test/noyau/widget/animals_screen_test.dart
+++ b/test/noyau/widget/animals_screen_test.dart
@@ -25,8 +25,12 @@ void main() {
     await tempDir.delete(recursive: true);
   });
 
-  testWidgets('renders without AppBar', (tester) async {
+  testWidgets('shows loading then IA suggestion when no animals', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: AnimalsScreen()));
+
+    // Initial loading indicator
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
     await tester.pumpAndSettle();
 
     expect(find.byType(AppBar), findsNothing);


### PR DESCRIPTION
## Summary
- load animals before displaying the animals screen
- refresh list after adding an animal
- show progress indicator while loading
- update widget test for new behaviour

## Testing
- `flutter test test/noyau/widget/animals_screen_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856617347b88320a50f7d5b125f9773