### PR TITLE
Remove i18n docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 🐾 AniSphère — Application intelligente pour le suivi de la vie animale
 
 AniSphère est une application modulaire, intuitive et évolutive qui accompagne les utilisateurs dans le suivi complet de leurs animaux. Grâce à une architecture hybride (local + cloud) et à une intelligence artificielle intégrée, AniSphère devient un véritable compagnon quotidien pour les particuliers, professionnels et associations.
+L'application fonctionne désormais exclusivement en français.
 
 🎯 Mission
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -11,10 +11,7 @@ Centraliser les bonnes pratiques, automatisations, et outils
 Servir de passerelle entre le code, l’IA et les fichiers de suivi (test, roadmap, modules)
 
 Il est mis à jour automatiquement à chaque évolution majeure du projet.
-Le système multilingue est **désactivé temporairement** pour simplifier la première version : l’application fonctionne donc uniquement en français.
-Les fichiers `.arb` restent toutefois présents dans `lib/l10n/` pour préparer une future réactivation.
-Lorsque la traduction sera réactivée, tous les textes devront passer par `AppLocalizations.of(context)` et le service central `lib/modules/noyau/i18n/`.
-`localeResolutionCallback` dans `lib/main.dart` force actuellement la langue française.
+L’application fonctionne désormais exclusivement en français.
 📌 Version Flutter/Dart requise
 
 Le développement d'AniSphère s'appuie sur **Flutter&nbsp;3.32.x** et **Dart&nbsp;3.4+**.
@@ -62,7 +59,6 @@ Chaque module dispose de son propre dossier dans lib/modules/[nom_du_module]
 Le noyau est toujours accessible depuis les modules, mais les modules ne doivent jamais l’altérer
 
 Tous les tests sont regroupés dans /test et suivent la même hiérarchie que lib/
-Tous les textes des modules doivent passer par `AppLocalizations.of(context)` et les services utilisent `I18nService` pour la langue active. Aucune ressource `.arb` ne doit être créée dans les modules.
 
 ### Services transverses du noyau
 - Messagerie : `lib/modules/messagerie/services/messaging_service.dart`

--- a/docs/0__instructions.md
+++ b/docs/0__instructions.md
@@ -38,11 +38,7 @@ L’interface est claire, animée, inspirée de Samsung Health
 
 Tous les textes, choix et graphismes doivent être accessibles et lisibles
 
-Le support multilingue est **désactivé temporairement** pour stabiliser la première version.
-L’application fonctionne actuellement uniquement en français mais le service `i18n_service.dart` et les ressources `.arb` dans `lib/l10n/` restent en place.
-Lorsque la traduction sera réactivée, tous les textes devront repasser par `AppLocalizations.of(context)`.
-Le système multilingue du noyau, situé dans `lib/modules/noyau/i18n/`, restera la référence.
-- Clés communes : `appTitle`, `mainScreenTitle`, `ai_score`, `breeder_name`, `breeder_email`, `breeder_phone`, `onboarding_title`, `onboarding_subtitle`, `onboarding_skip`, `onboarding_next`, `duplicate_animal_warning`, `duplicate_photo_warning`, `photo_timeline_title`.
+L’application fonctionne désormais exclusivement en français.
 
 🧠 Architecture IA
 

--- a/docs/1__idees.md
+++ b/docs/1__idees.md
@@ -40,9 +40,7 @@ Exports & données pro
 
 Génération PDF complète du carnet santé.
 
-Export en différentes langues (fonctionnalité payante hors langue native).
 
-Partage facilité vers vétérinaire, pension ou assurance.
 
 Module "Cabinet vétérinaire"
 
@@ -236,7 +234,6 @@ Export interopérable santé (API vétérinaires, PDF, Drive)
 
 Notifications IA (urgence, pertinence, prédiction)
 
-Traduction auto à l’export (multi-langue)
 
 🌍 Site compagnon AniSphère
 

--- a/docs/2__roadmap.md
+++ b/docs/2__roadmap.md
@@ -25,7 +25,6 @@ Statut :
 ✅ Gestion compte utilisateur : OK
 ✅ Architecture des modules : OK
 🔄 En cours : synchronisation automatique animaux (local + cloud)
-✅ Multilingue activé (i18n) — fichiers `.arb` gérés, langue utilisateur sélectionnable dans les paramètres
 
 🧠 Phase 2 — IA maîtresse & automatisations
 
