### PR TITLE
Fix closing brace in ModulesScreen

### DIFF
--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -77,6 +77,8 @@ class _ModulesScreenState extends State<ModulesScreen> {
       debugPrint("Erreur ouverture identite: $e");
     }
 
+  }
+
   Widget _buildModulesCommunaute() {
     final modules = _modulesByCategory['Communauté'] ?? [];
     if (modules.isEmpty) return const SizedBox.shrink();


### PR DESCRIPTION
## Summary
- close `_openIdentityScreen` with a closing brace
- ensure module build methods are top-level within `_ModulesScreenState`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a19cd02c8320a0ccff75a0dad080