### PR TITLE
Localize module summary strings

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "الهويات المسجلة"
+  ,"noHealthTracking": "لا يوجد تتبع صحي جارٍ"
+  ,"healthTrackingSummary": "حيوانات تحت المتابعة الصحية"
+  ,"noTrainingStarted": "لم يبدأ أي تدريب"
+  ,"trainingInProgress": "حيوانات قيد التدريب"
+  ,"trainingAvailableFor": "التدريب متاح لـ"
+  ,"noAnimalForTraining": "لا يوجد حيوان مسجل للتدريب"
+  ,"aiSummaryUndefined": "ملخص الذكاء الاصطناعي غير محدد"
+  ,"noActiveModule": "لا توجد وحدة نشطة"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "registrierte Identitäten"
+  ,"noHealthTracking": "Kein Gesundheitstracking aktiv"
+  ,"healthTrackingSummary": "Tiere im Gesundheitstracking"
+  ,"noTrainingStarted": "Kein Training gestartet"
+  ,"trainingInProgress": "Tiere im Training"
+  ,"trainingAvailableFor": "Training verfügbar für"
+  ,"noAnimalForTraining": "Kein Tier für das Training registriert"
+  ,"aiSummaryUndefined": "KI-Zusammenfassung nicht definiert"
+  ,"noActiveModule": "Kein aktives Modul"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "identities registered"
+  ,"noHealthTracking": "No health tracking in progress"
+  ,"healthTrackingSummary": "animals tracked for health"
+  ,"noTrainingStarted": "No training started"
+  ,"trainingInProgress": "animals in training"
+  ,"trainingAvailableFor": "Training available for"
+  ,"noAnimalForTraining": "No animal registered for training"
+  ,"aiSummaryUndefined": "AI summary not defined"
+  ,"noActiveModule": "No active module"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "identidades registradas"
+  ,"noHealthTracking": "No hay seguimiento de salud en curso"
+  ,"healthTrackingSummary": "animales con seguimiento de salud"
+  ,"noTrainingStarted": "No se inició ningún entrenamiento"
+  ,"trainingInProgress": "animales en entrenamiento"
+  ,"trainingAvailableFor": "Adiestramiento disponible para"
+  ,"noAnimalForTraining": "Ningún animal registrado para el adiestramiento"
+  ,"aiSummaryUndefined": "Resumen de IA no definido"
+  ,"noActiveModule": "Ningún módulo activo"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Enregistrer"
   ,"identityModuleTitle": "Identité"
   ,"identityModuleDescription": "Gérer l'identité de l'animal"
+  ,"identitiesRegistered": "identités enregistrées"
+  ,"noHealthTracking": "Aucun suivi de santé en cours"
+  ,"healthTrackingSummary": "animaux suivis en santé"
+  ,"noTrainingStarted": "Aucun apprentissage lancé"
+  ,"trainingInProgress": "animaux en apprentissage"
+  ,"trainingAvailableFor": "Dressage disponible pour"
+  ,"noAnimalForTraining": "Aucun animal enregistré pour le dressage"
+  ,"aiSummaryUndefined": "Résumé IA non défini"
+  ,"noActiveModule": "Aucun module actif"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "identità registrate"
+  ,"noHealthTracking": "Nessun monitoraggio della salute in corso"
+  ,"healthTrackingSummary": "animali monitorati per la salute"
+  ,"noTrainingStarted": "Nessun addestramento avviato"
+  ,"trainingInProgress": "animali in addestramento"
+  ,"trainingAvailableFor": "Addestramento disponibile per"
+  ,"noAnimalForTraining": "Nessun animale registrato per l'addestramento"
+  ,"aiSummaryUndefined": "Riepilogo IA non definito"
+  ,"noActiveModule": "Nessun modulo attivo"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "登録された識別"
+  ,"noHealthTracking": "健康追跡は行われていません"
+  ,"healthTrackingSummary": "匹が健康追跡中"
+  ,"noTrainingStarted": "トレーニングが開始されていません"
+  ,"trainingInProgress": "匹がトレーニング中"
+  ,"trainingAvailableFor": "トレーニング可能数"
+  ,"noAnimalForTraining": "トレーニング用の登録動物がいません"
+  ,"aiSummaryUndefined": "AI概要が未定義"
+  ,"noActiveModule": "有効なモジュールがありません"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -293,6 +293,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Manage your animal\'s identity'**
   String get identityModuleDescription;
