### PR TITLE
Add Firestore upload for VideoLogsCollector

### DIFF
--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -134,3 +134,4 @@ Ajoutez vos nouvelles entrées dans `test/test_tracker.md` puis lancez `dart scr
 | test/noyau/unit/video_analysis_service_test.dart | unit | package:anisphere/modules/noyau/services/video_analysis_service.dart | ✅ |
 | test/noyau/widget/biometric_guard_test.dart | widget | package:anisphere/modules/noyau/widgets/biometric_guard.dart | ✅ |
 | test/noyau/widget/gps_screen_test.dart | widget | package:anisphere/modules/noyau/screens/gps_screen.dart | ✅ |
+| test/noyau/unit/video_logs_collector_test.dart | unit | package:anisphere/modules/noyau/services/video_logs_collector.dart | ✅ |

--- a/lib/modules/noyau/services/video_logs_collector.dart
+++ b/lib/modules/noyau/services/video_logs_collector.dart
@@ -1,8 +1,47 @@
 // Copilot Prompt : VideoLogsCollector sends anonymized results of video analysis to logs_ia/.
 // Videos themselves are never persisted in Firebase or any cloud storage.
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import 'anonymization_service.dart';
+import 'offline_sync_queue.dart';
+
+/// Collects anonymized video analysis results and uploads them to Firestore.
 class VideoLogsCollector {
+  final FirebaseFirestore firestore;
+  final AnonymizationService _anonymizer;
+
+  VideoLogsCollector({
+    FirebaseFirestore? firestoreInstance,
+    AnonymizationService? anonymizer,
+  })  : firestore = firestoreInstance ?? FirebaseFirestore.instance,
+        _anonymizer = anonymizer ?? const AnonymizationService();
+
+  /// Uploads an anonymized result to `logs_ia/`.
+  ///
+  /// If the upload fails (typically offline), the entry is queued via
+  /// [OfflineSyncQueue].
   Future<void> uploadResult(Map<String, dynamic> result) async {
-    // TODO: implement Firestore upload to logs_ia/.
+    final sanitized = _anonymizer.anonymizeMap(result, ['userId', 'animalId']);
+    final category = sanitized['module'] as String? ?? 'general';
+    final data = <String, dynamic>{
+      ...sanitized,
+      'timestamp': sanitized['timestamp'] ?? DateTime.now().toIso8601String(),
+    };
+
+    try {
+      await firestore
+          .collection('logs_ia')
+          .doc(category)
+          .collection('entries')
+          .add(data);
+      debugPrint('✅ Video log uploaded for $category');
+    } catch (e) {
+      debugPrint('❌ Video log upload failed, queued. $e');
+      await OfflineSyncQueue.addTask(
+        SyncTask(type: 'video_log', data: data, timestamp: DateTime.now()),
+      );
+    }
   }
 }

--- a/test/noyau/unit/video_logs_collector_test.dart
+++ b/test/noyau/unit/video_logs_collector_test.dart
@@ -1,25 +1,81 @@
-// Copilot Prompt : Test automatique généré pour video_logs_collector.dart (unit)
+// Tests for VideoLogsCollector
+import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 @Skip('Temporarily disabled')
+import 'package:hive/hive.dart';
+import 'package:mockito/mockito.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:anisphere/modules/noyau/services/video_logs_collector.dart';
+import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
+
 import '../../test_config.dart';
 
-class VideoLogsCollector {
-  final List<String> _logs = [];
-  void add(String log) => _logs.add(log);
-  List<String> get logs => List.unmodifiable(_logs);
-}
+class MockCollection extends Mock implements CollectionReference<Map<String, dynamic>> {}
+class MockDocument extends Mock implements DocumentReference<Map<String, dynamic>> {}
+class MockFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
-  setUpAll(() async {
+  late Directory tempDir;
+
+  setUp(() async {
     await initTestEnv();
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(SyncTaskAdapter());
+    await Hive.openBox<SyncTask>('offline_sync_queue');
   });
 
-  test('add stores logs', () {
-    final collector = VideoLogsCollector();
-    collector.add('start');
-    collector.add('stop');
-    expect(collector.logs.length, 2);
-    expect(collector.logs.first, 'start');
-    expect(collector.logs.last, 'stop');
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('offline_sync_queue');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('uploadResult stores anonymized log', () async {
+    final firestore = FakeFirebaseFirestore();
+    final collector = VideoLogsCollector(firestoreInstance: firestore);
+
+    final result = {
+      'module': 'training',
+      'type': 'jump',
+      'userId': 'u1',
+      'animalId': 'a1',
+      'data': {'score': 0.5},
+    };
+
+    await collector.uploadResult(result);
+
+    final snap = await firestore
+        .collection('logs_ia')
+        .doc('training')
+        .collection('entries')
+        .get();
+    expect(snap.docs.length, 1);
+    final stored = snap.docs.first.data();
+    expect(stored['type'], 'jump');
+    expect(stored['userId'], isNot('u1'));
+  });
+
+  test('uploadResult queues task on failure', () async {
+    final mockFirestore = MockFirestore();
+    final mockLogs = MockCollection();
+    final mockDoc = MockDocument();
+    final mockEntries = MockCollection();
+    when(mockFirestore.collection('logs_ia')).thenReturn(mockLogs);
+    when(mockLogs.doc(any)).thenReturn(mockDoc);
+    when(mockDoc.collection('entries')).thenReturn(mockEntries);
+    when(mockEntries.add(any)).thenThrow(Exception('fail'));
+
+    final collector = VideoLogsCollector(firestoreInstance: mockFirestore);
+
+    await collector.uploadResult({
+      'module': 'training',
+      'userId': 'u1',
+      'animalId': 'a1',
+    });
+
+    final tasks = await OfflineSyncQueue.getAllTasks();
+    expect(tasks.length, 1);
+    expect(tasks.first.type, 'video_log');
   });
 }

--- a/test/test_tracker.md
+++ b/test/test_tracker.md
@@ -129,3 +129,4 @@ Ajoutez ici les nouveaux tests puis exécutez `dart scripts/update_test_tracker.
 | test/noyau/unit/video_analysis_service_test.dart | unit | package:anisphere/modules/noyau/services/video_analysis_service.dart | ⏭ |
 | test/noyau/widget/biometric_guard_test.dart | widget | package:anisphere/modules/noyau/widgets/biometric_guard.dart | ⏭ |
 | test/noyau/widget/gps_screen_test.dart | widget | package:anisphere/modules/noyau/screens/gps_screen.dart | ⏭ |
+| test/noyau/unit/video_logs_collector_test.dart | unit | package:anisphere/modules/noyau/services/video_logs_collector.dart | ⏭ |


### PR DESCRIPTION
## Summary
- inject FirebaseFirestore into `VideoLogsCollector`
- upload anonymized logs to `logs_ia` and queue on failure
- add unit tests for log upload and offline fallback
- track new test in documentation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685689d92bbc8320ab2cb0a863806664