### PR TITLE
Fix identity service mock expectation

### DIFF
--- a/test/identite/unit/identity_service_test.dart
+++ b/test/identite/unit/identity_service_test.dart
@@ -32,7 +32,7 @@ void main() {
       status: 'ok',
       legalStatus: 'dog',
     );
-    when(mockBox.put(any, any<IdentityModel>())).thenAnswer((_) async {});
+    when(mockBox.put(any, any)).thenAnswer((_) async {});
 
     final score = await service.computeCompletionScore(model);
 
@@ -52,7 +52,7 @@ void main() {
     when(mockBox.values).thenReturn([existing]);
     final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
     final model = IdentityModel(animalId: 'new', microchipNumber: 'dup');
-    when(mockBox.put(any, any<IdentityModel>())).thenAnswer((_) async {});
+    when(mockBox.put(any, any)).thenAnswer((_) async {});
 
     final result = await service.detectSiblingDuplicates(model);
 


### PR DESCRIPTION
## Summary
- adjust mock expectations in `identity_service_test.dart`

## Testing
- `flutter test test/identite/unit/identity_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa5478f88320b20168ea41d32815