### PR TITLE
Implement HMAC signing service

### DIFF
--- a/lib/modules/identite/services/identity_signature_service.dart
+++ b/lib/modules/identite/services/identity_signature_service.dart
@@ -1,24 +1,23 @@
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
-import '../models/identity_model.dart';
+import 'dart:typed_data';
 
-/// Offline service signing identity data using HMAC-SHA256.
+/// Offline service for signing data using HMAC-SHA256.
 class IdentitySignatureService {
   final List<int> _key;
 
   IdentitySignatureService(String secret) : _key = utf8.encode(secret);
 
-  /// Generates a signature string for the given identity model.
-  String sign(IdentityModel model) {
+  /// Generates a signature string for the provided [data].
+  String sign(Uint8List data) {
     final hmac = Hmac(sha256, _key);
-    final data = utf8.encode(model.toMap().toString());
     return hmac.convert(data).toString();
   }
 
-  /// Verifies that [signature] matches the provided [model].
-  bool verify(IdentityModel model, String signature) {
-    final expected = sign(model);
+  /// Verifies that [signature] matches the given [data].
+  bool verify(Uint8List data, String signature) {
+    final expected = sign(data);
     return _constantTimeEquals(expected, signature);
   }
 

--- a/lib/modules/noyau/screens/animal_screen.dart
+++ b/lib/modules/noyau/screens/animal_screen.dart
@@ -58,8 +58,8 @@ class AnimalScreen extends StatelessWidget {
                       try {
                         final identityBox =
                             Hive.box<IdentityModel>('identityBox');
-                        final identityService =
-                            IdentityService(localBox: identityBox);
+                        final identityService = IdentityService(
+                            localBox: identityBox, signatureSecret: 'secret');
                         Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (context) => IdentityScreen(

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -67,7 +67,8 @@ class _ModulesScreenState extends State<ModulesScreen> {
       }
       final animal = box.values.first;
       final identityBox = Hive.box<IdentityModel>('identityBox');
-      final identityService = IdentityService(localBox: identityBox);
+      final identityService =
+          IdentityService(localBox: identityBox, signatureSecret: 'secret');
       if (!mounted) return;
       Navigator.of(context).push(
         MaterialPageRoute(
@@ -134,7 +135,8 @@ class _ModulesScreenState extends State<ModulesScreen> {
       }
 
       final identityBox = Hive.box<IdentityModel>('identityBox');
-      final identityService = IdentityService(localBox: identityBox);
+      final identityService =
+          IdentityService(localBox: identityBox, signatureSecret: 'secret');
 
       if (!mounted) return;
       Navigator.of(context).push(

--- a/test/identite/unit/identity_service_test.dart
+++ b/test/identite/unit/identity_service_test.dart
@@ -13,7 +13,7 @@ void main() {
   });
   test('saveIdentityLocally should store model by animalId', () async {
     final mockBox = MockBox();
-    final service = IdentityService(localBox: mockBox);
+    final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
 
     final identity = IdentityModel(animalId: 'abc123');
 
@@ -24,7 +24,7 @@ void main() {
 
   test('computeCompletionScore stores aiScore in model', () async {
     final mockBox = MockBox();
-    final service = IdentityService(localBox: mockBox);
+    final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
     final model = IdentityModel(
       animalId: 'a1',
       microchipNumber: '1',
@@ -50,7 +50,7 @@ void main() {
       microchipNumber: 'dup',
     );
     when(mockBox.values).thenReturn([existing]);
-    final service = IdentityService(localBox: mockBox);
+    final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
     final model = IdentityModel(animalId: 'new', microchipNumber: 'dup');
     when(mockBox.put(any, any)).thenAnswer((_) async {});
 

--- a/test/identite/unit/identity_signature_service_test.dart
+++ b/test/identite/unit/identity_signature_service_test.dart
@@ -1,35 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-<<<<<<< HEAD
-import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
 import 'dart:typed_data';
-=======
-import 'package:anisphere/modules/identite/models/identity_model.dart';
 import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-<<<<<<< HEAD
-  test('signPdf appends signature data', () {
-    final service = IdentitySignatureService();
-    final data = Uint8List.fromList([1, 2, 3]);
-    final signed = service.signPdf(data, 'user');
-    expect(signed.length, greaterThan(data.length));
-=======
   test('sign and verify return true for same data', () {
     final service = IdentitySignatureService('secret');
-    final model = IdentityModel(animalId: 'a');
-    final sig = service.sign(model);
+    final data = Uint8List.fromList([1, 2, 3]);
+    final sig = service.sign(data);
 
-    expect(service.verify(model, sig), isTrue);
-    final other = model.toMap();
-    other['status'] = 'changed';
-    final changed = IdentityModel.fromMap(other);
-    expect(service.verify(changed, sig), isFalse);
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
+    expect(service.verify(data, sig), isTrue);
+    expect(service.verify(Uint8List.fromList([3, 2, 1]), sig), isFalse);
   });
 }

--- a/test/identite/widget/identity_screen_test.dart
+++ b/test/identite/widget/identity_screen_test.dart
@@ -19,7 +19,7 @@ void main() {
   });
   testWidgets('IdentityScreen displays score and import button',
       (WidgetTester tester) async {
-    final service = IdentityService(localBox: MockBox());
+    final service = IdentityService(localBox: MockBox(), signatureSecret: 'secret');
     final animal = AnimalModel(
       id: 'test',
       name: 'Test',


### PR DESCRIPTION
## Summary
- implement `IdentitySignatureService` with generic HMAC sign/verify
- require a `signatureSecret` in `IdentityService`
- sign PDFs using HMAC in `IdentityService.signIdentityPdf`
- update screen code to provide a secret
- adapt unit tests

## Testing
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*
- `flutter test test/identite/unit/identity_signature_service_test.dart -r compact` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685675075274832096ddc15299453097