### PR TITLE
Fix AppBar style const

### DIFF
--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -86,7 +86,7 @@ class MainScreenState extends State<MainScreen> {
         elevation: 0,
         title: const Text(
           'Maison',
-          style: const TextStyle(
+          style: TextStyle(
             fontWeight: FontWeight.w600,
             fontSize: 20,
             color: Color(0xFF183153),


### PR DESCRIPTION
## Summary
- remove redundant `const` from `TextStyle` inside `MainScreen` AppBar title

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa3e7e9483208c69ecd1d1b6184a