### PR TITLE
Fix localization merge conflicts

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -479,8 +479,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No active module'**
   String get noActiveModule;
-<<<<<<< HEAD
-=======
 
   /// No description provided for @share_title.
   ///
@@ -500,35 +498,6 @@ abstract class AppLocalizations {
   /// **'My Animals'**
   String get myAnimals_title;
 
-  /// No description provided for @settings_title.
-  ///
-  /// In en, this message translates to:
-  /// **'Settings'**
-  String get settings_title;
-
-  /// No description provided for @backup_success.
-  ///
-  /// In en, this message translates to:
-  /// **'Backup completed successfully.'**
-  String get backup_success;
-
-  /// No description provided for @backup_error.
-  ///
-  /// In en, this message translates to:
-  /// **'Error during backup.'**
-  String get backup_error;
-
-  /// No description provided for @restore_success.
-  ///
-  /// In en, this message translates to:
-  /// **'Restore successful.'**
-  String get restore_success;
-
-  /// No description provided for @restore_error.
-  ///
-  /// In en, this message translates to:
-  /// **'Error during restore.'**
-  String get restore_error;
 
   /// No description provided for @ai_score.
   String get ai_score;
@@ -616,11 +585,6 @@ abstract class AppLocalizations {
 
   /// No description provided for @stats_coming.
   String get stats_coming;
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -192,8 +192,6 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get noActiveModule => 'لا توجد وحدة نشطة';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'مشاركة';
@@ -205,22 +203,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get myAnimals_title => 'حيواناتي';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -192,8 +192,6 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Kein aktives Modul';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Teilen';
@@ -205,22 +203,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get myAnimals_title => 'Meine Tiere';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -192,8 +192,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noActiveModule => 'No active module';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Share';
@@ -203,24 +201,4 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get myAnimals_title => 'My Animals';
-
-  @override
-  String get settings_title => 'Settings';
-
-  @override
-  String get backup_success => 'Backup completed successfully.';
-
-  @override
-  String get backup_error => 'Error during backup.';
-
-  @override
-  String get restore_success => 'Restore successful.';
-
-  @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -204,17 +204,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get myAnimals_title => 'Mis Animales';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -192,8 +192,6 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Aucun module actif';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Partage';
@@ -205,22 +203,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get myAnimals_title => 'Mes Animaux';
 
   @override
-  String get settings_title => 'Paramètres';
 
   @override
-  String get backup_success => 'Sauvegarde effectuée avec succès.';
 
   @override
-  String get backup_error => 'Erreur lors de la sauvegarde.';
 
   @override
-  String get restore_success => 'Restauration réussie.';
 
   @override
-  String get restore_error => 'Erreur lors de la restauration.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -193,8 +193,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Nessun modulo attivo';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Condividi';
@@ -206,22 +204,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get myAnimals_title => 'I miei animali';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -191,8 +191,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get noActiveModule => '有効なモジュールがありません';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => '共有';
@@ -204,22 +202,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get myAnimals_title => '私の動物';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -192,8 +192,6 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Nenhum módulo ativo';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Compartilhar';
@@ -205,22 +203,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get myAnimals_title => 'Meus Animais';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -193,8 +193,6 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get noActiveModule => 'Нет активных модулей';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => 'Поделиться';
@@ -206,22 +204,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get myAnimals_title => 'Мои животные';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -191,8 +191,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get noActiveModule => '没有激活的模块';
-<<<<<<< HEAD
-=======
 
   @override
   String get share_title => '分享';
@@ -204,22 +202,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get myAnimals_title => '我的动物';
 
   @override
-  String get settings_title => 'Settings';
 
   @override
-  String get backup_success => 'Backup completed successfully.';
 
   @override
-  String get backup_error => 'Error during backup.';
 
   @override
-  String get restore_success => 'Restore successful.';
 
   @override
-  String get restore_error => 'Error during restore.';
-<<<<<<< HEAD
->>>>>>> codex/mettre-à-jour-les-clés-de-localisation
-=======
->>>>>>> 8ac19094 (Add localization keys for navigation)
->>>>>>> c0f6c366 (Add localization keys for navigation)
 }


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from localization files
- deduplicate localization keys
- keep correct translations for navigation keys

## Testing
- `grep -R "<<<<" -n lib/l10n`


------
https://chatgpt.com/codex/tasks/task_e_685697c58d588320bb908c8102493efd