+
+  /// No description provided for @identitiesRegistered.
+  ///
+  /// In en, this message translates to:
+  /// **'identities registered'**
+  String get identitiesRegistered;
+
+  /// No description provided for @noHealthTracking.
+  ///
+  /// In en, this message translates to:
+  /// **'No health tracking in progress'**
+  String get noHealthTracking;
+
+  /// No description provided for @healthTrackingSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'animals tracked for health'**
+  String get healthTrackingSummary;
+
+  /// No description provided for @noTrainingStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'No training started'**
+  String get noTrainingStarted;
+
+  /// No description provided for @trainingInProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'animals in training'**
+  String get trainingInProgress;
+
+  /// No description provided for @trainingAvailableFor.
+  ///
+  /// In en, this message translates to:
+  /// **'Training available for'**
+  String get trainingAvailableFor;
+
+  /// No description provided for @noAnimalForTraining.
+  ///
+  /// In en, this message translates to:
+  /// **'No animal registered for training'**
+  String get noAnimalForTraining;
+
+  /// No description provided for @aiSummaryUndefined.
+  ///
+  /// In en, this message translates to:
+  /// **'AI summary not defined'**
+  String get aiSummaryUndefined;
+
+  /// No description provided for @noActiveModule.
+  ///
+  /// In en, this message translates to:
+  /// **'No active module'**
+  String get noActiveModule;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -98,4 +98,31 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'الهويات المسجلة';
+
+  @override
+  String get noHealthTracking => 'لا يوجد تتبع صحي جارٍ';
+
+  @override
+  String get healthTrackingSummary => 'حيوانات تحت المتابعة الصحية';
+
+  @override
+  String get noTrainingStarted => 'لم يبدأ أي تدريب';
+
+  @override
+  String get trainingInProgress => 'حيوانات قيد التدريب';
+
+  @override
+  String get trainingAvailableFor => 'التدريب متاح لـ';
+
+  @override
+  String get noAnimalForTraining => 'لا يوجد حيوان مسجل للتدريب';
+
+  @override
+  String get aiSummaryUndefined => 'ملخص الذكاء الاصطناعي غير محدد';
+
+  @override
+  String get noActiveModule => 'لا توجد وحدة نشطة';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -98,4 +98,31 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'registrierte Identitäten';
+
+  @override
+  String get noHealthTracking => 'Kein Gesundheitstracking aktiv';
+
+  @override
+  String get healthTrackingSummary => 'Tiere im Gesundheitstracking';
+
+  @override
+  String get noTrainingStarted => 'Kein Training gestartet';
+
+  @override
+  String get trainingInProgress => 'Tiere im Training';
+
+  @override
+  String get trainingAvailableFor => 'Training verfügbar für';
+
+  @override
+  String get noAnimalForTraining => 'Kein Tier für das Training registriert';
+
+  @override
+  String get aiSummaryUndefined => 'KI-Zusammenfassung nicht definiert';
+
+  @override
+  String get noActiveModule => 'Kein aktives Modul';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -98,4 +98,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'identities registered';
+
+  @override
+  String get noHealthTracking => 'No health tracking in progress';
+
+  @override
+  String get healthTrackingSummary => 'animals tracked for health';
+
+  @override
+  String get noTrainingStarted => 'No training started';
+
+  @override
+  String get trainingInProgress => 'animals in training';
+
+  @override
+  String get trainingAvailableFor => 'Training available for';
+
+  @override
+  String get noAnimalForTraining => 'No animal registered for training';
+
+  @override
+  String get aiSummaryUndefined => 'AI summary not defined';
+
+  @override
+  String get noActiveModule => 'No active module';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -98,4 +98,31 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'identidades registradas';
+
+  @override
+  String get noHealthTracking => 'No hay seguimiento de salud en curso';
+
+  @override
+  String get healthTrackingSummary => 'animales con seguimiento de salud';
+
+  @override
+  String get noTrainingStarted => 'No se inició ningún entrenamiento';
+
+  @override
+  String get trainingInProgress => 'animales en entrenamiento';
+
+  @override
+  String get trainingAvailableFor => 'Adiestramiento disponible para';
+
+  @override
+  String get noAnimalForTraining => 'Ningún animal registrado para el adiestramiento';
+
+  @override
+  String get aiSummaryUndefined => 'Resumen de IA no definido';
+
+  @override
+  String get noActiveModule => 'Ningún módulo activo';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -98,4 +98,31 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Gérer l\'identité de l\'animal';
+
+  @override
+  String get identitiesRegistered => 'identités enregistrées';
+
+  @override
+  String get noHealthTracking => 'Aucun suivi de santé en cours';
+
+  @override
+  String get healthTrackingSummary => 'animaux suivis en santé';
+
+  @override
+  String get noTrainingStarted => 'Aucun apprentissage lancé';
+
+  @override
+  String get trainingInProgress => 'animaux en apprentissage';
+
+  @override
+  String get trainingAvailableFor => 'Dressage disponible pour';
+
+  @override
+  String get noAnimalForTraining => 'Aucun animal enregistré pour le dressage';
+
+  @override
+  String get aiSummaryUndefined => 'Résumé IA non défini';
+
+  @override
+  String get noActiveModule => 'Aucun module actif';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -98,4 +98,31 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'identità registrate';
+
+  @override
+  String get noHealthTracking => 'Nessun monitoraggio della salute in corso';
+
+  @override
+  String get healthTrackingSummary => 'animali monitorati per la salute';
+
+  @override
+  String get noTrainingStarted => 'Nessun addestramento avviato';
+
+  @override
+  String get trainingInProgress => 'animali in addestramento';
+
+  @override
+  String get trainingAvailableFor => 'Addestramento disponibile per';
+
+  @override
+  String get noAnimalForTraining => 'Nessun animale registrato per l\'addestramento';
+
+  @override
+  String get aiSummaryUndefined => 'Riepilogo IA non definito';
+
+  @override
+  String get noActiveModule => 'Nessun modulo attivo';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -97,4 +97,31 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => '登録された識別';
+
+  @override
+  String get noHealthTracking => '健康追跡は行われていません';
+
+  @override
+  String get healthTrackingSummary => '匹が健康追跡中';
+
+  @override
+  String get noTrainingStarted => 'トレーニングが開始されていません';
+
+  @override
+  String get trainingInProgress => '匹がトレーニング中';
+
+  @override
+  String get trainingAvailableFor => 'トレーニング可能数';
+
+  @override
+  String get noAnimalForTraining => 'トレーニング用の登録動物がいません';
+
+  @override
+  String get aiSummaryUndefined => 'AI概要が未定義';
+
+  @override
+  String get noActiveModule => '有効なモジュールがありません';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -98,4 +98,31 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'identidades registradas';
+
+  @override
+  String get noHealthTracking => 'Sem acompanhamento de saúde em andamento';
+
+  @override
+  String get healthTrackingSummary => 'animais em acompanhamento de saúde';
+
+  @override
+  String get noTrainingStarted => 'Nenhum treinamento iniciado';
+
+  @override
+  String get trainingInProgress => 'animais em treinamento';
+
+  @override
+  String get trainingAvailableFor => 'Treinamento disponível para';
+
+  @override
+  String get noAnimalForTraining => 'Nenhum animal registrado para treinamento';
+
+  @override
+  String get aiSummaryUndefined => 'Resumo de IA não definido';
+
+  @override
+  String get noActiveModule => 'Nenhum módulo ativo';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -98,4 +98,31 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => 'зарегистрированные идентичности';
+
+  @override
+  String get noHealthTracking => 'Отсутствует отслеживание здоровья';
+
+  @override
+  String get healthTrackingSummary => 'животных под наблюдением здоровья';
+
+  @override
+  String get noTrainingStarted => 'Тренировка не начата';
+
+  @override
+  String get trainingInProgress => 'животных на тренировке';
+
+  @override
+  String get trainingAvailableFor => 'Дрессировка доступна для';
+
+  @override
+  String get noAnimalForTraining => 'Нет животных, зарегистрированных для дрессировки';
+
+  @override
+  String get aiSummaryUndefined => 'ИИ-резюме не определено';
+
+  @override
+  String get noActiveModule => 'Нет активных модулей';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -97,4 +97,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get identitiesRegistered => '已登记身份';
+
+  @override
+  String get noHealthTracking => '没有进行健康跟踪';
+
+  @override
+  String get healthTrackingSummary => '只动物健康跟踪中';
+
+  @override
+  String get noTrainingStarted => '尚未开始训练';
+
+  @override
+  String get trainingInProgress => '只动物训练中';
+
+  @override
+  String get trainingAvailableFor => '可训练数量';
+
+  @override
+  String get noAnimalForTraining => '没有登记用于训练的动物';
+
+  @override
+  String get aiSummaryUndefined => 'AI 摘要未定义';
+
+  @override
+  String get noActiveModule => '没有激活的模块';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "identidades registradas"
+  ,"noHealthTracking": "Sem acompanhamento de saúde em andamento"
+  ,"healthTrackingSummary": "animais em acompanhamento de saúde"
+  ,"noTrainingStarted": "Nenhum treinamento iniciado"
+  ,"trainingInProgress": "animais em treinamento"
+  ,"trainingAvailableFor": "Treinamento disponível para"
+  ,"noAnimalForTraining": "Nenhum animal registrado para treinamento"
+  ,"aiSummaryUndefined": "Resumo de IA não definido"
+  ,"noActiveModule": "Nenhum módulo ativo"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "зарегистрированные идентичности"
+  ,"noHealthTracking": "Отсутствует отслеживание здоровья"
+  ,"healthTrackingSummary": "животных под наблюдением здоровья"
+  ,"noTrainingStarted": "Тренировка не начата"
+  ,"trainingInProgress": "животных на тренировке"
+  ,"trainingAvailableFor": "Дрессировка доступна для"
+  ,"noAnimalForTraining": "Нет животных, зарегистрированных для дрессировки"
+  ,"aiSummaryUndefined": "ИИ-резюме не определено"
+  ,"noActiveModule": "Нет активных модулей"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -29,4 +29,13 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"identitiesRegistered": "已登记身份"
+  ,"noHealthTracking": "没有进行健康跟踪"
+  ,"healthTrackingSummary": "只动物健康跟踪中"
+  ,"noTrainingStarted": "尚未开始训练"
+  ,"trainingInProgress": "只动物训练中"
+  ,"trainingAvailableFor": "可训练数量"
+  ,"noAnimalForTraining": "没有登记用于训练的动物"
+  ,"aiSummaryUndefined": "AI 摘要未定义"
+  ,"noActiveModule": "没有激活的模块"
 }

