### PR TITLE
Use consistent primaryBlue color

### DIFF
--- a/lib/modules/identite/screens/genealogy_screen.dart
+++ b/lib/modules/identite/screens/genealogy_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 import 'dart:io';
 import '../services/genealogy_pdf_ocr_service.dart';
 import '../models/genealogy_model.dart';
@@ -24,8 +25,10 @@ class _GenealogyScreenState extends State<GenealogyScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (duplicateAlert)
-              const Text('Doublon potentiel détecté',
-                  style: TextStyle(color: Colors.red)),
+              const Text(
+                'Doublon potentiel détecté',
+                style: TextStyle(color: primaryBlue),
+              ),
             const SizedBox(height: 8),
             if (genealogy != null) _buildGraph(),
             const SizedBox(height: 16),

--- a/lib/modules/noyau/screens/modules_screen.dart
+++ b/lib/modules/noyau/screens/modules_screen.dart
@@ -10,6 +10,7 @@ import 'package:anisphere/modules/noyau/services/animal_service.dart';
 import 'package:anisphere/modules/identite/screens/identity_screen.dart';
 import 'package:anisphere/modules/identite/services/identity_service.dart';
 import 'package:anisphere/modules/identite/models/identity_model.dart';
+import '../../../theme.dart';
 import 'package:hive/hive.dart';
 
 class ModulesScreen extends StatefulWidget {
@@ -193,7 +194,7 @@ class _ModulesScreenState extends State<ModulesScreen> {
                             ? null
                             : const Text(
                                 'Gratuit',
-                                style: TextStyle(color: Colors.green),
+                                style: TextStyle(color: primaryBlue),
                               ),
                       ),
                     );

--- a/lib/modules/noyau/widgets/notification_icon.dart
+++ b/lib/modules/noyau/widgets/notification_icon.dart
@@ -4,6 +4,7 @@
 
 
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class NotificationIcon extends StatelessWidget {
   final int unreadCount;
@@ -31,7 +32,7 @@ class NotificationIcon extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.all(3),
               decoration: const BoxDecoration(
-                color: Colors.red,
+                color: primaryBlue,
                 shape: BoxShape.circle,
               ),
               constraints: const BoxConstraints(minWidth: 16, minHeight: 16),

--- a/lib/modules/noyau/widgets/voice_input_button.dart
+++ b/lib/modules/noyau/widgets/voice_input_button.dart
@@ -1,6 +1,7 @@
 // Copilot: Widget bouton microphone pour lancer l'écoute vocale
 
 import 'package:flutter/material.dart';
+import '../../../theme.dart';
 
 class VoiceInputButton extends StatelessWidget {
   final VoidCallback onPressed;
@@ -11,8 +12,10 @@ class VoiceInputButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       iconSize: 48,
-      icon: Icon(listening ? Icons.mic : Icons.mic_none,
-          color: listening ? Colors.red : Colors.grey),
+      icon: Icon(
+        listening ? Icons.mic : Icons.mic_none,
+        color: listening ? primaryBlue : Colors.grey,
+      ),
       onPressed: onPressed,
     );
   }


### PR DESCRIPTION
## Summary
- update notification badge to use `primaryBlue`
- use `primaryBlue` in `VoiceInputButton` when listening
- style duplicate alert in genealogy screen with `primaryBlue`
- style "Gratuit" badge in modules screen with `primaryBlue`

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856be9d657883209532398a32da96ba