### PR TITLE
Remove redundant toList calls

### DIFF
--- a/lib/modules/identite/services/identity_passport_generator.dart
+++ b/lib/modules/identite/services/identity_passport_generator.dart
@@ -85,7 +85,7 @@ class IdentityPassportGenerator {
                   return pw.Bullet(
                     text: "$date : ${e.field} modifié de '${e.oldValue}' → '${e.newValue}'",
                   );
-                }).toList(),
+                }),
               ),
             ],
           ];

--- a/lib/modules/noyau/screens/message_list_screen.dart
+++ b/lib/modules/noyau/screens/message_list_screen.dart
@@ -60,7 +60,7 @@ class _MessageListScreenState extends State<MessageListScreen> {
               ),
             ),
           ];
-        }).toList(),
+        }),
       ),
     );
   }

--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -38,7 +38,7 @@ class ModulesByCategoryScreen extends StatelessWidget {
               const SizedBox(height: 24),
             ],
           );
-        }).toList(),
+        }),
       ),
     );
   }

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -203,7 +203,7 @@ class _ModulesScreenState extends State<ModulesScreen> {
               const SizedBox(height: 24),
             ],
           );
-          }).toList(),
+          }),
           _buildModulesCommunaute(),
         ],
       ),

--- a/lib/modules/noyau/screens/notifications_screen.dart
+++ b/lib/modules/noyau/screens/notifications_screen.dart
@@ -55,9 +55,9 @@ class NotificationsScreen extends StatelessWidget {
                 title: Text(notif['title'] ?? ""),
                 subtitle: Text("📅 ${notif['date']}"),
               );
-            }).toList(),
+            }),
           );
-        }).toList(),
+        }),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- remove `toList()` calls after map iterables that were used directly as children

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa43e5f88320bbcfab051860e1a4