### PR TITLE
Fix IA model loader mock

### DIFF
--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -39,7 +39,7 @@ void main() {
       (invocation) {
         final output = invocation.positionalArguments[1] as List;
         (output.first as List)[0] = 3.14;
-        return;
+        return null;
       },
     );
     final loader = IaInterpreterLoader(


### PR DESCRIPTION
## Summary
- fix mock in IA model loader test to explicitly return `null`

## Testing
- `flutter test test/noyau/unit/ia_local/ia_model_loader_test.dart -r expanded` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa5a48f08320a76df4dd3ca1314d