### PR TITLE
Add breeder fields to IdentityModel

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -3,6 +3,7 @@
 |--------------|------|--------|--------|
 | test/identite/unit/identity_model.g_test.dart | unit | package:anisphere/modules/identite/models/identity_model.g.dart | ✅ |
 | test/identite/unit/identity_model_test.dart | unit | package:anisphere/modules/identite/models/identity_model.dart | ✅ |
+| test/identite/unit/identity_model_serialization_test.dart | unit | package:anisphere/modules/identite/models/identity_model.dart | ✅ |
 | test/identite/unit/identity_card_generator_test.dart | unit | package:anisphere/modules/identite/services/identity_card_generator.dart | ✅ |
 | test/identite/unit/identity_reminder_service_test.dart | unit | package:anisphere/modules/identite/services/identity_reminder_service.dart | ✅ |
 | test/identite/unit/legal_status_service_test.dart | unit | package:anisphere/modules/identite/services/legal_status_service.dart | ✅ |

--- a/lib/modules/identite/models/identity_model.dart
+++ b/lib/modules/identite/models/identity_model.dart
@@ -37,6 +37,48 @@ class IdentityModel {
   @HiveField(8)
   final DateTime lastUpdate;
 
+  // Nouveaux champs pour la complétude IA et données administratives
+  @HiveField(9)
+  final double? aiScore;
+
+  @HiveField(10)
+  final bool verifiedBreed;
+
+  @HiveField(11)
+  final List<String> photoTimeline;
+
+  // Données administratives
+  @HiveField(12)
+  final String? litterNumber;
+
+  @HiveField(13)
+  final String? lofNumber;
+
+  @HiveField(14)
+  final String? originCountry;
+
+  @HiveField(15)
+  final String? alias;
+
+  // Informations éleveur
+  @HiveField(16)
+  final String? breederName;
+
+  @HiveField(17)
+  final String? breederAddress;
+
+  @HiveField(18)
+  final String? breederSiret;
+
+  @HiveField(19)
+  final String? breederEmail;
+
+  @HiveField(20)
+  final String? breederWebsite;
+
+  @HiveField(21)
+  final String? breederPhone;
+
   IdentityModel({
     required this.animalId,
     this.microchipNumber,
@@ -46,6 +88,19 @@ class IdentityModel {
     this.verifiedByIA = false,
     this.history = const [],
     this.hasPublicQR = false,
+    this.aiScore,
+    this.verifiedBreed = false,
+    this.photoTimeline = const [],
+    this.litterNumber,
+    this.lofNumber,
+    this.originCountry,
+    this.alias,
+    this.breederName,
+    this.breederAddress,
+    this.breederSiret,
+    this.breederEmail,
+    this.breederWebsite,
+    this.breederPhone,
     DateTime? lastUpdate,
   }) : lastUpdate = lastUpdate ?? DateTime.now();
 
@@ -61,6 +116,21 @@ class IdentityModel {
           .map((e) => IdentityChange.fromMap(Map<String, dynamic>.from(e)))
           .toList(),
       hasPublicQR: map['hasPublicQR'] ?? false,
+      aiScore: (map['aiScore'] as num?)?.toDouble(),
+      verifiedBreed: map['verifiedBreed'] ?? false,
+      photoTimeline: (map['photoTimeline'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+      litterNumber: map['litterNumber'],
+      lofNumber: map['lofNumber'],
+      originCountry: map['originCountry'],
+      alias: map['alias'],
+      breederName: map['breederName'],
+      breederAddress: map['breederAddress'],
+      breederSiret: map['breederSiret'],
+      breederEmail: map['breederEmail'],
+      breederWebsite: map['breederWebsite'],
+      breederPhone: map['breederPhone'],
       lastUpdate: (map['lastUpdate'] as Timestamp?)?.toDate() ?? DateTime.now(),
     );
   }
@@ -76,6 +146,19 @@ class IdentityModel {
       'history': history.map((e) => e.toMap()).toList(),
       'hasPublicQR': hasPublicQR,
       'lastUpdate': Timestamp.fromDate(lastUpdate),
+      'aiScore': aiScore,
+      'verifiedBreed': verifiedBreed,
+      'photoTimeline': photoTimeline,
+      'litterNumber': litterNumber,
+      'lofNumber': lofNumber,
+      'originCountry': originCountry,
+      'alias': alias,
+      'breederName': breederName,
+      'breederAddress': breederAddress,
+      'breederSiret': breederSiret,
+      'breederEmail': breederEmail,
+      'breederWebsite': breederWebsite,
+      'breederPhone': breederPhone,
     };
   }
 }

--- a/lib/modules/identite/models/identity_model.g.dart
+++ b/lib/modules/identite/models/identity_model.g.dart
@@ -26,13 +26,26 @@ class IdentityModelAdapter extends TypeAdapter<IdentityModel> {
       history: (fields[6] as List).cast<IdentityChange>(),
       hasPublicQR: fields[7] as bool,
       lastUpdate: fields[8] as DateTime?,
+      aiScore: fields[9] as double?,
+      verifiedBreed: fields[10] as bool,
+      photoTimeline: (fields[11] as List).cast<String>(),
+      litterNumber: fields[12] as String?,
+      lofNumber: fields[13] as String?,
+      originCountry: fields[14] as String?,
+      alias: fields[15] as String?,
+      breederName: fields[16] as String?,
+      breederAddress: fields[17] as String?,
+      breederSiret: fields[18] as String?,
+      breederEmail: fields[19] as String?,
+      breederWebsite: fields[20] as String?,
+      breederPhone: fields[21] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, IdentityModel obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(22)
       ..writeByte(0)
       ..write(obj.animalId)
       ..writeByte(1)
@@ -50,7 +63,33 @@ class IdentityModelAdapter extends TypeAdapter<IdentityModel> {
       ..writeByte(7)
       ..write(obj.hasPublicQR)
       ..writeByte(8)
-      ..write(obj.lastUpdate);
+      ..write(obj.lastUpdate)
+      ..writeByte(9)
+      ..write(obj.aiScore)
+      ..writeByte(10)
+      ..write(obj.verifiedBreed)
+      ..writeByte(11)
+      ..write(obj.photoTimeline)
+      ..writeByte(12)
+      ..write(obj.litterNumber)
+      ..writeByte(13)
+      ..write(obj.lofNumber)
+      ..writeByte(14)
+      ..write(obj.originCountry)
+      ..writeByte(15)
+      ..write(obj.alias)
+      ..writeByte(16)
+      ..write(obj.breederName)
+      ..writeByte(17)
+      ..write(obj.breederAddress)
+      ..writeByte(18)
+      ..write(obj.breederSiret)
+      ..writeByte(19)
+      ..write(obj.breederEmail)
+      ..writeByte(20)
+      ..write(obj.breederWebsite)
+      ..writeByte(21)
+      ..write(obj.breederPhone);
   }
 
   @override

--- a/test/identite/unit/identity_model_serialization_test.dart
+++ b/test/identite/unit/identity_model_serialization_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:anisphere/modules/identite/models/identity_model.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('IdentityModel serializes all new fields', () {
+    final model = IdentityModel(
+      animalId: 'id1',
+      aiScore: 0.5,
+      verifiedBreed: true,
+      photoTimeline: const ['u1'],
+      litterNumber: 'N123',
+      lofNumber: 'LOF1',
+      originCountry: 'FR',
+      alias: 'Buddy',
+      breederName: 'John',
+      breederAddress: 'Street 1',
+      breederSiret: 'S1',
+      breederEmail: 'john@ex.com',
+      breederWebsite: 'https://john.com',
+      breederPhone: '0000',
+    );
+
+    final map = model.toMap();
+    final from = IdentityModel.fromMap(map);
+
+    expect(from.aiScore, 0.5);
+    expect(from.verifiedBreed, isTrue);
+    expect(from.photoTimeline, ['u1']);
+    expect(from.litterNumber, 'N123');
+    expect(from.lofNumber, 'LOF1');
+    expect(from.originCountry, 'FR');
+    expect(from.alias, 'Buddy');
+    expect(from.breederName, 'John');
+    expect(from.breederAddress, 'Street 1');
+    expect(from.breederSiret, 'S1');
+    expect(from.breederEmail, 'john@ex.com');
+    expect(from.breederWebsite, 'https://john.com');
+    expect(from.breederPhone, '0000');
+  });
+}

--- a/test/identite/unit/identity_model_test.dart
+++ b/test/identite/unit/identity_model_test.dart
@@ -7,11 +7,39 @@ void main() {
     await initTestEnv();
   });
   test('IdentityModel should serialize and deserialize correctly', () {
-    final identity = IdentityModel(animalId: 'abc123');
+    final identity = IdentityModel(
+      animalId: 'abc123',
+      aiScore: 0.8,
+      verifiedBreed: true,
+      photoTimeline: const ['a', 'b'],
+      litterNumber: 'L1',
+      lofNumber: 'LOF123',
+      originCountry: 'FR',
+      alias: 'Loulou',
+      breederName: 'Bob',
+      breederAddress: '1 rue',
+      breederSiret: '123',
+      breederEmail: 'bob@example.com',
+      breederWebsite: 'https://bob.com',
+      breederPhone: '0600',
+    );
     final map = identity.toMap();
     final deserialized = IdentityModel.fromMap(map);
 
     expect(deserialized.animalId, equals('abc123'));
     expect(deserialized.verifiedByIA, isFalse);
+    expect(deserialized.aiScore, equals(0.8));
+    expect(deserialized.verifiedBreed, isTrue);
+    expect(deserialized.photoTimeline.length, 2);
+    expect(deserialized.litterNumber, 'L1');
+    expect(deserialized.lofNumber, 'LOF123');
+    expect(deserialized.originCountry, 'FR');
+    expect(deserialized.alias, 'Loulou');
+    expect(deserialized.breederName, 'Bob');
+    expect(deserialized.breederAddress, '1 rue');
+    expect(deserialized.breederSiret, '123');
+    expect(deserialized.breederEmail, 'bob@example.com');
+    expect(deserialized.breederWebsite, 'https://bob.com');
+    expect(deserialized.breederPhone, '0600');
   });
 }


### PR DESCRIPTION
## Summary
- extend `IdentityModel` with IA score, breed verification, photo timeline
- store litter, LOF, alias, origin and breeder details
- update Hive adapters for new fields
- test serialization for new fields
- track new test in `test_tracker.md`

## Testing
- `flutter test test/identite/unit/identity_model_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566c8326988320b3607fd4d7f89508