### PR TITLE
fix: resolve flutter analyze warnings

### DIFF
--- a/lib/modules/identite/services/identity_passport_generator.dart
+++ b/lib/modules/identite/services/identity_passport_generator.dart
@@ -85,7 +85,7 @@ class IdentityPassportGenerator {
                   return pw.Bullet(
                     text: "$date : ${e.field} modifié de '${e.oldValue}' → '${e.newValue}'",
                   );
-                }),
+                }).toList(), // Codex: Correction automatique flutter analyze
               ),
             ],
           ];

--- a/lib/modules/noyau/screens/main_screen.dart
+++ b/lib/modules/noyau/screens/main_screen.dart
@@ -86,7 +86,7 @@ class MainScreenState extends State<MainScreen> {
         elevation: 0,
         title: const Text(
           'Maison',
-          style: const TextStyle(
+          style: TextStyle( // Codex: Correction automatique flutter analyze
             fontWeight: FontWeight.w600,
             fontSize: 20,
             color: Color(0xFF183153),

--- a/lib/modules/noyau/screens/message_list_screen.dart
+++ b/lib/modules/noyau/screens/message_list_screen.dart
@@ -60,7 +60,7 @@ class _MessageListScreenState extends State<MessageListScreen> {
               ),
             ),
           ];
-        }),
+        }).toList(), // Codex: Correction automatique flutter analyze
       ),
     );
   }

--- a/lib/modules/noyau/screens/modules_by_category_screen.dart
+++ b/lib/modules/noyau/screens/modules_by_category_screen.dart
@@ -38,7 +38,7 @@ class ModulesByCategoryScreen extends StatelessWidget {
               const SizedBox(height: 24),
             ],
           );
-        }),
+        }).toList(), // Codex: Correction automatique flutter analyze
       ),
     );
   }

--- a/lib/modules/noyau/screens/notifications_screen.dart
+++ b/lib/modules/noyau/screens/notifications_screen.dart
@@ -55,9 +55,9 @@ class NotificationsScreen extends StatelessWidget {
                 title: Text(notif['title'] ?? ""),
                 subtitle: Text("📅 ${notif['date']}"),
               );
-            }),
+            }).toList(), // Codex: Correction automatique flutter analyze
           );
-        }),
+        }).toList(), // Codex: Correction automatique flutter analyze
       ),
     );
   }

--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -39,8 +39,7 @@ void main() {
       (invocation) {
         final output = invocation.positionalArguments[1] as List;
         (output.first as List)[0] = 3.14;
-        return null;
-      },
+      }, // Codex: Correction automatique flutter analyze
     );
     final loader = IaInterpreterLoader(
       modelPath: 'models/dummy.tflite',

--- a/test/noyau/unit/message_model_test.dart
+++ b/test/noyau/unit/message_model_test.dart
@@ -1,3 +1,4 @@
+@Skip('Temporarily disabled')
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -5,8 +6,6 @@ import 'package:hive/hive.dart';
 import 'package:anisphere/modules/noyau/models/message_model.dart';
 
 import '../../test_config.dart';
-
-@Skip('Temporarily disabled')
 void main() {
   late Directory tempDir;
 

--- a/test/noyau/unit/user_profile_model_test.dart
+++ b/test/noyau/unit/user_profile_model_test.dart
@@ -1,8 +1,7 @@
+@Skip('Temporarily disabled')
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/models/user_profile_model.dart';
-
-@Skip('Temporarily disabled')
 void main() {
   setUpAll(() async {
     await initTestEnv();

--- a/test/noyau/unit/video_logs_collector_test.dart
+++ b/test/noyau/unit/video_logs_collector_test.dart
@@ -9,8 +9,6 @@ import 'package:anisphere/modules/noyau/services/video_logs_collector.dart';
 import 'package:anisphere/modules/noyau/services/offline_sync_queue.dart';
 import '../../test_config.dart';
 
-class MockCollection extends Mock implements CollectionReference<Map<String, dynamic>> {}
-class MockDocument extends Mock implements DocumentReference<Map<String, dynamic>> {}
 class MockFirestore extends Mock implements FirebaseFirestore {}
 
 void main() {
@@ -56,14 +54,8 @@ void main() {
 
   test('uploadResult queues task on failure', () async {
     final mockFirestore = MockFirestore();
-    final mockLogs = MockCollection();
-    final mockDoc = MockDocument();
-    final mockEntries = MockCollection();
-    when(mockFirestore.collection('logs_ia')).thenReturn(mockLogs);
-    when(mockLogs.doc(any)).thenReturn(mockDoc);
-    when(mockDoc.collection('entries')).thenReturn(mockEntries);
-    when(mockEntries.add(any<Map<String, dynamic>>()))
-        .thenThrow(Exception('fail'));
+    when(mockFirestore.collection('logs_ia'))
+        .thenThrow(Exception('fail')); // Codex: Correction automatique flutter analyze
 
     final collector = VideoLogsCollector(firestoreInstance: mockFirestore);
 


### PR DESCRIPTION
## Summary
- cast iterables to lists for widget children
- remove redundant const keyword
- adjust @Skip annotations at library level
- fix closure return in IA model loader test
- use minimal mock for failing firestore test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ad95f9b48320b6ac309f428c75c1