### PR TITLE
Fix localization conflicts and add missing keys

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -45,4 +45,13 @@
   ,"duplicate_animal_warning": "الحيوان موجود بالفعل"
   ,"duplicate_photo_warning": "الصورة موجودة بالفعل"
   ,"photo_timeline_title": "الجدول الزمني للصور"
+  ,"identitiesRegistered": "الهويات المسجلة"
+  ,"noHealthTracking": "لا يوجد تتبع صحي جارٍ"
+  ,"healthTrackingSummary": "حيوانات تحت المتابعة الصحية"
+  ,"noTrainingStarted": "لم يبدأ أي تدريب"
+  ,"trainingInProgress": "حيوانات قيد التدريب"
+  ,"trainingAvailableFor": "التدريب متاح لـ"
+  ,"noAnimalForTraining": "لا يوجد حيوان مسجل للتدريب"
+  ,"aiSummaryUndefined": "ملخص الذكاء الاصطناعي غير محدد"
+  ,"noActiveModule": "لا توجد وحدة نشطة"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -45,4 +45,13 @@
   ,"duplicate_animal_warning": "Animal already exists"
   ,"duplicate_photo_warning": "Photo already exists"
   ,"photo_timeline_title": "Photo Timeline"
+  ,"identitiesRegistered": "registrierte Identitäten"
+  ,"noHealthTracking": "Kein Gesundheitstracking aktiv"
+  ,"healthTrackingSummary": "Tiere im Gesundheitstracking"
+  ,"noTrainingStarted": "Kein Training gestartet"
+  ,"trainingInProgress": "Tiere im Training"
+  ,"trainingAvailableFor": "Training verfügbar für"
+  ,"noAnimalForTraining": "Kein Tier für das Training registriert"
+  ,"aiSummaryUndefined": "KI-Zusammenfassung nicht definiert"
+  ,"noActiveModule": "Kein aktives Modul"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -34,7 +34,6 @@
   ,"backup_error": "Error during backup."
   ,"restore_success": "Restore successful."
   ,"restore_error": "Error during restore."
-<<<<<<< HEAD
   ,"ai_score": "AI score"
   ,"badge_state": "Badge"
   ,"timeline_photos": "Timeline photos"
@@ -42,8 +41,6 @@
   ,"import_pdf": "Import PDF"
   ,"duplicate_alert": "Possible duplicate detected"
   ,"identity_onboarding_message": "Manage your animal identity here. Swipe to change animal."
-=======
-  ,"ai_score": "AI Score"
   ,"breeder_name": "Breeder name"
   ,"breeder_email": "Breeder email"
   ,"breeder_phone": "Breeder phone"
@@ -54,5 +51,13 @@
   ,"duplicate_animal_warning": "Animal already exists"
   ,"duplicate_photo_warning": "Photo already exists"
   ,"photo_timeline_title": "Photo Timeline"
->>>>>>> codex/mettre-à-jour-les-fichiers-de-localisation
+  ,"identitiesRegistered": "identities registered"
+  ,"noHealthTracking": "No health tracking in progress"
+  ,"healthTrackingSummary": "animals tracked for health"
+  ,"noTrainingStarted": "No training started"
+  ,"trainingInProgress": "animals in training"
+  ,"trainingAvailableFor": "Training available for"
+  ,"noAnimalForTraining": "No animal registered for training"
+  ,"aiSummaryUndefined": "AI summary not defined"
+  ,"noActiveModule": "No active module"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -45,4 +45,13 @@
   ,"duplicate_animal_warning": "El animal ya existe"
   ,"duplicate_photo_warning": "La foto ya existe"
   ,"photo_timeline_title": "Cronología de fotos"
+  ,"identitiesRegistered": "identidades registradas"
+  ,"noHealthTracking": "No hay seguimiento de salud en curso"
+  ,"healthTrackingSummary": "animales con seguimiento de salud"
+  ,"noTrainingStarted": "No se inició ningún entrenamiento"
+  ,"trainingInProgress": "animales en entrenamiento"
+  ,"trainingAvailableFor": "Adiestramiento disponible para"
+  ,"noAnimalForTraining": "Ningún animal registrado para el adiestramiento"
+  ,"aiSummaryUndefined": "Resumen de IA no definido"
+  ,"noActiveModule": "Ningún módulo activo"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -35,14 +35,12 @@
   ,"restore_success": "Restauration réussie."
   ,"restore_error": "Erreur lors de la restauration."
   ,"ai_score": "Score IA"
-<<<<<<< HEAD
   ,"badge_state": "Badge"
   ,"timeline_photos": "Photos chronologiques"
   ,"import_icad": "Import I-CAD express"
   ,"import_pdf": "Importer PDF"
   ,"duplicate_alert": "Doublon potentiel détecté"
   ,"identity_onboarding_message": "Gérez l'identité de votre animal ici. Glissez pour changer d'animal."
-=======
   ,"breeder_name": "Nom de l'éleveur"
   ,"breeder_email": "Email de l'éleveur"
   ,"breeder_phone": "Téléphone de l'éleveur"
