### PR TITLE
Fix leftover merge markers in tests

### DIFF
--- a/test/identite/unit/identity_signature_service_test.dart
+++ b/test/identite/unit/identity_signature_service_test.dart
@@ -1,10 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
-<<<<<<< HEAD
-import 'package:anisphere/modules/identite/models/identity_model.dart';
-=======
 import 'dart:typed_data';
->>>>>>> codex/decider-et-implémenter-l-api-signpdf
 import 'package:anisphere/modules/identite/services/identity_signature_service.dart';
 
 void main() {
@@ -16,16 +12,7 @@ void main() {
     final service = IdentitySignatureService('secret');
     final data = Uint8List.fromList([1, 2, 3]);
     final sig = service.sign(data);
-
-<<<<<<< HEAD
-    expect(service.verify(model, sig), isTrue);
-    final other = model.toMap();
-    other['status'] = 'changed';
-    final changed = IdentityModel.fromMap(other);
-    expect(service.verify(changed, sig), isFalse);
-=======
     expect(service.verify(data, sig), isTrue);
     expect(service.verify(Uint8List.fromList([3, 2, 1]), sig), isFalse);
->>>>>>> codex/decider-et-implémenter-l-api-signpdf
   });
 }

--- a/test/noyau/unit/video_logs_collector_test.dart
+++ b/test/noyau/unit/video_logs_collector_test.dart
@@ -1,17 +1,12 @@
 // Tests for VideoLogsCollector
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
-<<<<<<< HEAD
-@Skip('Temporarily disabled')
 import 'package:hive/hive.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:anisphere/modules/noyau/services/video_logs_collector.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
-
-=======
->>>>>>> codex/réviser-et-résoudre-les-tests-@skip
 import '../../test_config.dart';
 
 class MockCollection extends Mock implements CollectionReference<Map<String, dynamic>> {}

--- a/test/noyau/widget/i18n_widget_test.dart
+++ b/test/noyau/widget/i18n_widget_test.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-<<<<<<< HEAD
-import 'package:anisphere/l10n/app_localizations.dart';
-=======
->>>>>>> codex/modifier-la-gestion-de-la-langue-pour-le-français
 import '../../test_config.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- clean up merge markers in identity_signature_service_test.dart
- clean up merge markers in i18n_widget_test.dart
- clean up merge markers in video_logs_collector_test.dart

## Testing
- `dart analyze` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685697d0091083209b7adace03418a2a