### PR TITLE
Fix identity signature test and widget

### DIFF
--- a/lib/modules/identite/widgets/identity_score_widget.dart
+++ b/lib/modules/identite/widgets/identity_score_widget.dart
@@ -1,15 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:anisphere/l10n/app_localizations.dart';
 
-<<<<<<< HEAD
-/// Widget displaying the AI score for an animal identity.
-class IdentityScoreWidget extends StatelessWidget {
-  final double score; // 0-100
-=======
 /// Displays a progress bar for the identity completeness score.
 class IdentityScoreWidget extends StatelessWidget {
   final double score;
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
   const IdentityScoreWidget({super.key, required this.score});
 
   @override
@@ -18,19 +12,11 @@ class IdentityScoreWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-<<<<<<< HEAD
-        Text(l10n.ai_score, style: Theme.of(context).textTheme.titleMedium),
-        const SizedBox(height: 4),
-        LinearProgressIndicator(value: score / 100),
-        const SizedBox(height: 4),
-        Text('${score.toStringAsFixed(0)}/100'),
-=======
         Text(
           '${l10n.identity_summary_title} score: ${score.toStringAsFixed(0)}%',
         ),
         const SizedBox(height: 4),
         LinearProgressIndicator(value: score / 100),
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
       ],
     );
   }

--- a/test/identite/unit/identity_signature_service_test.dart
+++ b/test/identite/unit/identity_signature_service_test.dart
@@ -1,35 +1,23 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-<<<<<<< HEAD
-import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
-import 'dart:typed_data';
-=======
 import 'package:anisphere/modules/identite/models/identity_model.dart';
 import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
 
 void main() {
   setUpAll(() async {
     await initTestEnv();
   });
 
-<<<<<<< HEAD
-  test('signPdf appends signature data', () {
-    final service = IdentitySignatureService();
-    final data = Uint8List.fromList([1, 2, 3]);
-    final signed = service.signPdf(data, 'user');
-    expect(signed.length, greaterThan(data.length));
-=======
   test('sign and verify return true for same data', () {
     final service = IdentitySignatureService('secret');
     final model = IdentityModel(animalId: 'a');
     final sig = service.sign(model);
 
     expect(service.verify(model, sig), isTrue);
-    final other = model.toMap();
-    other['status'] = 'changed';
-    final changed = IdentityModel.fromMap(other);
+
+    final modified = model.toMap();
+    modified['status'] = 'changed';
+    final changed = IdentityModel.fromMap(modified);
     expect(service.verify(changed, sig), isFalse);
->>>>>>> codex/créer-services-et-widgets-sous-lib/modules/identite
   });
 }


### PR DESCRIPTION
## Summary
- resolve merge conflicts in `identity_signature_service_test.dart`
- clean up `IdentityScoreWidget` and remove conflict markers

## Testing
- `flutter test` *(fails: /workspace/anisphere/flutter/bin/flutter: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856750be50c8320ba46a2d4bdc802a0