### PR TITLE
Fix test closure return value

### DIFF
--- a/test/noyau/unit/ia_local/ia_model_loader_test.dart
+++ b/test/noyau/unit/ia_local/ia_model_loader_test.dart
@@ -39,6 +39,7 @@ void main() {
       (invocation) {
         final output = invocation.positionalArguments[1] as List;
         (output.first as List)[0] = 3.14;
+        return null;
       }, // Codex: Correction automatique flutter analyze
     );
     final loader = IaInterpreterLoader(


### PR DESCRIPTION
## Summary
- ensure `thenAnswer` returns `null` in `IaInterpreterLoader` test

## Testing
- `dart test test/noyau/unit/ia_local/ia_model_loader_test.dart` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856caa52c8083208fa04360c846cd77