### PR TITLE
Localize main menu labels

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "بيت"
+  ,"share": "مشاركة"
+  ,"modules": "الوحدات"
+  ,"myAnimals": "حيواناتي"
+  ,"profile": "ملفي الشخصي"
+  ,"settings": "الإعدادات"
+  ,"notifications": "الإشعارات"
+  ,"about": "حول"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Heim"
+  ,"share": "Teilen"
+  ,"modules": "Module"
+  ,"myAnimals": "Meine Tiere"
+  ,"profile": "Mein Profil"
+  ,"settings": "Einstellungen"
+  ,"notifications": "Benachrichtigungen"
+  ,"about": "Über"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Home"
+  ,"share": "Share"
+  ,"modules": "Modules"
+  ,"myAnimals": "My Animals"
+  ,"profile": "My profile"
+  ,"settings": "Settings"
+  ,"notifications": "Notifications"
+  ,"about": "About"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Hogar"
+  ,"share": "Compartir"
+  ,"modules": "Módulos"
+  ,"myAnimals": "Mis Animales"
+  ,"profile": "Mi perfil"
+  ,"settings": "Configuración"
+  ,"notifications": "Notificaciones"
+  ,"about": "Acerca de"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Enregistrer"
   ,"identityModuleTitle": "Identité"
   ,"identityModuleDescription": "Gérer l'identité de l'animal"
+  ,"home": "Accueil"
+  ,"share": "Partage"
+  ,"modules": "Modules"
+  ,"myAnimals": "Mes Animaux"
+  ,"profile": "Mon profil"
+  ,"settings": "Paramètres"
+  ,"notifications": "Notifications"
+  ,"about": "À propos"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Casa"
+  ,"share": "Condividi"
+  ,"modules": "Moduli"
+  ,"myAnimals": "I miei animali"
+  ,"profile": "Il mio profilo"
+  ,"settings": "Impostazioni"
+  ,"notifications": "Notifiche"
+  ,"about": "Informazioni"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "家"
+  ,"share": "共有"
+  ,"modules": "モジュール"
+  ,"myAnimals": "私の動物"
+  ,"profile": "私のプロフィール"
+  ,"settings": "設定"
+  ,"notifications": "通知"
+  ,"about": "約"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -293,6 +293,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Manage your animal\'s identity'**
   String get identityModuleDescription;
