### PR TITLE
Add user profile model unit test

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -22,6 +22,7 @@ Ajoutez vos nouvelles entrées dans `test/test_tracker.md` puis lancez `dart scr
 | test/noyau/unit/user_model_test.dart | unit | package:anisphere/modules/noyau/models/user_model.dart | ✅ |
 | test/noyau/unit/animal_model.g_test.dart | unit | package:anisphere/modules/noyau/models/animal_model.g.dart | ✅ |
 | test/noyau/unit/user_model.g_test.dart | unit | package:anisphere/modules/noyau/models/user_model.g.dart | ✅ |
+| test/noyau/unit/user_profile_model_test.dart | unit | package:anisphere/modules/noyau/models/user_profile_model.dart | ✅ |
 | test/noyau/unit/modules_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_service.dart | ✅ |
 | test/noyau/unit/auth_service_test.dart | unit | package:anisphere/modules/noyau/services/auth_service.dart | ✅ |
 | test/noyau/unit/offline_sync_queue.g_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.g.dart | ✅ |

--- a/test/noyau/unit/user_profile_model_test.dart
+++ b/test/noyau/unit/user_profile_model_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+@Skip('Temporarily disabled')
+import '../../test_config.dart';
+import 'package:anisphere/modules/noyau/models/user_profile_model.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  test('copyWith returns new instance with updated fields', () {
+    final profile = UserProfileModel(
+      id: 'u1',
+      name: 'Test',
+      email: 'e@test.com',
+      phone: '123',
+      profilePicture: '',
+      profession: 'dev',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 2),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+      langue: 'fr',
+      birthDate: DateTime(2000, 1, 1),
+      lastName: 'Doe',
+      firstName: 'John',
+      birthPlace: 'City',
+      unit: 'Unit',
+      company: 'Company',
+      group: 'Group',
+      nigend: '123',
+      proValidated: true,
+    );
+
+    final copy = profile.copyWith(firstName: 'Jane', proValidated: false);
+
+    expect(copy, isNot(same(profile)));
+    expect(copy.firstName, 'Jane');
+    expect(copy.proValidated, isFalse);
+    expect(copy.lastName, profile.lastName);
+    expect(copy.id, profile.id);
+  });
+
+  test('toJson/fromJson round trip', () {
+    final profile = UserProfileModel(
+      id: 'u1',
+      name: 'Test',
+      email: 'e@test.com',
+      phone: '123',
+      profilePicture: '',
+      profession: 'dev',
+      ownedSpecies: const {},
+      ownedAnimals: const [],
+      preferences: const {},
+      moduleRoles: const {},
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 2),
+      activeModules: const [],
+      role: 'user',
+      iaPremium: false,
+      langue: 'fr',
+      birthDate: DateTime(2000, 1, 1),
+      lastName: 'Doe',
+      firstName: 'John',
+      birthPlace: 'City',
+      unit: 'Unit',
+      company: 'Company',
+      group: 'Group',
+      nigend: '123',
+      proValidated: true,
+    );
+
+    final json = profile.toJson();
+    final restored = UserProfileModel.fromJson(json);
+
+    expect(restored.firstName, profile.firstName);
+    expect(restored.lastName, profile.lastName);
+    expect(restored.birthPlace, profile.birthPlace);
+    expect(restored.nigend, profile.nigend);
+    expect(restored.birthDate, profile.birthDate);
+  });
+}

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -22,6 +22,7 @@ Ajoutez ici les nouveaux tests puis exécutez `dart scripts/update_test_tracker.
 | test/noyau/unit/user_model_test.dart | unit | package:anisphere/modules/noyau/models/user_model.dart | ⏭ |
 | test/noyau/unit/animal_model.g_test.dart | unit | package:anisphere/modules/noyau/models/animal_model.g.dart | ⏭ |
 | test/noyau/unit/user_model.g_test.dart | unit | package:anisphere/modules/noyau/models/user_model.g.dart | ⏭ |
+| test/noyau/unit/user_profile_model_test.dart | unit | package:anisphere/modules/noyau/models/user_profile_model.dart | ⏭ |
 | test/noyau/unit/modules_service_test.dart | unit | package:anisphere/modules/noyau/services/modules_service.dart | ⏭ |
 | test/noyau/unit/auth_service_test.dart | unit | package:anisphere/modules/noyau/services/auth_service.dart | ⏭ |
 | test/noyau/unit/offline_sync_queue.g_test.dart | unit | package:anisphere/modules/noyau/services/offline_sync_queue.g.dart | ⏭ |


### PR DESCRIPTION
## Summary
- add unit tests for `UserProfileModel`
- track the new test in `test_tracker.md`

## Testing
- `flutter test test/noyau/unit/user_profile_model_test.dart` *(fails: command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685689d799348320b2912cfe5a8207f5