### PR TITLE
Fix color test constants

### DIFF
--- a/test/noyau/widget/main_screen_test.dart
+++ b/test/noyau/widget/main_screen_test.dart
@@ -71,34 +71,34 @@ void main() {
     await tester.pumpAndSettle();
 
     final appBar = tester.widget<AppBar>(find.byType(AppBar));
-    expect(appBar.backgroundColor, const backgroundGray);
-    expect(appBar.foregroundColor, const primaryBlue);
+    expect(appBar.backgroundColor, backgroundGray);
+    expect(appBar.foregroundColor, primaryBlue);
     expect(appBar.elevation, 0);
 
     final title = tester.widget<Text>(find.text('Maison'));
     expect(title.style?.fontWeight, FontWeight.w600);
     expect(title.style?.fontSize, 20);
-    expect(title.style?.color, const primaryBlue);
+    expect(title.style?.color, primaryBlue);
 
     final qrIcon = tester.widget<Icon>(
       find.widgetWithIcon(IconButton, Icons.qr_code),
     );
-    expect(qrIcon.color, const primaryBlue);
+    expect(qrIcon.color, primaryBlue);
 
     final profileIcon = tester.widget<Icon>(
       find.widgetWithIcon(IconButton, Icons.person),
     );
-    expect(profileIcon.color, const primaryBlue);
+    expect(profileIcon.color, primaryBlue);
 
     final settingsIcon = tester.widget<Icon>(
       find.widgetWithIcon(IconButton, Icons.settings),
     );
-    expect(settingsIcon.color, const primaryBlue);
+    expect(settingsIcon.color, primaryBlue);
 
     final supportIcon = tester.widget<Icon>(
       find.widgetWithIcon(IconButton, Icons.help_outline),
     );
-    expect(supportIcon.color, const primaryBlue);
+    expect(supportIcon.color, primaryBlue);
   });
 
   testWidgets('shows SplashScreen when user is null', (tester) async {

--- a/test/noyau/widget/theme_colors_test.dart
+++ b/test/noyau/widget/theme_colors_test.dart
@@ -21,7 +21,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final theme = Theme.of(tester.element(find.byType(BottomNavigationBar)));
-    expect(theme.scaffoldBackgroundColor, const backgroundGray);
+    expect(theme.scaffoldBackgroundColor, backgroundGray);
     expect(theme.bottomNavigationBarTheme.selectedItemColor, primaryBlue);
   });
 


### PR DESCRIPTION
## Summary
- fix color constant comparisons in widget tests

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca99d7308320bc724072de373056