### PR TITLE
Remove localization packages

### DIFF
--- a/lib/modules/noyau/i18n/language_selector_widget.dart
+++ b/lib/modules/noyau/i18n/language_selector_widget.dart
@@ -1,7 +1,7 @@
 // Widget preserved for future language selection features.
 import 'package:flutter/material.dart';
-import 'package:anisphere/l10n/app_localizations.dart';
-import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+// import 'package:anisphere/l10n/app_localizations.dart';
+// import 'package:flutter_localized_locales/flutter_localized_locales.dart';
 import 'package:provider/provider.dart';
 import 'i18n_provider.dart';
 
@@ -20,18 +20,12 @@ class LanguageSelectorWidget extends StatelessWidget {
           context.read<I18nProvider>().setLocale(newLocale);
         }
       },
-      items: AppLocalizations.supportedLocales
-          .map(
-            (locale) => DropdownMenuItem<Locale>(
-              value: locale,
-              child: Text(
-                LocaleNames.of(context)!
-                        .nameOf(locale.languageCode) ??
-                    locale.languageCode,
-              ),
-            ),
-          )
-          .toList(),
+      items: const [
+        DropdownMenuItem<Locale>(
+          value: Locale('fr'),
+          child: Text('fr'),
+        )
+      ],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
-  intl: ^0.20.2
-  flutter_localized_locales: ^2.0.5
 
   # in_app_purchase: ^x.x.x  # uncomment when implementing IAP
   # UI

--- a/test/identite/widget/identity_screen_test.dart
+++ b/test/identite/widget/identity_screen_test.dart
@@ -5,7 +5,6 @@ import 'package:anisphere/modules/identite/screens/identity_screen.dart';
 import 'package:anisphere/modules/identite/services/identity_service.dart';
 import 'package:anisphere/modules/identite/models/identity_model.dart';
 import 'package:anisphere/modules/noyau/models/animal_model.dart';
-import 'package:anisphere/l10n/app_localizations.dart';
 import 'package:anisphere/modules/identite/widgets/identity_score_widget.dart';
 
 import 'package:hive/hive.dart';

--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -13,7 +13,6 @@ import 'package:anisphere/main.dart';
 import 'package:anisphere/modules/noyau/providers/theme_provider.dart';
 import 'package:anisphere/modules/noyau/i18n/i18n_provider.dart';
 
-import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 
 class _TestUserProvider extends UserProvider {

--- a/test/noyau/widget/modules_screen_test.dart
+++ b/test/noyau/widget/modules_screen_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/noyau/screens/modules_screen.dart';
 import 'package:anisphere/modules/noyau/services/modules_service.dart';
 import 'package:anisphere/modules/identite/screens/identity_screen.dart';
-import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 
 void main() {

--- a/test/noyau/widget/user_profile_screen_test.dart
+++ b/test/noyau/widget/user_profile_screen_test.dart
@@ -7,7 +7,6 @@ import 'package:anisphere/modules/noyau/services/user_service.dart';
 import 'package:anisphere/modules/noyau/services/auth_service.dart';
 import 'package:anisphere/modules/noyau/providers/user_provider.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
-import 'package:anisphere/l10n/app_localizations.dart';
 import '../../test_config.dart';
 import '../../helpers/test_fakes.dart';
 

--- a/test/noyau/widget/user_profile_summary_card_test.dart
+++ b/test/noyau/widget/user_profile_summary_card_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:anisphere/modules/noyau/widgets/user_profile_summary_card.dart';
 import 'package:anisphere/modules/noyau/models/user_model.dart';
-import 'package:anisphere/l10n/app_localizations.dart';
 
 void main() {
   testWidgets('shows update button when data missing', (tester) async {


### PR DESCRIPTION
## Summary
- drop `flutter_localizations`, `intl`, and `flutter_localized_locales`
- adjust unused `LanguageSelectorWidget`
- clean up tests by removing `AppLocalizations` imports

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856a3c6daf88320b958a7d3ca96a6d0