### PR TITLE
Fix typed matcher usage in tests

### DIFF
--- a/test/identite/unit/identity_service_test.dart
+++ b/test/identite/unit/identity_service_test.dart
@@ -32,7 +32,7 @@ void main() {
       status: 'ok',
       legalStatus: 'dog',
     );
-    when(mockBox.put(any, any)).thenAnswer((_) async {});
+    when(mockBox.put(any, any<IdentityModel>())).thenAnswer((_) async {});
 
     final score = await service.computeCompletionScore(model);
 
@@ -52,7 +52,7 @@ void main() {
     when(mockBox.values).thenReturn([existing]);
     final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
     final model = IdentityModel(animalId: 'new', microchipNumber: 'dup');
-    when(mockBox.put(any, any)).thenAnswer((_) async {});
+    when(mockBox.put(any, any<IdentityModel>())).thenAnswer((_) async {});
 
     final result = await service.detectSiblingDuplicates(model);
 

--- a/test/noyau/unit/video_logs_collector_test.dart
+++ b/test/noyau/unit/video_logs_collector_test.dart
@@ -62,7 +62,8 @@ void main() {
     when(mockFirestore.collection('logs_ia')).thenReturn(mockLogs);
     when(mockLogs.doc(any)).thenReturn(mockDoc);
     when(mockDoc.collection('entries')).thenReturn(mockEntries);
-    when(mockEntries.add(any)).thenThrow(Exception('fail'));
+    when(mockEntries.add(any<Map<String, dynamic>>()))
+        .thenThrow(Exception('fail'));
 
     final collector = VideoLogsCollector(firestoreInstance: mockFirestore);
 


### PR DESCRIPTION
## Summary
- use typed matchers for `Box.put` mocks
- use typed matchers for Firestore `add` mocks

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a19f7fd48320884fbef46219f760