### PR TITLE
Add locale fallback

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -15,6 +15,7 @@ AniSphère est maintenant multilingue grâce au système de traduction centralis
 * Tous les textes doivent être appelés via `AppLocalizations.of(context)` pour permettre la traduction automatique.
 * Les fichiers `.arb` sont regroupés dans `lib/l10n/` et générés ou traduits via script.
 * Le service central `lib/modules/noyau/i18n/` gère la langue globale pour tous les modules.
+* `localeResolutionCallback` dans `lib/main.dart` force la langue anglaise si la locale choisie n'est pas prise en charge.
 📌 Version Flutter/Dart requise
 
 Le développement d'AniSphère s'appuie sur **Flutter&nbsp;3.32.x** et **Dart&nbsp;3.4+**.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -168,6 +168,16 @@ class _MyAppState extends State<MyApp> {
       locale: locale,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
+      localeResolutionCallback:
+          (Locale? locale, Iterable<Locale> supportedLocales) {
+        if (locale == null) return const Locale('en');
+        for (final supportedLocale in supportedLocales) {
+          if (supportedLocale.languageCode == locale.languageCode) {
+            return supportedLocale;
+          }
+        }
+        return const Locale('en');
+      },
       debugShowCheckedModeBanner: false,
       theme: appTheme,
       darkTheme: darkTheme,


### PR DESCRIPTION
## Summary
- default to English locale when unsupported locale is passed
- explain the new callback in development docs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685664cfa7b48320ae6f6e982f128c12