### PR TITLE
Add identity scoring and PDF signing

### DIFF
--- a/lib/modules/identite/models/identity_model.dart
+++ b/lib/modules/identite/models/identity_model.dart
@@ -37,6 +37,12 @@ class IdentityModel {
   @HiveField(8)
   final DateTime lastUpdate;
 
+  @HiveField(9)
+  final double aiScore;
+
+  @HiveField(10)
+  final bool verifiedBreed;
+
   IdentityModel({
     required this.animalId,
     this.microchipNumber,
@@ -47,6 +53,8 @@ class IdentityModel {
     this.history = const [],
     this.hasPublicQR = false,
     DateTime? lastUpdate,
+    this.aiScore = 0.0,
+    this.verifiedBreed = false,
   }) : lastUpdate = lastUpdate ?? DateTime.now();
 
   factory IdentityModel.fromMap(Map<String, dynamic> map) {
@@ -62,6 +70,8 @@ class IdentityModel {
           .toList(),
       hasPublicQR: map['hasPublicQR'] ?? false,
       lastUpdate: (map['lastUpdate'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      aiScore: (map['aiScore'] as num?)?.toDouble() ?? 0.0,
+      verifiedBreed: map['verifiedBreed'] ?? false,
     );
   }
 
@@ -76,6 +86,8 @@ class IdentityModel {
       'history': history.map((e) => e.toMap()).toList(),
       'hasPublicQR': hasPublicQR,
       'lastUpdate': Timestamp.fromDate(lastUpdate),
+      'aiScore': aiScore,
+      'verifiedBreed': verifiedBreed,
     };
   }
 }

--- a/lib/modules/identite/models/identity_model.g.dart
+++ b/lib/modules/identite/models/identity_model.g.dart
@@ -26,13 +26,15 @@ class IdentityModelAdapter extends TypeAdapter<IdentityModel> {
       history: (fields[6] as List).cast<IdentityChange>(),
       hasPublicQR: fields[7] as bool,
       lastUpdate: fields[8] as DateTime?,
+      aiScore: fields[9] as double,
+      verifiedBreed: fields[10] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, IdentityModel obj) {
     writer
-      ..writeByte(9)
+      ..writeByte(11)
       ..writeByte(0)
       ..write(obj.animalId)
       ..writeByte(1)
@@ -50,7 +52,11 @@ class IdentityModelAdapter extends TypeAdapter<IdentityModel> {
       ..writeByte(7)
       ..write(obj.hasPublicQR)
       ..writeByte(8)
-      ..write(obj.lastUpdate);
+      ..write(obj.lastUpdate)
+      ..writeByte(9)
+      ..write(obj.aiScore)
+      ..writeByte(10)
+      ..write(obj.verifiedBreed);
   }
 
   @override

--- a/lib/modules/identite/services/identity_service.dart
+++ b/lib/modules/identite/services/identity_service.dart
@@ -1,11 +1,15 @@
 // Copilot Prompt : Service IdentityService pour AniSphère.
 // Gère l’enregistrement, la mise à jour, l’historique et la synchronisation locale/cloud
 // des fiches d’identité animale (QR, statut, photo, badge IA).
+import 'dart:io';
 import 'package:hive/hive.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:anisphere/services/ia/ia_metrics_collector.dart';
 import '../models/identity_model.dart';
 import '../models/genealogy_model.dart';
+import '../../noyau/services/storage_optimizer.dart';
+import 'identity_signature_service.dart';
+import 'dart:typed_data';
 
 /// Service IdentityService pour AniSphère.
 /// Gère l’enregistrement, la mise à jour, l’historique et la synchronisation locale/cloud
@@ -97,5 +101,79 @@ class IdentityService {
 
   GenealogyModel? getGenealogyLocally(String animalId) {
     return genealogyBox?.get(animalId);
+  }
+
+  Future<double> computeCompletionScore(IdentityModel model) async {
+    final fields = [
+      model.microchipNumber,
+      model.photoUrl,
+      model.status,
+      model.legalStatus,
+    ];
+    final filled =
+        fields.where((e) => e != null && e.toString().trim().isNotEmpty).length;
+    final score = filled / fields.length;
+    final updated = IdentityModel(
+      animalId: model.animalId,
+      microchipNumber: model.microchipNumber,
+      photoUrl: model.photoUrl,
+      status: model.status,
+      legalStatus: model.legalStatus,
+      verifiedByIA: model.verifiedByIA,
+      hasPublicQR: model.hasPublicQR,
+      history: model.history,
+      lastUpdate: model.lastUpdate,
+      aiScore: score,
+      verifiedBreed: model.verifiedBreed,
+    );
+    await saveIdentityLocally(updated);
+    return score;
+  }
+
+  Future<bool> detectSiblingDuplicates(IdentityModel model) async {
+    String? newHash = await _computePhotoHash(model.photoUrl);
+    bool found = false;
+    for (final other in localBox.values) {
+      if (other.animalId == model.animalId) continue;
+      if (model.microchipNumber != null &&
+          other.microchipNumber == model.microchipNumber) {
+        found = true;
+        break;
+      }
+      if (newHash != null) {
+        final otherHash = await _computePhotoHash(other.photoUrl);
+        if (otherHash != null && otherHash == newHash) {
+          found = true;
+          break;
+        }
+      }
+    }
+    final updated = IdentityModel(
+      animalId: model.animalId,
+      microchipNumber: model.microchipNumber,
+      photoUrl: model.photoUrl,
+      status: model.status,
+      legalStatus: model.legalStatus,
+      verifiedByIA: model.verifiedByIA,
+      hasPublicQR: model.hasPublicQR,
+      history: model.history,
+      lastUpdate: model.lastUpdate,
+      aiScore: model.aiScore,
+      verifiedBreed: found,
+    );
+    await saveIdentityLocally(updated);
+    return found;
+  }
+
+  Future<Uint8List> signIdentityPdf(Uint8List pdfData, String signerId) async {
+    final signer = IdentitySignatureService();
+    return signer.signPdf(pdfData, signerId);
+  }
+
+  Future<String?> _computePhotoHash(String? path) async {
+    if (path == null) return null;
+    final file = File(path);
+    if (!await file.exists()) return null;
+    return StorageOptimizer.computeHash(file);
   }
 }

--- a/lib/modules/identite/services/identity_signature_service.dart
+++ b/lib/modules/identite/services/identity_signature_service.dart
@@ -1,0 +1,13 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:crypto/crypto.dart';
+
+/// Simple service to append a digital signature to PDF data.
+class IdentitySignatureService {
+  /// Signs [pdfData] with a SHA-256 hash using [signerId].
+  Uint8List signPdf(Uint8List pdfData, String signerId) {
+    final digest = sha256.convert(<int>[...pdfData, ...utf8.encode(signerId)]);
+    final signature = utf8.encode('\nSignedBy:$signerId:${digest.toString()}');
+    return Uint8List.fromList([...pdfData, ...signature]);
+  }
+}

--- a/test/identite/unit/identity_model_test.dart
+++ b/test/identite/unit/identity_model_test.dart
@@ -13,5 +13,7 @@ void main() {
 
     expect(deserialized.animalId, equals('abc123'));
     expect(deserialized.verifiedByIA, isFalse);
+    expect(deserialized.aiScore, equals(0.0));
+    expect(deserialized.verifiedBreed, isFalse);
   });
 }

--- a/test/identite/unit/identity_service_test.dart
+++ b/test/identite/unit/identity_service_test.dart
@@ -21,4 +21,44 @@ void main() {
 
     verify(mockBox.put('abc123', identity)).called(1);
   });
