### PR TITLE
Add multi-language reset notice

### DIFF
--- a/docs/3__suivi_taches.md
+++ b/docs/3__suivi_taches.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 ✅ 3__suivi_taches.md — Tableau de bord global AniSphère
 
 Ce fichier est une vue d’ensemble condensée du projet AniSphère. Il permet de suivre l’évolution par grandes étapes (noyau + modules) sans entrer dans les détails techniques. Chaque module dispose de son propre fichier de suivi détaillé. Ce tableau sert à suivre le cap général du développement.

--- a/docs/noyau_suivi.md
+++ b/docs/noyau_suivi.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 # ✅ Suivi chronologique du développement — Noyau d’AniSphère
 *Fichier mis à jour au 21/06/2025*
 

--- a/docs/stockage_suivi.md
+++ b/docs/stockage_suivi.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 📦 stockage_suivi.md — Optimisation du stockage
 
 Ce document décrit le fonctionnement du `StorageOptimizer`. Ce service se charge

--- a/docs/suivi_identite.md
+++ b/docs/suivi_identite.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 ## Suivi de développement — Module Identité animale
 
 Ce document suit le développement du module Identité animale pour AniSphère. Il est actif par défaut, gratuit, et constitue une base stratégique pour la sécurité, la personnalisation et la fiabilité du suivi animal. Ce module est conçu pour être 100 % fonctionnel hors ligne, avec synchronisation différée et OCR intégré.

--- a/docs/suivi_superadmin.md
+++ b/docs/suivi_superadmin.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 # Suivi du module Superadmin
 
 Les fonctionnalités dédiées au rôle **Superadmin** sont désormais déplacées dans un module indépendant.

--- a/docs/test_tracker.md
+++ b/docs/test_tracker.md
@@ -1,3 +1,6 @@
+🛑 Restauration version française native — multilingue désactivé le 21/06/2025 via reset sur 9934dbf9.
+Toute nouvelle évolution doit être documentée ici jusqu’à la réactivation du multilingue.
+
 # Test Tracker AniSphère
 Ajoutez ici les nouveaux tests puis exécutez `dart scripts/update_test_tracker.dart` pour mettre à jour docs/test_tracker.md.
 


### PR DESCRIPTION
## Summary
- add a note about restoring the French version at the top of active docs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bb14b7fc8320a68151eac05eb974