### PR TITLE
Refactor theme colors

### DIFF
--- a/lib/modules/noyau/screens/home_screen.dart
+++ b/lib/modules/noyau/screens/home_screen.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../../theme.dart';
 
 import '../services/modules_summary_service.dart';
 import '../services/animal_service.dart';
@@ -125,7 +126,7 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
         subtitle: Text(summary.summary),
         trailing: summary.isPremium
-            ? const Icon(Icons.star, color: Colors.amber)
+            ? const Icon(Icons.star, color: primaryBlue)
             : const SizedBox.shrink(),
       ),
     );

--- a/lib/modules/noyau/widgets/ia_suggestion_card.dart
+++ b/lib/modules/noyau/widgets/ia_suggestion_card.dart
@@ -3,6 +3,7 @@
 // Utilisé sur l’écran d’accueil, le dashboard IA, ou dans les modules.
 // Doit être élégant, discret, mais réactif.
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class IASuggestionCard extends StatelessWidget {
   final String title;
@@ -52,7 +53,7 @@ class IASuggestionCard extends StatelessWidget {
                 child: TextButton(
                   onPressed: onAction,
                   style: TextButton.styleFrom(
-                    foregroundColor: const Color(0xFFFBC02D),
+                    foregroundColor: primaryBlue,
                   ),
                   child: Text(actionLabel!),
                 ),

--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 import '../models/module_model.dart';
 
 class ModuleCard extends StatelessWidget {
@@ -22,7 +23,7 @@ class ModuleCard extends StatelessWidget {
     final Color chipColor = switch (status) {
       'actif' => const Color(0xFF183153),
       'disponible' => Colors.grey,
-      'premium' => const Color(0xFFFBC02D),
+      'premium' => primaryBlue,
       _ => Colors.grey,
     };
 

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 const Color primaryBlue = Color(0xFF183153);
 const Color backgroundGray = Color(0xFFF2F2F2); // ✅ gris clair Samsung Health
 
-const Color accentYellow = Color(0xFFFBC02D);
-
 final ThemeData appTheme = ThemeData(
   brightness: Brightness.light,
   scaffoldBackgroundColor: backgroundGray, // ✅ fond global de tous les écrans


### PR DESCRIPTION
## Summary
- remove unused `accentYellow` color constant
- apply `primaryBlue` to module and suggestion widgets
- update home screen premium indicator color

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856be93e5b88320a152aefdad7b3731