@@ -146,7 +145,6 @@ Objectifs :
 
 Mise en place des offres gratuites / premium
 
-Export PDF multilingue payant (hors langue native)
 
 Déblocage de certains modules payants
 

--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -37,9 +37,6 @@ Système de recommandation IA (locale/cloud) : implémenté
 - [x] Document `ia_policy.md` sur le consentement RGPD
 - [x] Modèle `security_settings_model.dart`
 - [x] Écran `security_settings_screen.dart`
-- [x] Correction du chemin `l10n` (fichiers de localisation dans `lib/l10n`)
-- [x] Ajout des clés `appTitle` et `mainScreenTitle` pour la localisation
-- [x] Nettoyage des fichiers de localisation et ajout des clés `ai_score`, `breeder_*`, `onboarding_*`, `duplicate_*`, `photo_timeline_title`
 - [x] Extension du `identity_model.dart` avec les infos éleveur + tests
 
 🩺 Santé — Activation prévue (Roadmap Phase 4)
@@ -135,9 +132,8 @@ suivi_[module].md → suivi fin par module
 
 - ✅ Mise à jour automatique des tâches le 2025-06-18
 - ✅ Mise à jour automatique des tâches le 2025-06-20
-- ✅ Mise à jour automatique des tâches le 2025-06-30 (correctifs i18n)
 - ✅ Mise à jour automatique des tâches le 2025-07-10 (pipeline IA Python)
 
 - ✅ Mise à jour automatique des tâches le 2025-06-21
-- 📝 2025-07-20 : désactivation temporaire du support multilingue. L'application reste en français uniquement; les ressources `lib/l10n/` sont conservées pour une réactivation ultérieure.
+- 📝 2025-07-20 : suppression du service de traduction et des fichiers `lib/l10n/*.arb`. L'application fonctionne désormais uniquement en français.
 - ✅ Mise à jour automatique des tâches le 2025-07-21 (NotificationService intégré)

--- a/docs/6__technos_par_module.md
+++ b/docs/6__technos_par_module.md
@@ -27,12 +27,10 @@ OpenCV (via native plugin) : Analyse d’image, tri IA, reconnaissance.
 flutter_secure_storage : Stockage local chiffré de données sensibles.
 path : Gestion des chemins et manipulations de fichiers.
 
-shared_preferences : Gestion des préférences utilisateur (thème, vues, tutoriels) et stockage local de la langue choisie.
+shared_preferences : Gestion des préférences utilisateur (thème, vues, tutoriels).
 
 firebase_crashlytics : Suivi des erreurs en production.
 
-intl, flutter_localizations : Gestion du multilingue Flutter.
-Tous les modules utilisent `AppLocalizations` pour les textes, aucun système i18n n'est redéclaré.
 
 🩺 Module Santé
 
@@ -132,7 +130,7 @@ Image Picker : Ajout de photos (santé, profil, activité)
 
 Path_provider : Gestion du cache, documents, export
 
-Intl : Traductions, formats de date, langues
+Intl : Formats de date et nombres
 
 Compression : Réduction de poids avant envoi (images, fichiers)
 

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -4,6 +4,7 @@
 Ce fichier suit **étape par étape, dans l’ordre**, la conception, l’évolution, les tests et les grandes décisions du noyau AniSphère.  
 > Toute étape validée est datée, toute fonctionnalité doit être couverte par un test associé.  
 > Les tâches Superadmin ont été supprimées du noyau et sont désormais dans un module indépendant.
+L'application fonctionne désormais exclusivement en français.
 
 ---
 
