### PR TITLE
Fix closing bracket in modules_screen

### DIFF
--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -77,6 +77,8 @@ class _ModulesScreenState extends State<ModulesScreen> {
       debugPrint("Erreur ouverture identite: $e");
     }
 
+  }
+
   Widget _buildModulesCommunaute() {
     final modules = _modulesByCategory['Communauté'] ?? [];
     if (modules.isEmpty) return const SizedBox.shrink();


### PR DESCRIPTION
## Summary
- close `_openIdentityScreen` in `modules_screen.dart`
- run `dart analyze` (fails due to missing packages, but command executed)

## Testing
- `dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_685697cb5a308320946b1ba6fe3dfc77