### PR TITLE
Fix widget tests const usage

### DIFF
--- a/test/identite/widget/genealogy_summary_card_test.dart
+++ b/test/identite/widget/genealogy_summary_card_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   testWidgets('GenealogySummaryCard displays parent ids', (WidgetTester tester) async {
     final model = GenealogyModel(animalId: 'a1', fatherName: 'f1', motherName: 'm1', originCountry: 'FR');
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: GenealogySummaryCard(genealogy: model),
     ));
 

--- a/test/identite/widget/identity_screen_test.dart
+++ b/test/identite/widget/identity_screen_test.dart
@@ -30,7 +30,7 @@ void main() {
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     );
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: IdentityScreen(animals: [animal], service: service),
     ));
 

--- a/test/noyau/widget/important_notifications_widget_test.dart
+++ b/test/noyau/widget/important_notifications_widget_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   testWidgets('hides widget when list is empty', (tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: ImportantNotificationsWidget(notifications: []),
     ));
 

--- a/test/noyau/widget/user_profile_summary_card_test.dart
+++ b/test/noyau/widget/user_profile_summary_card_test.dart
@@ -25,7 +25,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: UserProfileSummaryCard(user: user, proValidated: false),
         ),


### PR DESCRIPTION
## Summary
- drop `const` from MaterialApp where widget parameters aren't const

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856a19ff5dc832090225c2a8af848c3