### PR TITLE
Fix captureAny default value

### DIFF
--- a/test/identite/unit/identity_verification_service_test.dart
+++ b/test/identite/unit/identity_verification_service_test.dart
@@ -31,7 +31,6 @@ void main() {
     final captured = verify(
       mockIdentityService.saveIdentityLocally(
         captureAny<IdentityModel>(
-          that: isA<IdentityModel>(),
           defaultValue: IdentityModel(animalId: 'id'),
         ),
       ),


### PR DESCRIPTION
## Summary
- remove `that: isA<IdentityModel>()` when capturing the argument

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856caaa31bc8320be3d57bceb597a76