### PR TITLE
Fix merge conflicts in identity signature test

### DIFF
--- a/test/identite/unit/identity_signature_service_test.dart
+++ b/test/identite/unit/identity_signature_service_test.dart
@@ -1,25 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-<<<<<<< HEAD
-import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
-import 'dart:typed_data';
-=======
 import 'package:anisphere/modules/identite/models/identity_model.dart';
 import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-<<<<<<< HEAD
-  test('signPdf appends signature data', () {
-    final service = IdentitySignatureService();
-    final data = Uint8List.fromList([1, 2, 3]);
-    final signed = service.signPdf(data, 'user');
-    expect(signed.length, greaterThan(data.length));
-=======
   test('sign and verify return true for same data', () {
     final service = IdentitySignatureService('secret');
     final model = IdentityModel(animalId: 'a');
@@ -30,6 +18,5 @@ void main() {
     other['status'] = 'changed';
     final changed = IdentityModel.fromMap(other);
     expect(service.verify(changed, sig), isFalse);
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
   });
 }


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `identity_signature_service_test.dart`
- keep only the sign/verify test variant

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856750275148320a76e677721fe0652