### PR TITLE
Localize support screen and logout button

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "بيت"
+  ,"logout": "تسجيل الخروج"
+  ,"support": "الدعم"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Heim"
+  ,"logout": "Ausloggen"
+  ,"support": "Unterstützung"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Home"
+  ,"logout": "Log out"
+  ,"support": "Support"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Hogar"
+  ,"logout": "Cerrar sesión"
+  ,"support": "Soporte"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Enregistrer"
   ,"identityModuleTitle": "Identité"
   ,"identityModuleDescription": "Gérer l'identité de l'animal"
+  ,"home": "Accueil"
+  ,"logout": "Se déconnecter"
+  ,"support": "Support"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Casa"
+  ,"logout": "Disconnettersi"
+  ,"support": "Supporto"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "家"
+  ,"logout": "ログアウト"
+  ,"support": "サポート"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Lar"
+  ,"logout": "Sair"
+  ,"support": "Suporte"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Дом"
+  ,"logout": "Выйти"
+  ,"support": "Поддержка"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -29,4 +29,7 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "家"
+  ,"logout": "登出"
+  ,"support": "支持"
 }

--- a/lib/modules/noyau/screens/support_screen.dart
+++ b/lib/modules/noyau/screens/support_screen.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../i18n/app_localizations.dart';
+
 import '../providers/support_provider.dart';
 import '../providers/user_provider.dart';
 import '../models/support_ticket_model.dart';
@@ -40,7 +42,7 @@ class _SupportScreenState extends State<SupportScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Support')),
+      appBar: AppBar(title: Text(AppLocalizations.of(context)!.support)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/modules/noyau/screens/user_profile_screen.dart
+++ b/lib/modules/noyau/screens/user_profile_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import '../i18n/app_localizations.dart';
 import 'user_edit_screen.dart';
 
 class UserProfileScreen extends StatelessWidget {
@@ -135,7 +136,7 @@ class UserProfileScreen extends StatelessWidget {
           Center(
             child: ElevatedButton.icon(
               icon: const Icon(Icons.logout),
-              label: const Text("Se déconnecter"),
+              label: Text(AppLocalizations.of(context)!.logout),
               style: ElevatedButton.styleFrom(
                 backgroundColor: const Color(0xFF183153),
                 foregroundColor: Colors.white,

--- a/test/noyau/widget/user_profile_screen_test.dart
+++ b/test/noyau/widget/user_profile_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 import '../../helpers/test_fakes.dart';
 
@@ -43,12 +44,17 @@ void main() {
     await tester.pumpWidget(
       ChangeNotifierProvider<UserProvider>(
         create: (_) => _TestUserProvider(),
-        child: const MaterialApp(home: UserProfileScreen()),
+        child: MaterialApp(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          home: const UserProfileScreen(),
+        ),
       ),
     );
 
     expect(find.text('Mon Profil'), findsOneWidget);
     expect(find.text('Test'), findsOneWidget);
-    expect(find.text('Se déconnecter'), findsOneWidget);
+    expect(find.text('Log out'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- hook up support and logout labels to localizations
- add `home`, `logout`, and `support` keys to all ARB files
- update widget test to use localization delegates

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685664cd487483209d20dd4334280d5d