### PR TITLE
Insert library directives for message & user profile tests

### DIFF
--- a/test/noyau/unit/message_model_test.dart
+++ b/test/noyau/unit/message_model_test.dart
@@ -1,4 +1,5 @@
 @Skip('Temporarily disabled')
+library message_model_test;
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/test/noyau/unit/user_profile_model_test.dart
+++ b/test/noyau/unit/user_profile_model_test.dart
@@ -1,4 +1,5 @@
 @Skip('Temporarily disabled')
+library user_profile_model_test;
 import 'package:flutter_test/flutter_test.dart';
 import '../../test_config.dart';
 import 'package:anisphere/modules/noyau/models/user_profile_model.dart';


### PR DESCRIPTION
## Summary
- add library directive to `message_model_test.dart`
- add library directive to `user_profile_model_test.dart`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/noyau/unit/message_model_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856caa7f2748320b83c7e086e84f51d