### PR TITLE
Fix mockito default values in unit tests

### DIFF
--- a/test/identite/unit/identity_service_test.dart
+++ b/test/identite/unit/identity_service_test.dart
@@ -32,12 +32,26 @@ void main() {
       status: 'ok',
       legalStatus: 'dog',
     );
-    when(mockBox.put(any, any)).thenAnswer((_) async {});
+    when(
+      mockBox.put(
+        any,
+        any<IdentityModel>(
+          defaultValue: IdentityModel(animalId: 'id'),
+        ),
+      ),
+    ).thenAnswer((_) async {});
 
     final score = await service.computeCompletionScore(model);
 
-    final saved =
-        verify(mockBox.put('a1', captureAny)).captured.single as IdentityModel;
+    final saved = verify(
+      mockBox.put(
+        'a1',
+        captureAny<IdentityModel>(
+          that: isA<IdentityModel>(),
+          defaultValue: IdentityModel(animalId: 'id'),
+        ),
+      ),
+    ).captured.single as IdentityModel;
     expect(saved.aiScore, closeTo(1.0, 0.01));
     expect(score, closeTo(1.0, 0.01));
   });
@@ -52,12 +66,26 @@ void main() {
     when(mockBox.values).thenReturn([existing]);
     final service = IdentityService(localBox: mockBox, signatureSecret: 'secret');
     final model = IdentityModel(animalId: 'new', microchipNumber: 'dup');
-    when(mockBox.put(any, any)).thenAnswer((_) async {});
+    when(
+      mockBox.put(
+        any,
+        any<IdentityModel>(
+          defaultValue: IdentityModel(animalId: 'id'),
+        ),
+      ),
+    ).thenAnswer((_) async {});
 
     final result = await service.detectSiblingDuplicates(model);
 
-    final saved =
-        verify(mockBox.put('new', captureAny)).captured.single as IdentityModel;
+    final saved = verify(
+      mockBox.put(
+        'new',
+        captureAny<IdentityModel>(
+          that: isA<IdentityModel>(),
+          defaultValue: IdentityModel(animalId: 'id'),
+        ),
+      ),
+    ).captured.single as IdentityModel;
     expect(saved.verifiedBreed, isTrue);
     expect(result, isTrue);
   });

--- a/test/identite/unit/identity_verification_service_test.dart
+++ b/test/identite/unit/identity_verification_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'package:anisphere/modules/identite/models/identity_model.dart';
 import 'package:anisphere/modules/identite/services/identity_verification_service.dart';
+import 'package:anisphere/modules/identite/logic/ia_local_analyzer.dart';
 import 'package:mockito/mockito.dart';
 import 'mock_services.mocks.dart';
 
@@ -19,8 +20,11 @@ void main() {
 
     final mockIdentityService = MockIdentityService();
     final mockAnalyzer = MockIdentityLocalAnalyzer();
-    when(mockAnalyzer.analyze(any))
-        .thenAnswer((_) async => {'photoScore': 0.8});
+    when(
+      mockAnalyzer.analyze(
+        any<IdentityAnalysisInput>(defaultValue: IdentityAnalysisInput()),
+      ),
+    ).thenAnswer((_) async => {'photoScore': 0.8});
     final service = IdentityVerificationService(
       identityService: mockIdentityService,
       analyzer: mockAnalyzer,


### PR DESCRIPTION
## Summary
- ensure `when` and `verify` calls in identity unit tests provide `defaultValue`
- update analyzer expectations with `IdentityAnalysisInput`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856caa2269c83208bbbf4fe84830ebc