@@ -214,15 +215,6 @@ AniSphère introduit une authentification biométrique (empreinte digitale ou re
 | lib/modules/noyau/models/security_settings_model.dart | Stockage local des choix de sécurité et de consentement |
 | lib/modules/noyau/screens/security_settings_screen.dart | Interface pour modifier ou révoquer son consentement |
 
-### ✅ Multilingue (i18n)
-- 📁 `lib/modules/noyau/i18n/`
-- Fichiers : `i18n_service.dart`, `i18n_provider.dart`, `app_localizations.dart`
-- 📁 Traductions : `lib/l10n/app_xx.arb` (fr, en, es, it, de, pt, ar, zh, ru, ja…)
-- Fonction : Gère automatiquement la langue globale de l'application
-- Intégration : `MaterialApp(locale: ...)`, `AppLocalizations.of(context)`
-- Modules : Tous les modules utilisent automatiquement ce système sans duplication
-- Exports PDF & QR utilisent la langue active via `i18n_service`
-
 ---
 
 ## 🗂️ Annexes & liens
@@ -338,16 +330,12 @@ Responsable : Superadmin
 - 🧩 Mise à jour de `ia_logger.dart` pour tracer les paiements, tests à jour le 2025-06-15
 
 - 🧩 Synchronisation automatique du noyau le 2025-06-18
-- 🆕 Multilingue : i18n_service, i18n_provider, fichiers .arb
-- 🆕 Support complet de **10 langues** grâce à `i18n_service.dart` et aux fichiers `.arb` localisés
-- 🛠️ 2025-06-30 : Correction des imports i18n (`AppLocalizations`, `I18nProvider`) et mise à jour des tests associés
 - 🆕 2025-07-15 : Gestion rôles utilisateurs / validation pro via `user_profile_model.dart` et `pro_validation_service.dart`
 
 - 🧩 Synchronisation automatique du noyau le 2025-06-19
-- 🆕 2025-06-21 : Ajout du module **Identité** dans `ModulesScreen` (catégorie "Communauté") et localisation dans les fichiers `.arb`.
+- 🆕 2025-06-21 : Ajout du module **Identité** dans `ModulesScreen` (catégorie "Communauté").
 - 🛠️ 2025-06-21 : `ModuleCard` devient cliquable et ouvre `IdentityScreen` via `_openIdentityScreen`.
 - ✅ 2025-06-21 : Test widget `modules_screen_test.dart` mis à jour pour vérifier l'accès à l'identité.
-- 🛠️ 2025-06-21 : Nettoyage des fichiers de localisation (`lib/l10n/*.arb`) et ajout des clés `ai_score`, `breeder_name`, `breeder_email`, `breeder_phone`, `onboarding_title`, `onboarding_subtitle`, `onboarding_skip`, `onboarding_next`, `duplicate_animal_warning`, `duplicate_photo_warning`, `photo_timeline_title`.
 - 🛠️ 2025-06-21 : Mise à jour du `identity_model.dart` (champs éleveur) avec tests.
 
 - 🧩 Synchronisation automatique du noyau le 2025-06-21

--- a/docs/suivi_identite.md
+++ b/docs/suivi_identite.md
@@ -181,9 +181,4 @@ Assurer à chaque animal une fiche unique, fiable, partageable et intelligente, 
 - Carte cliquable ouvrant l'écran du module sélectionné (Identité compris)
 - Date : 2025-06-21
 
-### ✅ Localisations Identity
-- 📁 `lib/l10n/app_xx.arb`
-- Nouvelles clés `identityModuleTitle` et `identityModuleDescription` pour toutes les langues
-- Ajout des clés `ai_score`, `breeder_*`, `onboarding_*`, `duplicate_*`, `photo_timeline_title`
-- Date : 2025-06-21
 

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -116,9 +116,6 @@ Ajoutez ici les nouveaux tests puis exécutez `dart scripts/update_test_tracker.
 | test/noyau/unit/payment_service_test.dart | unit | package:anisphere/modules/noyau/services/payment_service.dart | ✅ |
 | test/noyau/unit/iap_validator_test.dart | unit | package:anisphere/modules/noyau/services/iap_validator.dart | ✅ |
 | test/noyau/unit/behavior_analysis_service_test.dart | unit | package:anisphere/modules/noyau/services/behavior_analysis_service.dart | ✅ |
-| test/noyau/unit/i18n_service_test.dart | unit | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
-| test/noyau/widget/i18n_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_service.dart | ✅ |
-| test/noyau/widget/language_selector_widget_test.dart | widget | package:anisphere/modules/noyau/i18n/i18n_provider.dart | ✅ |
 | test/noyau/unit/ia_local/ia_model_loader_test.dart | unit | package:anisphere/modules/noyau/services/ia_interpreter_loader.dart | ✅ |
 | test/identite/unit/genealogy_model_test.dart | unit | package:anisphere/modules/identite/models/genealogy_model.dart | ✅ |
 | test/identite/unit/genealogy_ocr_service_test.dart | unit | package:anisphere/modules/identite/services/genealogy_ocr_service.dart | ✅ |


### PR DESCRIPTION
## Summary
- note French-only usage
- drop i18n docs and translation instructions
- log removal in task tracker

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a3c82be88320ba074328034044db