### PR TITLE
fix module card color

### DIFF
--- a/lib/modules/noyau/widgets/module_card.dart
+++ b/lib/modules/noyau/widgets/module_card.dart
@@ -21,7 +21,7 @@ class ModuleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color chipColor = switch (status) {
-      'actif' => const primaryBlue,
+      'actif' => primaryBlue,
       'disponible' => Colors.grey,
       'premium' => primaryBlue,
       _ => Colors.grey,


### PR DESCRIPTION
## Summary
- remove const from color switch in module card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca954bcc83209a25a55e5fce1c3d