### PR TITLE
Update splash screen loader

### DIFF
--- a/lib/modules/noyau/screens/splash_screen.dart
+++ b/lib/modules/noyau/screens/splash_screen.dart
@@ -49,16 +49,13 @@ class _SplashScreenState extends State<SplashScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: primaryBlue, // bleu foncé branding
+      backgroundColor: backgroundGray,
       body: Center(
         child: FadeTransition(
           opacity: _opacityAnimation,
           child: SlideTransition(
             position: _slideAnimation,
-            child: Image.asset(
-              'assets/logo/anisphere_logo.png',
-              width: 180,
-            ),
+            child: const CircularProgressIndicator(),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- use `backgroundGray` color for `SplashScreen`
- display a `CircularProgressIndicator` while animating instead of the logo

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856da53fefc83208f03741d730967bb