### PR TITLE
Update widget backgrounds to use backgroundGray

### DIFF
--- a/lib/modules/noyau/widgets/ia_banner.dart
+++ b/lib/modules/noyau/widgets/ia_banner.dart
@@ -3,6 +3,7 @@
 // Peut signaler un état IA actif (mode onboarding, offline, alerte santé).
 // Discret, mais visible et réutilisable dans tous les modules.
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class IABanner extends StatelessWidget {
   final String message;
@@ -14,7 +15,7 @@ class IABanner extends StatelessWidget {
     super.key,
     required this.message,
     this.icon = Icons.info_outline,
-    this.background = const Color(0xFFFFF8E1), // Jaune solaire clair
+    this.background = backgroundGray,
     this.textColor = const Color(0xFF183153),  // Bleu nuit
   });
 

--- a/lib/modules/noyau/widgets/ia_chip.dart
+++ b/lib/modules/noyau/widgets/ia_chip.dart
@@ -2,6 +2,7 @@
 // Affiche un petit badge (Chip) représentant un état IA ou un tag intelligent.
 // Utilisé dans les dashboards, listes d’animaux ou en haut des écrans IA.
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class IAChip extends StatelessWidget {
   final String label;
@@ -26,7 +27,7 @@ class IAChip extends StatelessWidget {
         ),
       ),
       avatar: Icon(icon, size: 18, color: const Color(0xFF183153)),
-      backgroundColor: backgroundColor ?? const Color(0xFFFFF8E1), // Jaune solaire très clair
+      backgroundColor: backgroundColor ?? backgroundGray,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),
         side: const BorderSide(color: Color(0xFF183153)), // Bordure bleu nuit

--- a/lib/modules/noyau/widgets/important_notifications_widget.dart
+++ b/lib/modules/noyau/widgets/important_notifications_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 import '../screens/notifications_screen.dart';
 
 /// Display up to three important notifications.
@@ -19,7 +20,7 @@ class ImportantNotificationsWidget extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.all(16),
-      color: const Color(0xFFFFF8E1),
+      color: backgroundGray,
       child: InkWell(
         onTap: () {
           Navigator.push(

--- a/lib/modules/noyau/widgets/premium_trial_banner.dart
+++ b/lib/modules/noyau/widgets/premium_trial_banner.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class PremiumTrialBanner extends StatelessWidget {
   final VoidCallback onActivate;
@@ -15,7 +16,7 @@ class PremiumTrialBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: const Color(0xFFFFF8E1),
+      color: backgroundGray,
       padding: const EdgeInsets.all(16),
       child: Row(
         children: [

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 const Color primaryBlue = Color(0xFF183153);
-const Color backgroundGray = Color(0xFFF2F2F2); // ✅ gris clair Samsung Health
+const Color backgroundGray = Color(0xFFF5F5F5); // ✅ gris clair Samsung Health
 
 const Color accentYellow = Color(0xFFFBC02D);
 


### PR DESCRIPTION
## Summary
- switch `backgroundGray` to `0xFFF5F5F5`
- use `backgroundGray` in `IABanner`
- update default color for `IAChip`
- apply `backgroundGray` in `PremiumTrialBanner`
- use gray card in `ImportantNotificationsWidget`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856be9861d08320ba1f628d5aada06a