@@ -53,5 +51,13 @@
   ,"duplicate_animal_warning": "L'animal existe déjà"
   ,"duplicate_photo_warning": "La photo existe déjà"
   ,"photo_timeline_title": "Timeline photo"
->>>>>>> codex/mettre-à-jour-les-fichiers-de-localisation
+  ,"identitiesRegistered": "identités enregistrées"
+  ,"noHealthTracking": "Aucun suivi de santé en cours"
+  ,"healthTrackingSummary": "animaux suivis en santé"
+  ,"noTrainingStarted": "Aucun apprentissage lancé"
+  ,"trainingInProgress": "animaux en apprentissage"
+  ,"trainingAvailableFor": "Dressage disponible pour"
+  ,"noAnimalForTraining": "Aucun animal enregistré pour le dressage"
+  ,"aiSummaryUndefined": "Résumé IA non défini"
+  ,"noActiveModule": "Aucun module actif"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -45,4 +45,13 @@
   ,"duplicate_animal_warning": "Animale già esistente"
   ,"duplicate_photo_warning": "Foto già esistente"
   ,"photo_timeline_title": "Cronologia foto"
+  ,"identitiesRegistered": "identità registrate"
+  ,"noHealthTracking": "Nessun monitoraggio della salute in corso"
+  ,"healthTrackingSummary": "animali monitorati per la salute"
+  ,"noTrainingStarted": "Nessun addestramento avviato"
+  ,"trainingInProgress": "animali in addestramento"
+  ,"trainingAvailableFor": "Addestramento disponibile per"
+  ,"noAnimalForTraining": "Nessun animale registrato per l'addestramento"
+  ,"aiSummaryUndefined": "Riepilogo IA non definito"
+  ,"noActiveModule": "Nessun modulo attivo"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -45,4 +45,13 @@
   ,"duplicate_animal_warning": "動物は既に存在します"
   ,"duplicate_photo_warning": "写真は既に存在します"
   ,"photo_timeline_title": "写真タイムライン"
