### PR TITLE
Add new settings localization keys

### DIFF
--- a/docs/suivi_noyau.md
+++ b/docs/suivi_noyau.md
@@ -1,0 +1,8 @@
+# Suivi du noyau
+
+### ✅ Localisations Noyau
+- 📁 `lib/l10n/app_xx.arb`
+- Nouvelles clés `settings_title`, `backup_success`, `backup_error`, `restore_success`, `restore_error`
+- Fichiers modifiés : `lib/modules/noyau/screens/settings_screen.dart`, localisations `.arb` et `.dart`
+- Date : 2025-06-21
+

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Enregistrer"
   ,"identityModuleTitle": "Identité"
   ,"identityModuleDescription": "Gérer l'identité de l'animal"
+  ,"settings_title": "Paramètres"
+  ,"backup_success": "Sauvegarde effectuée avec succès."
+  ,"backup_error": "Erreur lors de la sauvegarde."
+  ,"restore_success": "Restauration réussie."
+  ,"restore_error": "Erreur lors de la restauration."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -293,6 +293,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Manage your animal\'s identity'**
   String get identityModuleDescription;
+
+  /// No description provided for @settings_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settings_title;
+
+  /// No description provided for @backup_success.
+  ///
+  /// In en, this message translates to:
+  /// **'Backup completed successfully.'**
+  String get backup_success;
+
+  /// No description provided for @backup_error.
+  ///
+  /// In en, this message translates to:
+  /// **'Error during backup.'**
+  String get backup_error;
+
+  /// No description provided for @restore_success.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore successful.'**
+  String get restore_success;
+
+  /// No description provided for @restore_error.
+  ///
+  /// In en, this message translates to:
+  /// **'Error during restore.'**
+  String get restore_error;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -98,4 +98,19 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -98,4 +98,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -98,4 +98,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -98,4 +98,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Gérer l\'identité de l\'animal';
+
+  @override
+  String get settings_title => 'Paramètres';
+
+  @override
+  String get backup_success => 'Sauvegarde effectuée avec succès.';
+
+  @override
+  String get backup_error => 'Erreur lors de la sauvegarde.';
+
+  @override
+  String get restore_success => 'Restauration réussie.';
+
+  @override
+  String get restore_error => 'Erreur lors de la restauration.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -98,4 +98,19 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -97,4 +97,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -98,4 +98,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -98,4 +98,19 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -97,4 +97,19 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get identityModuleDescription => 'Manage your animal\'s identity';
+
+  @override
+  String get settings_title => 'Settings';
+
+  @override
+  String get backup_success => 'Backup completed successfully.';
+
+  @override
+  String get backup_error => 'Error during backup.';
+
+  @override
+  String get restore_success => 'Restore successful.';
+
+  @override
+  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -29,4 +29,9 @@
   ,"save_button": "Save"
   ,"identityModuleTitle": "Identity"
   ,"identityModuleDescription": "Manage your animal's identity"
+  ,"settings_title": "Settings"
+  ,"backup_success": "Backup completed successfully."
+  ,"backup_error": "Error during backup."
+  ,"restore_success": "Restore successful."
+  ,"restore_error": "Error during restore."
 }

--- a/lib/modules/noyau/screens/settings_screen.dart
+++ b/lib/modules/noyau/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../services/backup_service.dart';
 import '../providers/user_provider.dart';
 import '../services/animal_service.dart';
 import '../providers/theme_provider.dart';
+import 'package:anisphere/l10n/app_localizations.dart';
 import 'feedback_settings_screen.dart';
 import '../providers/payment_provider.dart';
 import 'iap_screen.dart';
@@ -64,11 +65,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (success) {
       await _loadLastBackup();
       messenger.showSnackBar(
-        const SnackBar(content: Text("Sauvegarde effectuée avec succès.")),
+        SnackBar(content: Text(t.backup_success)),
       );
     } else {
       messenger.showSnackBar(
-        const SnackBar(content: Text("Erreur lors de la sauvegarde.")),
+        SnackBar(content: Text(t.backup_error)),
       );
     }
   }
@@ -81,11 +82,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final success = await backupService.restoreBackup(user.id);
     if (success) {
       messenger.showSnackBar(
-        const SnackBar(content: Text("Restauration réussie.")),
+        SnackBar(content: Text(t.restore_success)),
       );
     } else {
       messenger.showSnackBar(
-        const SnackBar(content: Text("Erreur lors de la restauration.")),
+        SnackBar(content: Text(t.restore_error)),
       );
     }
   }
@@ -100,8 +101,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: const Text("Paramètres")),
+      appBar: AppBar(title: Text(t.settings_title)),
       body: ListView(
         padding: const EdgeInsets.all(24),
         children: [


### PR DESCRIPTION
## Summary
- localize Settings screen title and snackbar messages
- document new localization keys in `docs/suivi_noyau.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685664d2e3d08320922f4ebdde9d4751