+
+  /// No description provided for @home.
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get home;
+
+  /// No description provided for @share.
+  ///
+  /// In en, this message translates to:
+  /// **'Share'**
+  String get share;
+
+  /// No description provided for @modules.
+  ///
+  /// In en, this message translates to:
+  /// **'Modules'**
+  String get modules;
+
+  /// No description provided for @myAnimals.
+  ///
+  /// In en, this message translates to:
+  /// **'My Animals'**
+  String get myAnimals;
+
+  /// No description provided for @profile.
+  ///
+  /// In en, this message translates to:
+  /// **'My profile'**
+  String get profile;
+
+  /// No description provided for @settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settings;
+
+  /// No description provided for @notifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notifications;
+
+  /// No description provided for @about.
+  ///
+  /// In en, this message translates to:
+  /// **'About'**
+  String get about;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -98,4 +98,28 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'بيت';
+
+  @override
+  String get share => 'مشاركة';
+
+  @override
+  String get modules => 'الوحدات';
+
+  @override
+  String get myAnimals => 'حيواناتي';
+
+  @override
+  String get profile => 'ملفي الشخصي';
+
+  @override
+  String get settings => 'الإعدادات';
+
+  @override
+  String get notifications => 'الإشعارات';
+
+  @override
+  String get about => 'حول';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -98,4 +98,28 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Heim';
+
+  @override
+  String get share => 'Teilen';
+
+  @override
+  String get modules => 'Module';
+
+  @override
+  String get myAnimals => 'Meine Tiere';
+
+  @override
+  String get profile => 'Mein Profil';
+
+  @override
+  String get settings => 'Einstellungen';
+
+  @override
+  String get notifications => 'Benachrichtigungen';
+
+  @override
+  String get about => 'Über';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -98,4 +98,28 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Home';
+
+  @override
+  String get share => 'Share';
+
+  @override
+  String get modules => 'Modules';
+
+  @override
+  String get myAnimals => 'My Animals';
+
+  @override
+  String get profile => 'My profile';
+
+  @override
+  String get settings => 'Settings';
+
+  @override
+  String get notifications => 'Notifications';
+
+  @override
+  String get about => 'About';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -98,4 +98,28 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Hogar';
+
+  @override
+  String get share => 'Compartir';
+
+  @override
+  String get modules => 'Módulos';
+
+  @override
+  String get myAnimals => 'Mis Animales';
+
+  @override
+  String get profile => 'Mi perfil';
+
+  @override
+  String get settings => 'Configuración';
+
+  @override
+  String get notifications => 'Notificaciones';
+
+  @override
+  String get about => 'Acerca de';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -98,4 +98,28 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Gérer l\'identité de l\'animal';
+
+  @override
+  String get home => 'Accueil';
+
+  @override
+  String get share => 'Partage';
+
+  @override
+  String get modules => 'Modules';
+
+  @override
+  String get myAnimals => 'Mes Animaux';
+
+  @override
+  String get profile => 'Mon profil';
+
+  @override
+  String get settings => 'Paramètres';
+
+  @override
+  String get notifications => 'Notifications';
+
+  @override
+  String get about => 'À propos';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -98,4 +98,28 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Casa';
+
+  @override
+  String get share => 'Condividi';
+
+  @override
+  String get modules => 'Moduli';
+
+  @override
+  String get myAnimals => 'I miei animali';
+
+  @override
+  String get profile => 'Il mio profilo';
+
+  @override
+  String get settings => 'Impostazioni';
+
+  @override
+  String get notifications => 'Notifiche';
+
+  @override
+  String get about => 'Informazioni';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -97,4 +97,28 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => '家';
+
+  @override
+  String get share => '共有';
+
+  @override
+  String get modules => 'モジュール';
+
+  @override
+  String get myAnimals => '私の動物';
+
+  @override
+  String get profile => '私のプロフィール';
+
+  @override
+  String get settings => '設定';
+
+  @override
+  String get notifications => '通知';
+
+  @override
+  String get about => '約';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -98,4 +98,28 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Lar';
+
+  @override
+  String get share => 'Compartilhar';
+
+  @override
+  String get modules => 'Módulos';
+
+  @override
+  String get myAnimals => 'Meus Animais';
+
+  @override
+  String get profile => 'Meu perfil';
+
+  @override
+  String get settings => 'Configurações';
+
+  @override
+  String get notifications => 'Notificações';
+
+  @override
+  String get about => 'Sobre';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -98,4 +98,28 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => 'Дом';
+
+  @override
+  String get share => 'Поделиться';
+
+  @override
+  String get modules => 'Модули';
+
+  @override
+  String get myAnimals => 'Мои животные';
+
+  @override
+  String get profile => 'Мой профиль';
+
+  @override
+  String get settings => 'Настройки';
+
+  @override
+  String get notifications => 'Уведомления';
+
+  @override
+  String get about => 'О программе';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -97,4 +97,28 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get home => '家';
+
+  @override
+  String get share => '分享';
+
+  @override
+  String get modules => '模块';
+
+  @override
+  String get myAnimals => '我的动物';
+
+  @override
+  String get profile => '我的资料';
+
+  @override
+  String get settings => '设置';
+
+  @override
+  String get notifications => '通知';
+
+  @override
+  String get about => '关于';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Lar"
+  ,"share": "Compartilhar"
+  ,"modules": "Módulos"
+  ,"myAnimals": "Meus Animais"
+  ,"profile": "Meu profil"
+  ,"settings": "Configurações"
+  ,"notifications": "Notificações"
+  ,"about": "Sobre"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "Дом"
+  ,"share": "Поделиться"
+  ,"modules": "Модули"
+  ,"myAnimals": "Мои животные"
+  ,"profile": "Мой профиль"
+  ,"settings": "Настройки"
+  ,"notifications": "Уведомления"
+  ,"about": "О программе"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -29,4 +29,12 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"home": "家"
+  ,"share": "分享"
+  ,"modules": "模块"
+  ,"myAnimals": "我的动物"
+  ,"profile": "我的资料"
+  ,"settings": "设置"
+  ,"notifications": "通知"
+  ,"about": "关于"
 }

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -140,11 +140,23 @@ class MainScreenState extends State<MainScreen> {
       ),
       body: _pages[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Accueil'),
-          BottomNavigationBarItem(icon: Icon(Icons.share), label: 'Partage'),
-          BottomNavigationBarItem(icon: Icon(Icons.apps), label: 'Modules'),
-          BottomNavigationBarItem(icon: Icon(Icons.pets), label: 'Mes Animaux'),
+        items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.home),
+            label: AppLocalizations.of(context)?.home ?? 'Accueil',
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.share),
+            label: AppLocalizations.of(context)?.share ?? 'Partage',
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.apps),
+            label: AppLocalizations.of(context)?.modules ?? 'Modules',
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.pets),
+            label: AppLocalizations.of(context)?.myAnimals ?? 'Mes Animaux',
+          ),
         ],
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,

