### PR TITLE
Inject NotificationService into HomeScreen

### DIFF
--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -6,6 +6,7 @@ Ce fichier est une vue d’ensemble condensée du projet AniSphère. Il permet d
 
 - [ ] Créer les `*SummaryCard` pour chaque module actif (santé, dressage, éducation, communauté, etc.) à afficher dans `home_screen.dart`
 - [x] Ajout widget profil utilisateur
+- [x] Intégration de `NotificationService` dans `HomeScreen`
 
 
 🔰 Statut actuel
@@ -139,3 +140,4 @@ suivi_[module].md → suivi fin par module
 
 - ✅ Mise à jour automatique des tâches le 2025-06-21
 - 📝 2025-07-20 : désactivation temporaire du support multilingue. L'application reste en français uniquement; les ressources `lib/l10n/` sont conservées pour une réactivation ultérieure.
+- ✅ Mise à jour automatique des tâches le 2025-07-21 (NotificationService intégré)

--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -13,10 +13,13 @@ import '../services/pro_validation_service.dart';
 import '../widgets/quick_actions_sheet.dart';
 import '../widgets/user_profile_summary_card.dart';
 import '../widgets/important_notifications_widget.dart';
+import '../services/notification_service.dart';
 import 'animal_form_screen.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  final NotificationService notificationService;
+
+  const HomeScreen({super.key, required this.notificationService});
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -93,15 +96,17 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
-  void _loadImportantNotifications() {
-    // TODO: replace with real data from notifications service
-    setState(() {
-      importantNotifications = [
-        'Rappel vermifuge dans 3 jours',
-        'Nouvelle mise à jour disponible',
-        'Votre profil est incomplet'
-      ];
-    });
+  Future<void> _loadImportantNotifications() async {
+    try {
+      final pending = await widget.notificationService.fetchPendingNotifications();
+      if (mounted) {
+        setState(() {
+          importantNotifications = pending;
+        });
+      }
+    } catch (e) {
+      debugPrint('❌ Erreur chargement notifications : $e');
+    }
   }
 
   Widget _buildModuleCard(ModuleSummary summary) {

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -31,12 +31,8 @@ class MainScreen extends StatefulWidget {
 class MainScreenState extends State<MainScreen> {
   int _selectedIndex = 0;
   IAScheduler? _scheduler;
-  static final List<Widget> _pages = <Widget>[
-    const HomeScreen(),
-    const ShareScreen(),
-    const ModulesScreen(),
-    const AnimalsScreen(),
-  ];
+  late final NotificationService _notificationService;
+  late final List<Widget> _pages;
   void _onItemTapped(int index) {
     setState(() {
       _selectedIndex = index;
@@ -46,6 +42,13 @@ class MainScreenState extends State<MainScreen> {
   @override
   void initState() {
     super.initState();
+    _notificationService = NotificationService();
+    _pages = [
+      HomeScreen(notificationService: _notificationService),
+      const ShareScreen(),
+      const ModulesScreen(),
+      const AnimalsScreen(),
+    ];
     // ⚙️ Planification IA dès que le widget est monté
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final user = Provider.of<UserProvider>(context, listen: false).user;
@@ -56,7 +59,7 @@ class MainScreenState extends State<MainScreen> {
       if (user != null) {
         final executor = IAExecutor(
           iaMaster: IAMaster.instance,
-          notificationService: NotificationService(),
+          notificationService: _notificationService,
           modulesService: ModulesService(),
           animalService: AnimalService(),
         );

--- a/lib/modules/noyau/services/notification_service.dart
+++ b/lib/modules/noyau/services/notification_service.dart
@@ -90,4 +90,16 @@ class NotificationService {
     await _notificationsPlugin.cancelAll();
     debugPrint("❌ Toutes les notifications supprimées.");
   }
+
+  /// 📝 Récupère les notifications en attente.
+  /// TODO: ajouter test
+  Future<List<String>> fetchPendingNotifications() async {
+    // 🔜 Cette méthode s'appuiera sur le stockage local/cloud
+    // pour retourner les notifications réelles encore non traitées.
+    return [
+      'Rappel vermifuge dans 3 jours',
+      'Nouvelle mise à jour disponible',
+      'Votre profil est incomplet',
+    ];
+  }
 }

--- a/test/noyau/unit/notification_service_test.dart
+++ b/test/noyau/unit/notification_service_test.dart
@@ -40,4 +40,10 @@ void main() {
     await NotificationService.cancelAll();
     expect(log.any((c) => c.method == 'cancelAll'), isTrue);
   });
+
+  test('fetchPendingNotifications returns list', () async {
+    final service = NotificationService();
+    final pending = await service.fetchPendingNotifications();
+    expect(pending, isNotEmpty);
+  });
 }

--- a/test/noyau/widget/home_screen_test.dart
+++ b/test/noyau/widget/home_screen_test.dart
@@ -10,11 +10,19 @@ import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/screens/home_screen.dart';
 import 'package:anisphere/modules/noyau/widgets/important_notifications_widget.dart';
+import 'package:anisphere/modules/noyau/services/notification_service.dart';
 
 import '../../test_config.dart';
 
 class _TestUserProvider extends UserProvider {
   _TestUserProvider() : super(UserService(skipHiveInit: true), AuthService());
+}
+
+class _FakeNotificationService extends NotificationService {
+  @override
+  Future<List<String>> fetchPendingNotifications() async {
+    return ['Test'];
+  }
 }
 
 void main() {
@@ -31,7 +39,9 @@ void main() {
           ChangeNotifierProvider<IAContextProvider>(
               create: (_) => IAContextProvider()),
         ],
-        child: const MaterialApp(home: HomeScreen()),
+        child: MaterialApp(
+          home: HomeScreen(notificationService: _FakeNotificationService()),
+        ),
       ),
     );
 
@@ -50,7 +60,9 @@ void main() {
           ChangeNotifierProvider<IAContextProvider>(
               create: (_) => IAContextProvider()),
         ],
-        child: const MaterialApp(home: HomeScreen()),
+        child: MaterialApp(
+          home: HomeScreen(notificationService: _FakeNotificationService()),
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- wire up `NotificationService` in `HomeScreen`
- build pages in `MainScreen` with the injected service
- expose `fetchPendingNotifications` in the service
- update widget and service unit tests
- refresh task tracker documentation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685689dbd92c8320af164ad8e9d92413