+
+  test('computeCompletionScore stores aiScore in model', () async {
+    final mockBox = MockBox();
+    final service = IdentityService(localBox: mockBox);
+    final model = IdentityModel(
+      animalId: 'a1',
+      microchipNumber: '1',
+      photoUrl: 'p',
+      status: 'ok',
+      legalStatus: 'dog',
+    );
+    when(mockBox.put(any, any)).thenAnswer((_) async {});
+
+    final score = await service.computeCompletionScore(model);
+
+    final saved =
+        verify(mockBox.put('a1', captureAny)).captured.single as IdentityModel;
+    expect(saved.aiScore, closeTo(1.0, 0.01));
+    expect(score, closeTo(1.0, 0.01));
+  });
+
+  test('detectSiblingDuplicates sets verifiedBreed when duplicate found',
+      () async {
+    final mockBox = MockBox();
+    final existing = IdentityModel(
+      animalId: 'old',
+      microchipNumber: 'dup',
+    );
+    when(mockBox.values).thenReturn([existing]);
+    final service = IdentityService(localBox: mockBox);
+    final model = IdentityModel(animalId: 'new', microchipNumber: 'dup');
+    when(mockBox.put(any, any)).thenAnswer((_) async {});
+
+    final result = await service.detectSiblingDuplicates(model);
+
+    final saved =
+        verify(mockBox.put('new', captureAny)).captured.single as IdentityModel;
+    expect(saved.verifiedBreed, isTrue);
+    expect(result, isTrue);
+  });
 }

--- a/test/identite/unit/identity_signature_service_test.dart
+++ b/test/identite/unit/identity_signature_service_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../../test_config.dart';
+import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
+import 'dart:typed_data';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('signPdf appends signature data', () {
+    final service = IdentitySignatureService();
+    final data = Uint8List.fromList([1, 2, 3]);
+    final signed = service.signPdf(data, 'user');
+    expect(signed.length, greaterThan(data.length));
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -7,6 +7,7 @@
 | test/identite/unit/identity_reminder_service_test.dart | unit | package:anisphere/modules/identite/services/identity_reminder_service.dart | ✅ |
 | test/identite/unit/legal_status_service_test.dart | unit | package:anisphere/modules/identite/services/legal_status_service.dart | ✅ |
 | test/identite/unit/identity_service_test.dart | unit | package:anisphere/modules/identite/services/identity_service.dart | ✅ |
+| test/identite/unit/identity_signature_service_test.dart | unit | package:anisphere/modules/identite/services/identity_signature_service.dart | ✅ |
 | test/identite/unit/identity_verification_service_test.dart | unit | package:anisphere/modules/identite/services/identity_verification_service.dart | ✅ |
 | test/identite/unit/qr_generator_service_test.dart | unit | package:anisphere/modules/identite/services/qr_generator_service.dart | ✅ |
 | test/identite/unit/ocr_icad_service_test.dart | unit | package:anisphere/modules/identite/services/ocr_icad_service.dart | ✅ |


### PR DESCRIPTION
## Summary
- store AI score and breed verification in `IdentityModel`
- add PDF signing helper `IdentitySignatureService`
- implement AI scoring, duplicate detection and PDF signing in `IdentityService`
- add unit tests for new features
- track tests in `test_tracker.md`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68566c86648c8320a36b6c01cfa4769d