--- a/lib/modules/noyau/widgets/more_menu.dart
+++ b/lib/modules/noyau/widgets/more_menu.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:anisphere/modules/noyau/screens/user_profile_screen.dart';
 import 'package:anisphere/modules/noyau/screens/settings_screen.dart';
 import 'package:anisphere/modules/noyau/screens/notifications_screen.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 
 class MoreMenuButton extends StatelessWidget {
   const MoreMenuButton({super.key});
@@ -43,11 +44,26 @@ class MoreMenuButton extends StatelessWidget {
             break;
         }
       },
-      itemBuilder: (BuildContext context) => const [
-        PopupMenuItem(value: 'profile', child: Text('Mon profil')),
-        PopupMenuItem(value: 'settings', child: Text('Paramètres')),
-        PopupMenuItem(value: 'notifications', child: Text('Notifications')),
-        PopupMenuItem(value: 'about', child: Text('À propos')),
+      itemBuilder: (BuildContext context) => [
+        PopupMenuItem(
+          value: 'profile',
+          child:
+              Text(AppLocalizations.of(context)?.profile ?? 'Mon profil'),
+        ),
+        PopupMenuItem(
+          value: 'settings',
+          child:
+              Text(AppLocalizations.of(context)?.settings ?? 'Paramètres'),
+        ),
+        PopupMenuItem(
+          value: 'notifications',
+          child: Text(
+              AppLocalizations.of(context)?.notifications ?? 'Notifications'),
+        ),
+        PopupMenuItem(
+          value: 'about',
+          child: Text(AppLocalizations.of(context)?.about ?? 'À propos'),
+        ),
       ],
     );
   }

--- a/test/noyau/widget/more_menu_test.dart
+++ b/test/noyau/widget/more_menu_test.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/noyau/widgets/more_menu.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 
 void main() {
@@ -9,7 +10,14 @@ void main() {
     await initTestEnv();
   });
   testWidgets('shows menu items when tapped', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: MoreMenuButton())));
+    await tester.pumpWidget(
+      MaterialApp(
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        locale: const Locale('fr'),
+        home: const Scaffold(body: MoreMenuButton()),
+      ),
+    );
     await tester.tap(find.byType(MoreMenuButton));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- localize main screen bottom navigation labels
- localize popup menu items in `MoreMenuButton`
- update widget test to load localization delegates
- add `home`, `share`, `modules`, `myAnimals`, `profile`, `settings`, `notifications`, `about` keys in all ARB files
- update generated localization dart files with new getters

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685664cf20f4832084438e5f6e471eeb