### PR TITLE
Fix closing brace in language selector test

### DIFF
--- a/test/noyau/widget/language_selector_widget_test.dart
+++ b/test/noyau/widget/language_selector_widget_test.dart
@@ -12,5 +12,4 @@ void main() {
   });
 
   testWidgets('selecting a language updates provider', (tester) async {}, skip: true);
-  });
 }


### PR DESCRIPTION
## Summary
- fix extra closing `)` so `main()` closes properly in `language_selector_widget_test`

## Testing
- `flutter test --coverage` *(fails: command not found)*
- `dart scripts/update_test_tracker.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685697d265d88320bf6325d937f61167