### PR TITLE
Fix Skip placements in tests

### DIFF
--- a/test/noyau/unit/message_model_test.dart
+++ b/test/noyau/unit/message_model_test.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-@Skip('Temporarily disabled')
 import 'package:hive/hive.dart';
 import 'package:anisphere/modules/noyau/models/message_model.dart';
 
 import '../../test_config.dart';
 
+@Skip('Temporarily disabled')
 void main() {
   late Directory tempDir;
 

--- a/test/noyau/unit/user_profile_model_test.dart
+++ b/test/noyau/unit/user_profile_model_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-@Skip('Temporarily disabled')
 import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/models/user_profile_model.dart';
 
+@Skip('Temporarily disabled')
 void main() {
   setUpAll(() async {
     await initTestEnv();


### PR DESCRIPTION
## Summary
- move `@Skip` annotations to decorate `main` in message_model_test and user_profile_model_test

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856a1a16fd883208eb06eff5920feb0