### PR TITLE
Fix mock_services library directive

### DIFF
--- a/test/identite/unit/mock_services.dart
+++ b/test/identite/unit/mock_services.dart
@@ -1,5 +1,4 @@
 @GenerateMocks([IdentityService, IdentityLocalAnalyzer])
-library mock_services;
 
 import 'package:mockito/annotations.dart';
 import 'package:anisphere/modules/identite/services/identity_service.dart';


### PR DESCRIPTION
## Summary
- remove leftover `library mock_services` declaration

## Testing
- `flutter test --coverage` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca9de5788320847fcdb7b6f5a0aa