--- a/lib/modules/noyau/services/modules_summary_service.dart
+++ b/lib/modules/noyau/services/modules_summary_service.dart
@@ -51,8 +51,8 @@ class ModulesSummaryService {
               ModuleSummary(
                 moduleName: "Santé",
                 summary: animals.isEmpty
-                    ? "Aucun suivi de santé en cours"
-                    : "${animals.length} animaux suivis en santé",
+                    ? l10n.noHealthTracking
+                    : "${animals.length} ${l10n.healthTrackingSummary}",
                 icon: "🩺",
                 isPremium: false,
               ),
@@ -64,8 +64,8 @@ class ModulesSummaryService {
               ModuleSummary(
                 moduleName: "Éducation",
                 summary: context.animalCount == 0
-                    ? "Aucun apprentissage lancé"
-                    : "${context.animalCount} animaux en apprentissage",
+                    ? l10n.noTrainingStarted
+                    : "${context.animalCount} ${l10n.trainingInProgress}",
                 icon: "📚",
                 isPremium: false,
               ),
@@ -77,8 +77,8 @@ class ModulesSummaryService {
               ModuleSummary(
                 moduleName: "Dressage",
                 summary: context.hasAnimals
-                    ? "Dressage disponible pour ${context.animalCount} animaux"
-                    : "Aucun animal enregistré pour le dressage",
+                    ? "${l10n.trainingAvailableFor} ${context.animalCount}"
+                    : l10n.noAnimalForTraining,
                 icon: "🎯",
                 isPremium: true,
               ),
@@ -91,7 +91,7 @@ class ModulesSummaryService {
                 moduleName: l10n.identityModuleTitle,
                 summary: context.animalCount == 0
                     ? l10n.identityModuleDescription
-                    : "${context.animalCount} identités enregistrées",
+                    : "${context.animalCount} ${l10n.identitiesRegistered}",
                 icon: "🆔",
                 isPremium: false,
               ),
@@ -103,7 +103,7 @@ class ModulesSummaryService {
             summaries.add(
               ModuleSummary(
                 moduleName: module.name,
-                summary: "Résumé IA non défini",
+                summary: l10n.aiSummaryUndefined,
                 icon: "✨",
                 isPremium: false,
               ),
@@ -119,7 +119,7 @@ class ModulesSummaryService {
   Future<String> generateSummaryText() async {
     final summaries = await generateSummaries();
     if (summaries.isEmpty) {
-      return 'Aucun module actif';
+      return l10n.noActiveModule;
     }
     return summaries
         .map((s) => '${s.moduleName}: ${s.summary}')


### PR DESCRIPTION
## Summary
- replace French strings in `ModulesSummaryService` with localization keys
- add new localization keys for module summaries across all languages
- update generated localization Dart files accordingly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685664d0ce088320a7a6bf4f0f2f6ebc