+  ,"identitiesRegistered": "登録された識別"
+  ,"noHealthTracking": "健康追跡は行われていません"
+  ,"healthTrackingSummary": "匹が健康追跡中"
+  ,"noTrainingStarted": "トレーニングが開始されていません"
+  ,"trainingInProgress": "匹がトレーニング中"
+  ,"trainingAvailableFor": "トレーニング可能数"
+  ,"noAnimalForTraining": "トレーニング用の登録動物がいません"
+  ,"aiSummaryUndefined": "AI概要が未定義"
+  ,"noActiveModule": "有効なモジュールがありません"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -294,7 +294,6 @@ abstract class AppLocalizations {
   /// **'Manage your animal\'s identity'**
   String get identityModuleDescription;
 
-<<<<<<< HEAD
   /// No description provided for @identitiesRegistered.
   ///
   /// In en, this message translates to:
@@ -348,7 +347,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No active module'**
   String get noActiveModule;
-=======
+
   /// No description provided for @settings_title.
   ///
   /// In en, this message translates to:
@@ -378,7 +377,93 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error during restore.'**
   String get restore_error;
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
+
+  /// No description provided for @ai_score.
+  String get ai_score;
+
+  /// No description provided for @badge_state.
+  String get badge_state;
+
+  /// No description provided for @timeline_photos.
+  String get timeline_photos;
+
+  /// No description provided for @import_icad.
+  String get import_icad;
+
+  /// No description provided for @import_pdf.
+  String get import_pdf;
+
+  /// No description provided for @duplicate_alert.
+  String get duplicate_alert;
+
+  /// No description provided for @identity_onboarding_message.
+  String get identity_onboarding_message;
+
+  /// No description provided for @breeder_name.
+  String get breeder_name;
+
+  /// No description provided for @breeder_email.
+  String get breeder_email;
+
+  /// No description provided for @breeder_phone.
+  String get breeder_phone;
+
+  /// No description provided for @onboarding_title.
+  String get onboarding_title;
+
+  /// No description provided for @onboarding_subtitle.
+  String get onboarding_subtitle;
+
+  /// No description provided for @onboarding_skip.
+  String get onboarding_skip;
+
+  /// No description provided for @onboarding_next.
+  String get onboarding_next;
+
+  /// No description provided for @duplicate_animal_warning.
+  String get duplicate_animal_warning;
+
+  /// No description provided for @duplicate_photo_warning.
+  String get duplicate_photo_warning;
+
+  /// No description provided for @photo_timeline_title.
+  String get photo_timeline_title;
+
+  /// No description provided for @local_share_success.
+  String get local_share_success;
+
+  /// No description provided for @cloud_share_success.
+  String get cloud_share_success;
+
+  /// No description provided for @identity_access_error.
+  String get identity_access_error;
+
+  /// No description provided for @no_animal_available.
+  String get no_animal_available;
+
+  /// No description provided for @no_animal_recorded.
+  String get no_animal_recorded;
+
+  /// No description provided for @save_error.
+  String get save_error;
+
+  /// No description provided for @generic_error.
+  String get generic_error;
+
+  /// No description provided for @ocr_feature_coming.
+  String get ocr_feature_coming;
+
+  /// No description provided for @export_feature_coming.
+  String get export_feature_coming;
+
+  /// No description provided for @qr_scanned.
+  String get qr_scanned;
+
+  /// No description provided for @privacy_settings_coming.
+  String get privacy_settings_coming;
+
+  /// No description provided for @stats_coming.
+  String get stats_coming;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -100,7 +100,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'الهويات المسجلة';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get noActiveModule => 'لا توجد وحدة نشطة';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -100,7 +100,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'registrierte Identitäten';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Kein aktives Modul';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -100,7 +100,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'identities registered';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noActiveModule => 'No active module';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -100,7 +100,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get identityModuleDescription => 'Gérer l\'identité de l\'animal';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'identités enregistrées';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Aucun module actif';
-=======
+
+  @override
   String get settings_title => 'Paramètres';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get restore_error => 'Erreur lors de la restauration.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -100,7 +100,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'identità registrate';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Nessun modulo attivo';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -99,7 +99,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => '登録された識別';
 
   @override
@@ -125,7 +124,8 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get noActiveModule => '有効なモジュールがありません';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -139,5 +139,4 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -100,7 +100,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'identidades registradas';
 
   @override
@@ -126,7 +125,8 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Nenhum módulo ativo';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -140,5 +140,4 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -100,7 +100,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => 'зарегистрированные идентичности';
 
   @override
@@ -127,7 +126,8 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Нет активных модулей';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -141,5 +141,4 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -99,7 +99,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get identityModuleDescription => 'Manage your animal\'s identity';
 
   @override
-<<<<<<< HEAD
   String get identitiesRegistered => '已登记身份';
 
   @override
@@ -125,7 +124,8 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get noActiveModule => '没有激活的模块';
-=======
+
+  @override
   String get settings_title => 'Settings';
 
   @override
@@ -139,5 +139,4 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get restore_error => 'Error during restore.';
->>>>>>> codex/mettre-à-jour-docs/suivi_noyau.md
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -56,4 +56,13 @@
   ,"duplicate_animal_warning": "O animal já existe"
   ,"duplicate_photo_warning": "A foto já existe"
   ,"photo_timeline_title": "Linha do tempo de fotos"
+  ,"identitiesRegistered": "identidades registradas"
+  ,"noHealthTracking": "Sem acompanhamento de saúde em andamento"
+  ,"healthTrackingSummary": "animais em acompanhamento de saúde"
+  ,"noTrainingStarted": "Nenhum treinamento iniciado"
+  ,"trainingInProgress": "animais em treinamento"
+  ,"trainingAvailableFor": "Treinamento disponível para"
+  ,"noAnimalForTraining": "Nenhum animal registrado para treinamento"
+  ,"aiSummaryUndefined": "Resumo de IA não definido"
+  ,"noActiveModule": "Nenhum módulo ativo"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -56,4 +56,13 @@
   ,"duplicate_animal_warning": "Животное уже существует"
   ,"duplicate_photo_warning": "Фото уже существует"
   ,"photo_timeline_title": "Хронология фото"
+  ,"identitiesRegistered": "зарегистрированные идентичности"
+  ,"noHealthTracking": "Отсутствует отслеживание здоровья"
+  ,"healthTrackingSummary": "животных под наблюдением здоровья"
+  ,"noTrainingStarted": "Тренировка не начата"
+  ,"trainingInProgress": "животных на тренировке"
+  ,"trainingAvailableFor": "Дрессировка доступна для"
+  ,"noAnimalForTraining": "Нет животных, зарегистрированных для дрессировки"
+  ,"aiSummaryUndefined": "ИИ-резюме не определено"
+  ,"noActiveModule": "Нет активных модулей"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -56,4 +56,13 @@
   ,"duplicate_animal_warning": "动物已存在"
   ,"duplicate_photo_warning": "照片已存在"
   ,"photo_timeline_title": "照片时间线"
+  ,"identitiesRegistered": "已登记身份"
+  ,"noHealthTracking": "没有进行健康跟踪"
+  ,"healthTrackingSummary": "只动物健康跟踪中"
+  ,"noTrainingStarted": "尚未开始训练"
+  ,"trainingInProgress": "只动物训练中"
+  ,"trainingAvailableFor": "可训练数量"
+  ,"noAnimalForTraining": "没有登记用于训练的动物"
+  ,"aiSummaryUndefined": "AI 摘要未定义"
+  ,"noActiveModule": "没有激活的模块"
 }


### PR DESCRIPTION
## Summary
- merge localization conflict markers across `.arb` files
- add identity and backup/restore strings for all languages
- expand `AppLocalizations` with new getters used by modules
- resolve conflict markers in generated localization Dart files

## Testing
- `flutter gen-l10n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566fd8f9c883209d220dbcc8931c8f