### PR TITLE
Update background gray color

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 const Color primaryBlue = Color(0xFF183153);
-const Color backgroundGray = Color(0xFFF2F2F2); // ✅ gris clair Samsung Health
+const Color backgroundGray = Color(0xFFF5F5F5); // ✅ gris clair Samsung Health
 
 const Color accentYellow = Color(0xFFFBC02D);
 

--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -70,7 +70,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final appBar = tester.widget<AppBar>(find.byType(AppBar));
-    expect(appBar.backgroundColor, const Color(0xFFF2F2F2));
+    expect(appBar.backgroundColor, const Color(0xFFF5F5F5));
     expect(appBar.foregroundColor, const Color(0xFF183153));
     expect(appBar.elevation, 0);
 

--- a/test/noyau/widget/theme_colors_test.dart
+++ b/test/noyau/widget/theme_colors_test.dart
@@ -21,7 +21,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final theme = Theme.of(tester.element(find.byType(BottomNavigationBar)));
-    expect(theme.scaffoldBackgroundColor, const Color(0xFFF2F2F2));
+    expect(theme.scaffoldBackgroundColor, const Color(0xFFF5F5F5));
     expect(theme.bottomNavigationBarTheme.selectedItemColor, primaryBlue);
   });
 


### PR DESCRIPTION
## Summary
- tweak theme background color to `0xFFF5F5F5`
- update widget tests expecting the new color

## Testing
- `flutter test test/noyau/widget/main_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856beaa13f08320934739b22690e75c