### PR TITLE
Fix mock matcher

### DIFF
--- a/test/noyau/unit/video_logs_collector_test.dart
+++ b/test/noyau/unit/video_logs_collector_test.dart
@@ -62,8 +62,7 @@ void main() {
     when(mockFirestore.collection('logs_ia')).thenReturn(mockLogs);
     when(mockLogs.doc(any)).thenReturn(mockDoc);
     when(mockDoc.collection('entries')).thenReturn(mockEntries);
-    when(mockEntries.add(any<Map<String, dynamic>>()))
-        .thenThrow(Exception('fail'));
+    when(mockEntries.add(any)).thenThrow(Exception('fail'));
 
     final collector = VideoLogsCollector(firestoreInstance: mockFirestore);
 


### PR DESCRIPTION
## Summary
- fix matcher to use `any` instead of generic in `video_logs_collector_test`

## Testing
- `flutter pub get` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa6019e08320939a0d70421f77b0