### PR TITLE
fix: convert iterable to list for children params

### DIFF
--- a/lib/modules/noyau/screens/message_list_screen.dart
+++ b/lib/modules/noyau/screens/message_list_screen.dart
@@ -60,7 +60,7 @@ class _MessageListScreenState extends State<MessageListScreen> {
               ),
             ),
           ];
-        }),
+        }).toList(), // Codex: Correction automatique .toList()
       ),
     );
   }

--- a/lib/modules/noyau/screens/notifications_screen.dart
+++ b/lib/modules/noyau/screens/notifications_screen.dart
@@ -55,9 +55,9 @@ class NotificationsScreen extends StatelessWidget {
                 title: Text(notif['title'] ?? ""),
                 subtitle: Text("📅 ${notif['date']}"),
               );
-            }),
+            }).toList(), // Codex: Correction automatique .toList()
           );
-        }),
+        }).toList(), // Codex: Correction automatique .toList()
       ),
     );
   }


### PR DESCRIPTION
## Summary
- ensure `.map` results are converted to `List<Widget>` in notifications and messages screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae4bfde08320bc5d7c036be2980e